### PR TITLE
Do not use packageMetadata.getOrigin as path when loading packages

### DIFF
--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/config/MavenConfigurationProperties.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/config/MavenConfigurationProperties.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
+
+/**
+ * Configure the properties for the MavenResourceLoader. Note that these properties used
+ * for all deployers in the DeployerRepository.
+ * @author Mark Pollack
+ */
+@ConfigurationProperties(prefix = "maven")
+public class MavenConfigurationProperties extends MavenProperties {
+}

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/config/SkipperServerConfiguration.java
@@ -18,10 +18,8 @@ package org.springframework.cloud.skipper.config;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.deployer.resource.docker.DockerResourceLoader;
-import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.maven.MavenResourceLoader;
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
 import org.springframework.context.annotation.Bean;
@@ -35,16 +33,12 @@ import org.springframework.core.io.ResourceLoader;
  */
 @Configuration
 @EnableConfigurationProperties({ SkipperServerProperties.class, CloudFoundryPlatformProperties.class,
-		LocalPlatformProperties.class, KubernetesPlatformProperties.class })
+		LocalPlatformProperties.class, KubernetesPlatformProperties.class,
+		MavenConfigurationProperties.class })
 public class SkipperServerConfiguration {
 
 	@Bean
-	public MavenProperties mavenProperties() {
-		return new MavenConfigurationProperties();
-	}
-
-	@Bean
-	public DelegatingResourceLoader delegatingResourceLoader(MavenProperties mavenProperties) {
+	public DelegatingResourceLoader delegatingResourceLoader(MavenConfigurationProperties mavenProperties) {
 		DockerResourceLoader dockerLoader = new DockerResourceLoader();
 		MavenResourceLoader mavenResourceLoader = new MavenResourceLoader(mavenProperties);
 		Map<String, ResourceLoader> loaders = new HashMap<>();
@@ -53,7 +47,4 @@ public class SkipperServerConfiguration {
 		return new DelegatingResourceLoader(loaders);
 	}
 
-	@ConfigurationProperties(prefix = "maven")
-	static class MavenConfigurationProperties extends MavenProperties {
-	}
 }

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/deployer/AppDeployerReleaseManager.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/deployer/AppDeployerReleaseManager.java
@@ -170,7 +170,6 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 		return release;
 	}
 
-
 	private List<Deployment> unmarshallDeployments(String manifests) {
 
 		List<AppDeploymentKind> deploymentKindList = new ArrayList<>();

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/ReleaseService.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/ReleaseService.java
@@ -120,8 +120,9 @@ public class ReleaseService {
 				throw new PackageException("Can not find a package named " + packageName);
 			}
 			else {
-				// TODO multi-repository support....
-				throw new PackageException("Package name " + packageName + " is not unique across all repositories");
+				// TODO find latest version
+				throw new PackageException("Package name " + packageName + " is not unique.  Finding latest version " +
+						" not yet implemented");
 			}
 		}
 		else {
@@ -136,8 +137,7 @@ public class ReleaseService {
 
 	protected Release deploy(PackageMetadata packageMetadata, DeployProperties deployProperties) {
 		Assert.notNull(packageMetadata, "Can't download package, PackageMetadata is a null value.");
-		this.packageService.downloadPackage(packageMetadata);
-		Package packageToInstall = this.packageService.loadPackage(packageMetadata);
+		Package packageToInstall = this.packageService.downloadPackage(packageMetadata);
 		Release release = createInitialRelease(deployProperties, packageToInstall);
 		return deploy(release);
 	}
@@ -188,8 +188,7 @@ public class ReleaseService {
 	public Release createReleaseForUpdate(PackageMetadata packageMetadata, Integer newVersion,
 			UpdateProperties deployProperties, String platformName) {
 		Assert.notNull(deployProperties, "Deploy Properties can not be null");
-		this.packageService.downloadPackage(packageMetadata);
-		Package packageToInstall = this.packageService.loadPackage(packageMetadata);
+		Package packageToInstall = this.packageService.downloadPackage(packageMetadata);
 		packageToInstall.getMetadata().setId(packageMetadata.getId());
 		Release release = new Release();
 		release.setName(deployProperties.getReleaseName());

--- a/spring-cloud-skipper-server/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server/src/main/resources/application.yml
@@ -12,6 +12,12 @@ spring:
         username: dummy
         password: dummy
 
+# TODO - remove, pre M1 development simplicity
+maven:
+  remoteRepositories:
+    springRepo:
+      url: https://repo.spring.io/libs-snapshot
+
 logging:
   level:
     org.springframework.beans: 'WARN'

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/AbstractControllerTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/AbstractControllerTests.java
@@ -141,7 +141,7 @@ public class AbstractControllerTests extends AbstractMockMvcTests {
 			Release deployedRelease) {
 		assertThat(deployedRelease.getName()).isEqualTo(releaseName);
 		assertThat(deployedRelease.getPlatformName()).isEqualTo("test");
-		assertThat(deployedRelease.getPkg().getMetadata()).isEqualToIgnoringGivenFields(packageMetadata, "id");
+		assertThat(deployedRelease.getPkg().getMetadata()).isEqualToIgnoringGivenFields(packageMetadata, "id", "origin");
 		assertThat(deployedRelease.getPkg().getMetadata().equals(packageMetadata));
 		assertThat(deployedRelease.getInfo().getStatus().getStatusCode()).isEqualTo(StatusCode.DEPLOYED);
 	}

--- a/spring-cloud-skipper-server/src/test/resources/application-index-test.yml
+++ b/spring-cloud-skipper-server/src/test/resources/application-index-test.yml
@@ -2,6 +2,7 @@ spring:
   cloud:
     skipper:
       server:
+        skipperHome: target/skipperTest
         packageRepositories:
          -
            name: test

--- a/spring-cloud-skipper-server/src/test/resources/application-repo-test.yml
+++ b/spring-cloud-skipper-server/src/test/resources/application-repo-test.yml
@@ -2,6 +2,7 @@ spring:
   cloud:
     skipper:
       server:
+        skipperHome: target/skipperTest
         packageRepositories:
          -
            name: test

--- a/spring-cloud-skipper-server/src/test/resources/application.yml
+++ b/spring-cloud-skipper-server/src/test/resources/application.yml
@@ -4,8 +4,12 @@ spring:
   cloud:
     skipper:
       server:
-        skipperHome: target/skipperTest
         synchonizeIndexOnContextRefresh: false
+
+maven:
+  remoteRepositories:
+    springRepo:
+      url: https://repo.spring.io/libs-snapshot
 
 logging:
   level:

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/config/ShellConfiguration.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/config/ShellConfiguration.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.cloud.skipper.client.SkipperClientConfiguration;
@@ -33,6 +34,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.Order;
+import org.springframework.shell.ResultHandler;
 import org.springframework.shell.Shell;
 import org.springframework.shell.jline.DefaultShellApplicationRunner;
 import org.springframework.shell.jline.PromptProvider;
@@ -78,6 +80,10 @@ public class ShellConfiguration {
 		@Autowired
 		private SkipperClientProperties clientProperties;
 
+		@Autowired
+		@Qualifier("main")
+		private ResultHandler resultHandler;
+
 		@Override
 		public void run(ApplicationArguments args) throws Exception {
 			Target target = new Target(clientProperties.getServerUrl(), clientProperties.getUsername(),
@@ -89,7 +95,7 @@ public class ShellConfiguration {
 				targetHolder.changeTarget(target, null);
 			}
 			catch (Exception e) {
-				e.printStackTrace();
+				resultHandler.handleResult(e);
 			}
 
 		}


### PR DESCRIPTION

* Remove PackageService.loadPackage method, downloadPackage now returns Package
* application.yml for tests specify their own local skipperHome to use local 'target' directory
* Default application.yml specifies spring snapshot repo for maven to simplify development.
* Add ignoring of "origin" in package metadata, going to be implemented correctly in another issue shortly
* Move @ConfigurationProperties for Maven to a top level class
* Do not directly instantiate MavenConfigurationProperties


Fixes #96