### PR TITLE
Add package summary projection and tests.

### DIFF
--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageIndexSynchronizer.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageIndexSynchronizer.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.config.SkipperServerProperties;
-import org.springframework.cloud.skipper.repository.PackageSummaryRepository;
+import org.springframework.cloud.skipper.repository.PackageMetadataRepository;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -40,13 +40,13 @@ public class PackageIndexSynchronizer {
 
 	private PackageIndexDownloader packageIndexDownloader;
 
-	private PackageSummaryRepository packageSummaryRepository;
+	private PackageMetadataRepository packageSummaryRepository;
 
 	private SkipperServerProperties skipperServerProperties;
 
 	@Autowired
 	public PackageIndexSynchronizer(PackageIndexDownloader packageIndexDownloader,
-			PackageSummaryRepository packageSummaryRepository,
+			PackageMetadataRepository packageSummaryRepository,
 			SkipperServerProperties skipperServerProperties) {
 		this.packageIndexDownloader = packageIndexDownloader;
 		this.packageSummaryRepository = packageSummaryRepository;

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageMetadata.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageMetadata.java
@@ -19,6 +19,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
 
 /**
  * @author Mark Pollack
@@ -33,21 +34,73 @@ public class PackageMetadata {
 	/**
 	 * The Package Index spec version this file is based on. Required
 	 */
+	@NotNull
 	private String apiVersion;
-
-	/**
-	 *
-	 */
-	private String kind;
 
 	/**
 	 * The repository ID this Package Index file belongs to. Required
 	 */
+	@NotNull
 	private String origin;
 
+	/**
+	 * What type of package system is being used.
+	 */
+	private String kind;
+
+
+	/**
+	 * The name of the package
+	 */
 	private String name;
 
+	/**
+	 * The version of the package
+	 */
 	private String version;
+
+	/**
+	 * The version of the application in the package (assuming package maps to one app)
+	 */
+	private String appVersion;
+
+	/**
+	 * Location to source code for this package.
+	 */
+	private String packageSourceUrl;
+
+	/**
+	 * The home page of the package
+	 */
+	private String packageHomeUrl;
+
+	/**
+	 * A comma separated list of tags to use for searching
+	 */
+	private String tags;
+
+	/**
+	 * Who is maintaining this package
+	 */
+	private String maintainer;
+
+	/**
+	 * Brief description of the package.  The packages README.md will contain more information.
+	 * TODO - decide format.
+	 */
+	private String description;
+
+
+	/**
+	 * Hash of package binary that will be donwloaded using SHA256 hash algorithm.
+	 */
+	private String sha256;
+
+	/**
+	 * Url location of a icon.
+	 * TODO: size specification
+	 */
+	private String iconUrl;
 
 	public PackageMetadata() {
 	}
@@ -90,5 +143,77 @@ public class PackageMetadata {
 
 	public void setVersion(String version) {
 		this.version = version;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getAppVersion() {
+		return appVersion;
+	}
+
+	public void setAppVersion(String appVersion) {
+		this.appVersion = appVersion;
+	}
+
+	public String getPackageSourceUrl() {
+		return packageSourceUrl;
+	}
+
+	public void setPackageSourceUrl(String packageSourceUrl) {
+		this.packageSourceUrl = packageSourceUrl;
+	}
+
+	public String getPackageHomeUrl() {
+		return packageHomeUrl;
+	}
+
+	public void setPackageHomeUrl(String packageHomeUrl) {
+		this.packageHomeUrl = packageHomeUrl;
+	}
+
+	public String getTags() {
+		return tags;
+	}
+
+	public void setTags(String tags) {
+		this.tags = tags;
+	}
+
+	public String getMaintainer() {
+		return maintainer;
+	}
+
+	public void setMaintainer(String maintainer) {
+		this.maintainer = maintainer;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getSha256() {
+		return sha256;
+	}
+
+	public void setSha256(String sha256) {
+		this.sha256 = sha256;
+	}
+
+	public String getIconUrl() {
+		return iconUrl;
+	}
+
+	public void setIconUrl(String iconUrl) {
+		this.iconUrl = iconUrl;
 	}
 }

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageSummary.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageSummary.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.index;
+
+import org.springframework.data.rest.core.config.Projection;
+
+/**
+ * @author Mark Pollack
+ */
+@Projection(name = "summary", types = { PackageMetadata.class })
+public interface PackageSummary {
+
+	String getName();
+
+	String getVersion();
+
+	String getIconUrl();
+
+}

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/repository/PackageMetadataRepository.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/repository/PackageMetadataRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.repository;
+
+import java.util.List;
+
+import org.springframework.cloud.skipper.index.PackageMetadata;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+/**
+ * @author Mark Pollack
+ */
+@RepositoryRestResource(path = "packageMetadata", collectionResourceRel = "packageMetadata")
+public interface PackageMetadataRepository extends PagingAndSortingRepository<PackageMetadata, Long> {
+
+	List<PackageMetadata> findByName(@Param("name") String name);
+
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/AbstractIntegrationTest.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/AbstractIntegrationTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper;
+
+import org.junit.runner.RunWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Base class to implement transactional integration tests using the root application
+ * configuration.
+ *
+ * @author Oliver Gierke
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@Transactional
+@SpringBootTest
+public abstract class AbstractIntegrationTest {
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/AbstractMockMvcTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/AbstractMockMvcTests.java
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.repository;
+package org.springframework.cloud.skipper;
 
-import java.util.List;
+import org.junit.runner.RunWith;
 
-import org.springframework.cloud.skipper.index.PackageMetadata;
-import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.data.repository.query.Param;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Mark Pollack
  */
-@RepositoryRestResource
-public interface PackageSummaryRepository extends PagingAndSortingRepository<PackageMetadata, Long> {
-
-	List<PackageMetadata> findByName(@Param("name") String name);
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AbstractMockMvcTests {
 
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/index/PackageIndexLoaderTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/index/PackageIndexLoaderTests.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.skipper.config.SkipperServerProperties;
-import org.springframework.cloud.skipper.repository.PackageSummaryRepository;
+import org.springframework.cloud.skipper.repository.PackageMetadataRepository;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
@@ -48,7 +48,7 @@ public class PackageIndexLoaderTests {
 	private SkipperServerProperties skipperServerProperties;
 
 	@Autowired
-	private PackageSummaryRepository packageSummaryRepository;
+	private PackageMetadataRepository packageSummaryRepository;
 
 	@Before
 	public void cleanPackageIndexDir() throws IOException {

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataCreator.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataCreator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.repository;
+
+import org.springframework.cloud.skipper.index.PackageMetadata;
+
+/**
+ * @author Mark Pollack
+ */
+public class PackageMetadataCreator {
+
+	public static void createTwoPackages(PackageMetadataRepository repository) {
+		PackageMetadata packageMetadata = new PackageMetadata();
+		packageMetadata.setApiVersion("1");
+		packageMetadata.setOrigin("www.example.com");
+		packageMetadata.setKind("skipper");
+		packageMetadata.setName("package1");
+		packageMetadata.setVersion("1.0.0");
+		packageMetadata.setIconUrl("http://www.gilligansisle.com/images/a2.gif");
+		packageMetadata.setMaintainer("Alan Hale Jr.");
+		repository.save(packageMetadata);
+		packageMetadata = new PackageMetadata();
+		packageMetadata.setApiVersion("1");
+		packageMetadata.setOrigin("www.example.com");
+		packageMetadata.setKind("skipper");
+		packageMetadata.setName("package2");
+		packageMetadata.setVersion("2.0.0");
+		packageMetadata.setIconUrl("http://www.gilligansisle.com/images/a1.gif");
+		packageMetadata.setMaintainer("Bob Denver");
+		repository.save(packageMetadata);
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataMvcTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataMvcTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.repository;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.AbstractMockMvcTests;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Mark Pollack
+ */
+public class PackageMetadataMvcTests extends AbstractMockMvcTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private PackageMetadataRepository packageMetadataRepository;
+
+	@Before
+	public void deleteAllBeforeTests() {
+		packageMetadataRepository.deleteAll();
+	}
+
+	@Test
+	public void shouldReturnRepositoryIndex() throws Exception {
+		mockMvc.perform(get("/")).andDo(print()).andExpect(status().isOk()).andExpect(
+				jsonPath("$._links.packageMetadata").exists());
+	}
+
+	@Test
+	public void testProjection() throws Exception {
+		PackageMetadataCreator.createTwoPackages(packageMetadataRepository);
+		mockMvc.perform(get("/packageMetadata?projection=summary")).andDo(print()).andExpect(status().isOk())
+				.andExpect(jsonPath("$._embedded.packageMetadata[0].version").value("1.0.0"))
+				.andExpect(jsonPath("$._embedded.packageMetadata[0].iconUrl")
+						.value("http://www.gilligansisle.com/images/a2.gif"))
+				.andExpect(jsonPath("$._embedded.packageMetadata[0].description").doesNotExist())
+				.andExpect(jsonPath("$._embedded.packageMetadata[1].version").value("2.0.0"))
+				.andExpect(jsonPath("$._embedded.packageMetadata[1].iconUrl")
+						.value("http://www.gilligansisle.com/images/a1.gif"))
+				.andExpect(jsonPath("$._embedded.packageMetadata[1].description").doesNotExist());
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataRepositoryTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataRepositoryTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.repository;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.AbstractIntegrationTest;
+import org.springframework.cloud.skipper.index.PackageMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Mark Pollack
+ */
+public class PackageMetadataRepositoryTests extends AbstractIntegrationTest {
+
+	@Autowired
+	private PackageMetadataRepository packageMetadataRepository;
+
+	@Test
+	public void basicCrud() {
+		PackageMetadataCreator.createTwoPackages(packageMetadataRepository);
+		Iterable<PackageMetadata> packages = packageMetadataRepository.findAll();
+		assertThat(packages).isNotEmpty();
+		assertThat(packages).hasSize(2);
+		List<PackageMetadata> packagesNamed1 = packageMetadataRepository.findByName("package1");
+		assertThat(packagesNamed1).isNotEmpty();
+		assertThat(packagesNamed1).hasSize(1);
+		assertThat(packagesNamed1.get(0).getMaintainer()).isEqualTo("Alan Hale Jr.");
+		List<PackageMetadata> packagesNamed2 = packageMetadataRepository.findByName("package2");
+		assertThat(packagesNamed2).isNotEmpty();
+		assertThat(packagesNamed2).hasSize(1);
+		assertThat(packagesNamed2.get(0).getMaintainer()).isEqualTo("Bob Denver");
+
+	}
+
+}


### PR DESCRIPTION
The url `/packageMetadata?projection=summary` gets the summary projection
and contains a link to the full record.

Fixes #11
Fixes #13
Fixes #15

Here is a sample response from the tests:

```
Body = {
  "_embedded" : {
    "packageMetadata" : [ {
      "version" : "1.0.0",
      "iconUrl" : null,
      "name" : "package1",
      "_links" : {
        "self" : {
          "href" : "http://localhost/packageMetadata/1"
        },
        "packageMetadata" : {
          "href" : "http://localhost/packageMetadata/1{?projection}",
          "templated" : true
        }
      }
    }, {
      "version" : "2.0.0",
      "iconUrl" : null,
      "name" : "package2",
      "_links" : {
        "self" : {
          "href" : "http://localhost/packageMetadata/2"
        },
        "packageMetadata" : {
          "href" : "http://localhost/packageMetadata/2{?projection}",
          "templated" : true
        }
      }
    } ]
  },
  "_links" : {
    "self" : {
      "href" : "http://localhost/packageMetadata{?page,size,sort,projection}",
      "templated" : true
    },
    "profile" : {
      "href" : "http://localhost/profile/packageMetadata"
    },
    "search" : {
      "href" : "http://localhost/packageMetadata/search"
    }
  },
  "page" : {
    "size" : 20,
    "totalElements" : 2,
    "totalPages" : 1,
    "number" : 0
  }
}
```