### PR TITLE
Add package upload functionality

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.skipper.domain.AboutInfo;
 import org.springframework.cloud.skipper.domain.DeployProperties;
 import org.springframework.cloud.skipper.domain.DeployRequest;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.PackageUploadProperties;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Repository;
 import org.springframework.cloud.skipper.domain.UpdateRequest;
@@ -158,6 +159,12 @@ public class DefaultSkipperClient implements SkipperClient {
 		return this.restTemplate.getForObject(url, RepositoryResources.class);
 	}
 
+	@Override
+	public PackageMetadata upload(PackageUploadProperties packageUploadProperties) {
+		String url = String.format("%s/%s/%s", baseUrl, "package", "upload");
+		return this.restTemplate.postForObject(url, packageUploadProperties, PackageMetadata.class);
+	}
+
 	protected Traverson createTraverson(String baseUrl) {
 		try {
 			return new Traverson(new URI(baseUrl), MediaTypes.HAL_JSON);
@@ -170,5 +177,4 @@ public class DefaultSkipperClient implements SkipperClient {
 	public static class RepositoryResources extends Resources<Repository> {
 
 	}
-
 }

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -19,6 +19,7 @@ import org.springframework.cloud.skipper.domain.AboutInfo;
 import org.springframework.cloud.skipper.domain.DeployProperties;
 import org.springframework.cloud.skipper.domain.DeployRequest;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.PackageUploadProperties;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Repository;
 import org.springframework.cloud.skipper.domain.UpdateRequest;
@@ -71,6 +72,15 @@ public interface SkipperClient {
 	 * @return the deploye {@link Release}
 	 */
 	Release update(UpdateRequest updateRequest);
+
+	/*
+	 * Upload the package.
+	 *
+	 * @param packageUploadProperties the properties for the package upload.
+	 * @return package metadata for the uploaded package
+	 */
+	PackageMetadata upload(PackageUploadProperties packageUploadProperties);
+
 	/**
 	 * Undeploy a specific release.
 	 *

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/config/SkipperServerProperties.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/config/SkipperServerProperties.java
@@ -38,8 +38,8 @@ public class SkipperServerProperties {
 	private String skipperHome = System.getProperty("user.home") + File.separator + ".skipper";
 
 	/**
-	 * Flag indicating to sync the local contents of the index directory with the database on
-	 * startup.
+	 * Flag indicating to sync the local contents of the index directory with the database
+	 * on startup.
 	 */
 	private boolean synchonizeIndexOnContextRefresh = true;
 

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/controller/PackageController.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/controller/PackageController.java
@@ -18,7 +18,10 @@ package org.springframework.cloud.skipper.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.domain.DeployProperties;
 import org.springframework.cloud.skipper.domain.DeployRequest;
+import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.PackageUploadProperties;
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.service.PackageService;
 import org.springframework.cloud.skipper.service.ReleaseService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,9 +43,12 @@ public class PackageController {
 
 	private ReleaseService releaseService;
 
+	private PackageService packageService;
+
 	@Autowired
-	public PackageController(ReleaseService releaseService) {
+	public PackageController(ReleaseService releaseService, PackageService packageService) {
 		this.releaseService = releaseService;
+		this.packageService = packageService;
 	}
 
 	@RequestMapping(path = "/deploy", method = RequestMethod.POST)
@@ -55,5 +61,11 @@ public class PackageController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public Release deploy(@PathVariable("id") String id, @RequestBody DeployProperties deployProperties) {
 		return this.releaseService.deploy(id, deployProperties);
+	}
+
+	@RequestMapping(path = "/upload", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	public PackageMetadata upload(@RequestBody PackageUploadProperties packageUploadProperties) {
+		return this.packageService.upload(packageUploadProperties);
 	}
 }

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageIndexSynchronizer.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/index/PackageIndexSynchronizer.java
@@ -66,7 +66,6 @@ public class PackageIndexSynchronizer {
 		if (this.skipperServerProperties.isSynchonizeIndexOnContextRefresh()) {
 			loadAll();
 		}
-
 	}
 
 	// Package protected for testing

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/ReleaseService.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/ReleaseService.java
@@ -84,8 +84,8 @@ public class ReleaseService {
 	 * Downloads the package metadata and package zip file specified by the given Id and
 	 * deploys the package on the target platform.
 	 * @param id of the package
-	 * @param deployProperties contains the name of the release, the platfrom to deploy to,
-	 * and configuration values to replace in the package template.
+	 * @param deployProperties contains the name of the release, the platfrom to deploy
+	 * to, and configuration values to replace in the package template.
 	 * @return the Release object associated with this deployment
 	 * @throws PackageException if the package to deploy can not be found.
 	 */
@@ -137,8 +137,7 @@ public class ReleaseService {
 
 	protected Release deploy(PackageMetadata packageMetadata, DeployProperties deployProperties) {
 		Assert.notNull(packageMetadata, "Can't download package, PackageMetadata is a null value.");
-		Package packageToInstall = this.packageService.downloadPackage(packageMetadata);
-		Release release = createInitialRelease(deployProperties, packageToInstall);
+		Release release = createInitialRelease(deployProperties, this.packageService.downloadPackage(packageMetadata));
 		return deploy(release);
 	}
 
@@ -260,9 +259,7 @@ public class ReleaseService {
 		newRelease.setManifest(releaseToRollback.getManifest());
 		newRelease.setVersion(currentRelease.getVersion() + 1);
 		newRelease.setPlatformName(releaseToRollback.getPlatformName());
-		// Do not set ConfigValues since the manifest from the previous release has
-		// already
-		// resolved those...
+		// Do not set ConfigValues since the manifest from the previous release has already resolved those...
 		newRelease.setInfo(createNewInfo());
 
 		return update(currentRelease, newRelease);

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/RepositoryInitializationService.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/RepositoryInitializationService.java
@@ -67,7 +67,6 @@ public class RepositoryInitializationService {
 						".  Repository name already in database.");
 			}
 		}
-
 	}
 
 	private void addLocalRepository() {
@@ -76,4 +75,5 @@ public class RepositoryInitializationService {
 		repository.setUrl("file://" + skipperServerProperties.getPackageDir());
 		repositoryRepository.save(repository);
 	}
+
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/AbstractControllerTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/AbstractControllerTests.java
@@ -141,7 +141,8 @@ public class AbstractControllerTests extends AbstractMockMvcTests {
 			Release deployedRelease) {
 		assertThat(deployedRelease.getName()).isEqualTo(releaseName);
 		assertThat(deployedRelease.getPlatformName()).isEqualTo("test");
-		assertThat(deployedRelease.getPkg().getMetadata()).isEqualToIgnoringGivenFields(packageMetadata, "id", "origin");
+		assertThat(deployedRelease.getPkg().getMetadata()).isEqualToIgnoringGivenFields(packageMetadata,
+				"id", "origin", "packageFile");
 		assertThat(deployedRelease.getPkg().getMetadata().equals(packageMetadata));
 		assertThat(deployedRelease.getInfo().getStatus().getStatusCode()).isEqualTo(StatusCode.DEPLOYED);
 	}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/service/ConfigValueUtilsTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/service/ConfigValueUtilsTests.java
@@ -58,7 +58,7 @@ public class ConfigValueUtilsTests {
 	public void testYamlMerge() throws IOException {
 		Resource resource = new ClassPathResource("/org/springframework/cloud/skipper/service/ticktock-1.0.0");
 
-		Package pkg = packageService.loadPackageOnPath("classpathOrigin", resource.getFile().getPath());
+		Package pkg = packageService.loadPackageOnPath(resource.getFile());
 		Map<String, Object> mergedMap = ConfigValueUtils.mergeConfigValues(pkg, new ConfigValues());
 
 		DumperOptions dumperOptions = new DumperOptions();

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -15,7 +15,10 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.keyvalue.annotation.KeySpace;
@@ -73,6 +76,13 @@ public class PackageMetadata {
 	private String packageHomeUrl;
 
 	/**
+	 * Package file.
+	 */
+	@Lob
+	@JsonIgnore
+	private byte[] packageFile;
+
+	/**
 	 * A comma separated list of tags to use for searching
 	 */
 	private String tags;
@@ -83,8 +93,8 @@ public class PackageMetadata {
 	private String maintainer;
 
 	/**
-	 * Brief description of the package. The packages README.md will contain more information.
-	 * TODO - decide format.
+	 * Brief description of the package. The packages README.md will contain more
+	 * information. TODO - decide format.
 	 */
 	private String description;
 
@@ -171,6 +181,14 @@ public class PackageMetadata {
 
 	public void setPackageHomeUrl(String packageHomeUrl) {
 		this.packageHomeUrl = packageHomeUrl;
+	}
+
+	public byte[] getPackageFile() {
+		return packageFile;
+	}
+
+	public void setPackageFile(byte[] packageFile) {
+		this.packageFile = packageFile;
 	}
 
 	public String getTags() {

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageUploadProperties.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageUploadProperties.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+public class PackageUploadProperties {
+
+	private String name;
+
+	private String repoName;
+
+	private String version;
+
+	private String extension;
+
+	private byte[] fileToUpload;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getRepoName() {
+		return repoName;
+	}
+
+	public void setRepoName(String repoName) {
+		this.repoName = repoName;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public String getExtension() {
+		return extension;
+	}
+
+	public void setExtension(String extension) {
+		this.extension = extension;
+	}
+
+	public byte[] getFileToUpload() {
+		return fileToUpload;
+	}
+
+	public void setFileToUpload(byte[] fileToUpload) {
+		this.fileToUpload = fileToUpload;
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
@@ -22,11 +22,14 @@ import javax.validation.constraints.NotNull;
  * @author Mark Pollack
  */
 @Entity
+// todo: Add isLocal flag to differentiate local vs remote.
+// todo: Add description
+// todo: Add order flag
 public class Repository {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
-	private long id;
+	private String id;
 
 	/**
 	 * A short name, e.g. 'stable' to associate with this repository, must be unique.
@@ -50,6 +53,14 @@ public class Repository {
 	// TODO security/checksum fields of referenced index file.
 
 	public Repository() {
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
 	}
 
 	public String getName() {


### PR DESCRIPTION
  - Package service handles uploading of package from the client
   - It assumes the client sets the PackageUploadProperties with necessary byte[]
and other attributes such as package name, version and file extension
  - Add package upload command that gets the client input
   - Retrieves the file content from client file path and sends over to server as byte[] via PackageUploadProperties
   - Unpack the file content under the local package Repository location

Resolves #60

```
skipper:>package upload --path file:///Users/igopinatha/workspace/git/ilayaperumalg/spring-cloud-skipper/spring-cloud-skipper-server/packages/ticktock/ticktock-1.0.0.zip
/Users/igopinatha/.skipper/packages/ticktock/ticktock-1.0.0.zip
skipper:>

[igopinatha@mbp ~/.skipper/packages]$ tree
.
└── ticktock
    ├── ticktock-1.0.0
    │   ├── package.yml
    │   ├── packages
    │   │   ├── log
    │   │   │   ├── package.yml
    │   │   │   ├── templates
    │   │   │   │   └── log.yml
    │   │   │   └── values.yml
    │   │   └── time
    │   │       ├── package.yml
    │   │       ├── templates
    │   │       │   └── time.yml
    │   │       └── values.yml
    │   └── values.yml
    └── ticktock-1.0.0.zip

7 directories, 9 files
```