### PR TITLE
Improve PackageMetadataMVC tests

### DIFF
--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageIndexDownloader.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageIndexDownloader.java
@@ -76,17 +76,17 @@ public class PackageIndexDownloader implements ResourceLoaderAware {
 	public List<File> getIndexFiles() {
 		List<File> files = new ArrayList<>();
 		Path indexPath = Paths.get(skipperServerProperties.getPackageIndexDir());
-		try (Stream<Path> paths = Files.walk(indexPath, 1)) {
-			files = paths.filter(i -> i.toString().endsWith(".yml"))
-					.map(i -> i.toAbsolutePath().toFile())
-					.collect(Collectors.toList());
+		if (indexPath.toFile().exists()) {
+			try (Stream<Path> paths = Files.walk(indexPath, 1)) {
+				files = paths.filter(i -> i.toString().endsWith(".yml"))
+						.map(i -> i.toAbsolutePath().toFile())
+						.collect(Collectors.toList());
+			}
+			catch (IOException e) {
+				logger.error("Could not read index files in path " + indexPath, e);
+			}
 		}
-		catch (IOException e) {
-			logger.error("Could not read index files in path " + indexPath, e);
-		}
-		finally {
-			return files;
-		}
+		return files;
 	}
 
 	public String computeFilename(Resource resource) throws IOException {

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataMvcTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataMvcTests.java
@@ -15,16 +15,13 @@
  */
 package org.springframework.cloud.skipper.repository;
 
-import org.junit.Before;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runners.MethodSorters;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.AbstractMockMvcTests;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -33,10 +30,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
  */
-@Transactional
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@TestPropertySource(properties = "spring.cloud.skipper.server.skipperHome=unused")
 public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 
 	@Autowired
@@ -44,11 +41,6 @@ public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 
 	@Autowired
 	private PackageMetadataRepository packageMetadataRepository;
-
-	@Before
-	public void deleteAllBeforeTests() {
-		packageMetadataRepository.deleteAll();
-	}
 
 	@Test
 	public void shouldReturnRepositoryIndex() throws Exception {
@@ -65,12 +57,12 @@ public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 						.value("http://www.gilligansisle.com/images/a2.gif"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[0].description").doesNotExist())
 				.andExpect(jsonPath("$._embedded.packageMetadata[0]._links.install.href")
-						.value("http://localhost/packageMetadata/3/install"))
+						.value("http://localhost/packageMetadata/1/install"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[1].version").value("2.0.0"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[1].iconUrl")
 						.value("http://www.gilligansisle.com/images/a1.gif"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[1]._links.install.href")
-						.value("http://localhost/packageMetadata/4/install"))
+						.value("http://localhost/packageMetadata/2/install"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[1].description").doesNotExist());
 	}
 
@@ -81,11 +73,11 @@ public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 				.andExpect(jsonPath("$._embedded.packageMetadata[0].version").value("1.0.0"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[0].description").value("A very cool project"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[0]._links.install.href")
-						.value("http://localhost/packageMetadata/3/install"))
+						.value("http://localhost/packageMetadata/1/install"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[1].version").value("2.0.0"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[1].description").value("Another very cool project"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[1]._links.install.href")
-						.value("http://localhost/packageMetadata/4/install"));
+						.value("http://localhost/packageMetadata/2/install"));
 
 	}
 }


### PR DESCRIPTION
 - Add an explicit skipperHome property value for the tests so that the default isn't used
 - Remove deleteAll before tests
 - Remove Transactional and test method ordering