### PR TITLE
Add spring-boot-configuration-processor

### DIFF
--- a/spring-cloud-skipper-client/pom.xml
+++ b/spring-cloud-skipper-client/pom.xml
@@ -64,6 +64,12 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-skipper</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
 </project>

--- a/spring-cloud-skipper-server/pom.xml
+++ b/spring-cloud-skipper-server/pom.xml
@@ -109,6 +109,12 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Add dependency in order to generate metadata for classes annotated with
`@ConfigurationProperties`.