### PR TITLE
Switch from in memory key-value store to JPA

### DIFF
--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/domain/AppDeployerData.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/domain/AppDeployerData.java
@@ -15,17 +15,13 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.keyvalue.annotation.KeySpace;
+import javax.persistence.Entity;
 
 /**
  * @author Mark Pollack
  */
-@KeySpace("appdeployerdata")
-public class AppDeployerData {
-
-	@Id
-	private String id;
+@Entity
+public class AppDeployerData extends AbstractEntity {
 
 	private String releaseName;
 

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/ReleaseService.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/ReleaseService.java
@@ -188,7 +188,6 @@ public class ReleaseService {
 			UpdateProperties deployProperties, String platformName) {
 		Assert.notNull(deployProperties, "Deploy Properties can not be null");
 		Package packageToInstall = this.packageService.downloadPackage(packageMetadata);
-		packageToInstall.getMetadata().setId(packageMetadata.getId());
 		Release release = new Release();
 		release.setName(deployProperties.getReleaseName());
 		release.setPlatformName(platformName);

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataCreator.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/PackageMetadataCreator.java
@@ -24,7 +24,6 @@ public class PackageMetadataCreator {
 
 	public static void createTwoPackages(PackageMetadataRepository repository) {
 		PackageMetadata packageMetadata = new PackageMetadata();
-		packageMetadata.setId("1");
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setOrigin("www.example.com");
 		packageMetadata.setKind("skipper");
@@ -35,7 +34,6 @@ public class PackageMetadataCreator {
 		packageMetadata.setMaintainer("Alan Hale Jr.");
 		repository.save(packageMetadata);
 		packageMetadata = new PackageMetadata();
-		packageMetadata.setId("2");
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setOrigin("www.example.com");
 		packageMetadata.setKind("skipper");

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/AbstractEntity.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/AbstractEntity.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.springframework.hateoas.Identifiable;
+
+/**
+ * Base class for entity implementations. Uses a {@link String} id.
+ * @author Oliver Gierke
+ */
+@MappedSuperclass
+//TODO consider using Long instead of String
+public class AbstractEntity implements Identifiable<String> {
+
+	private final @Id @GeneratedValue(strategy = GenerationType.AUTO) @JsonIgnore String id;
+
+	protected AbstractEntity() {
+		this.id = null;
+	}
+
+	@Override
+	public String getId() {
+		return this.id;
+	}
+}
+

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ConfigValues.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ConfigValues.java
@@ -15,12 +15,6 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import org.springframework.util.StringUtils;
-
 /**
  * @author Mark Pollack
  */
@@ -28,9 +22,6 @@ public class ConfigValues {
 
 	// The raw YML string of configuration values.
 	private String raw;
-
-	// TODO: not currently used.
-	private Map<String, String> values;
 
 	public ConfigValues() {
 	}
@@ -43,19 +34,4 @@ public class ConfigValues {
 		this.raw = raw;
 	}
 
-	public Map<String, String> getValues() {
-		return values;
-	}
-
-	public void setValues(Map<String, String> values) {
-		this.values = values;
-	}
-
-	@JsonIgnore
-	public boolean isConfigEmpty() {
-		if (values == null || StringUtils.isEmpty(raw)) {
-			return true;
-		}
-		return false;
-	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Info.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Info.java
@@ -17,11 +17,17 @@ package org.springframework.cloud.skipper.domain;
 
 import java.util.Date;
 
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+
 /**
  * @author Mark Pollack
  */
-public class Info {
+@Entity
+public class Info extends AbstractEntity {
 
+	@OneToOne(cascade = { CascadeType.ALL })
 	private Status status;
 
 	private Date firstDeployed;

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -15,23 +15,17 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import javax.persistence.Entity;
 import javax.persistence.Lob;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.keyvalue.annotation.KeySpace;
-
 /**
  * @author Mark Pollack
  */
-// @Entity
-@KeySpace("packagemetadata")
-public class PackageMetadata {
-
-	@Id
-	private String id;
+@Entity
+public class PackageMetadata extends AbstractEntity {
 
 	/**
 	 * The Package Index spec version this file is based on. Required
@@ -93,8 +87,8 @@ public class PackageMetadata {
 	private String maintainer;
 
 	/**
-	 * Brief description of the package. The packages README.md will contain more
-	 * information. TODO - decide format.
+	 * Brief description of the package. The packages README.md will contain more information.
+	 * TODO - decide format.
 	 */
 	private String description;
 
@@ -151,13 +145,13 @@ public class PackageMetadata {
 		this.version = version;
 	}
 
-	public String getId() {
-		return id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
-	}
+	// public String getId() {
+	// return id;
+	// }
+	//
+	// public void setId(String id) {
+	// this.id = id;
+	// }
 
 	public String getAppVersion() {
 		return appVersion;
@@ -303,7 +297,7 @@ public class PackageMetadata {
 	@Override
 	public String toString() {
 		return "PackageMetadata{" +
-				"id='" + id + '\'' +
+				"id='" + getId() + '\'' +
 				", apiVersion='" + apiVersion + '\'' +
 				", origin='" + origin + '\'' +
 				", kind='" + kind + '\'' +

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
@@ -15,36 +15,53 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import javax.persistence.Column;
+import java.io.IOException;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
+import javax.persistence.OneToOne;
+import javax.persistence.PostLoad;
+import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.keyvalue.annotation.KeySpace;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.util.StringUtils;
 
 /**
  * @author Mark Pollack
  */
-@KeySpace("release)")
-public class Release {
-
-	@Id
-	private String id;
+@Entity
+public class Release extends AbstractEntity {
 
 	/**
-	 * A short name, to associate with the release of this package, must be unique.
+	 * A short name, to associate with the release of this package.
 	 */
 	@NotNull
-	@Column(unique = true)
 	private String name;
 
 	private int version;
 
+	@OneToOne(cascade = { CascadeType.ALL })
 	private Info info;
 
+	@Transient
 	private Package pkg;
 
+	@Lob
+	private String pkgJsonString;
+
+	@Transient
 	private ConfigValues configValues = new ConfigValues();
 
+	@Lob
+	private String configValuesString;
+
+	//TODO Since we store the release manifest now in the DB, we don't need the ManifestStore unless we want to also
+	//     store external, e.g git.
+	@Lob
 	private String manifest;
 
 	private String platformName;
@@ -82,6 +99,15 @@ public class Release {
 
 	public void setPkg(Package pkg) {
 		this.pkg = pkg;
+		//TODO Do we want to store the package file at this specific moment in time?
+		this.pkg.getMetadata().setPackageFileBytes(null);
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			this.pkgJsonString = mapper.writeValueAsString(pkg);
+		}
+		catch (JsonProcessingException e) {
+			e.printStackTrace();
+		}
 	}
 
 	public ConfigValues getConfigValues() {
@@ -95,6 +121,9 @@ public class Release {
 
 	public void setConfigValues(ConfigValues configValues) {
 		this.configValues = configValues;
+		if (configValues != null && StringUtils.hasText(configValues.getRaw())) {
+			this.configValuesString = configValues.getRaw();
+		}
 	}
 
 	public String getManifest() {
@@ -111,5 +140,20 @@ public class Release {
 
 	public void setPlatformName(String platformName) {
 		this.platformName = platformName;
+	}
+
+	@PostLoad
+	public void afterLoad() {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			this.pkg = mapper.readValue(this.pkgJsonString, Package.class);
+			this.configValues = new ConfigValues();
+			if (this.configValuesString != null && StringUtils.hasText(configValuesString)) {
+				this.configValues.setRaw(this.configValuesString);
+			}
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
@@ -15,7 +15,8 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
 
 /**
@@ -25,11 +26,7 @@ import javax.validation.constraints.NotNull;
 // todo: Add isLocal flag to differentiate local vs remote.
 // todo: Add description
 // todo: Add order flag
-public class Repository {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
-	private String id;
+public class Repository extends AbstractEntity {
 
 	/**
 	 * A short name, e.g. 'stable' to associate with this repository, must be unique.
@@ -53,14 +50,6 @@ public class Repository {
 	// TODO security/checksum fields of referenced index file.
 
 	public Repository() {
-	}
-
-	public String getId() {
-		return id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
 	}
 
 	public String getName() {

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
@@ -15,12 +15,18 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
 /**
  * @author Mark Pollack
  */
-public class Status {
+@Entity
+public class Status extends AbstractEntity {
 
 	// Status from the Release managment platform
+	@Enumerated(EnumType.STRING)
 	private StatusCode statusCode;
 
 	// Status from the underlying platform

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/StatusCode.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/StatusCode.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.domain;
 /**
  * @author Mark Pollack
  */
+
 public enum StatusCode {
 
 	// Status_UNKNOWN indicates that a release is in an uncertain state.


### PR DESCRIPTION
* PackageMetadata and Release are now @Entity along with nested classes
* Add AbstractEntity base class
* In Release entity, Serialize Package, ConfigValues, and Manifest as Lob
* Keep AppDeployerData as in-memory since it is used internally and
  initialized when the application starts.  We don't want to store user creds
  in the DB.

Fixes #106