### PR TITLE
Move exception from server to spring-cloud-skipper

### DIFF
--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/controller/SkipperController.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/controller/SkipperController.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.domain.AboutInfo;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
@@ -27,7 +28,6 @@ import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
-import org.springframework.cloud.skipper.repository.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.service.PackageService;
 import org.springframework.cloud.skipper.service.ReleaseService;
 import org.springframework.http.HttpStatus;

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/repository/ReleaseRepositoryCustom.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/repository/ReleaseRepositoryCustom.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.skipper.repository;
 
 import java.util.List;
 
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.Release;
 

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/repository/ReleaseRepositoryImpl.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/repository/ReleaseRepositoryImpl.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
 

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/ReleaseService.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/service/ReleaseService.java
@@ -24,6 +24,7 @@ import com.samskivert.mustache.Mustache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.deployer.ReleaseAnalyzer;
 import org.springframework.cloud.skipper.deployer.ReleaseManager;
@@ -41,7 +42,6 @@ import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.repository.DeployerRepository;
 import org.springframework.cloud.skipper.repository.PackageMetadataRepository;
-import org.springframework.cloud.skipper.repository.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.repository.ReleaseRepository;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/ReleaseRepositoryTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/repository/ReleaseRepositoryTests.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.AbstractIntegrationTest;
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
@@ -187,7 +188,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 			fail("Expected ReleaseNotFoundException");
 		}
 		catch (ReleaseNotFoundException e) {
-			assertThat(e.getMessage().equals(ReleaseNotFoundException.getExceptionMessage(releaseName)));
+			assertThat(e.getMessage().equals(String.format("Release with the name [%s] doesn't exist", releaseName)));
 		}
 	}
 
@@ -200,7 +201,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 			fail("Expected ReleaseNotFoundException");
 		}
 		catch (ReleaseNotFoundException e) {
-			assertThat(e.getMessage().equals(ReleaseNotFoundException.getExceptionMessage(releaseName, version)));
+			assertThat(e.getMessage().equals(String.format("Release with the name [%s] and version [%s] doesn't exist", releaseName, version)));
 		}
 	}
 

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/service/ReleaseServiceTests.java
@@ -19,13 +19,13 @@ import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.AbstractIntegrationTest;
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.cloud.skipper.repository.ReleaseNotFoundException;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/ReleaseNotFoundException.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/ReleaseNotFoundException.java
@@ -13,33 +13,51 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.repository;
-
-import org.springframework.cloud.skipper.SkipperException;
+package org.springframework.cloud.skipper;
 
 /**
+ * A {@link SkipperException} indicating a missing {@code Skipper} release.
+ *
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
 @SuppressWarnings("serial")
 public class ReleaseNotFoundException extends SkipperException {
 
+	/**
+	 * Instantiates a new {@code ReleaseNotFoundException}.
+	 *
+	 * @param releaseName the release name
+	 */
 	public ReleaseNotFoundException(String releaseName) {
 		super(getExceptionMessage(releaseName));
 	}
 
+	/**
+	 * Instantiates a new {@code ReleaseNotFoundException}.
+	 *
+	 * @param releaseName the release name
+	 * @param version the version
+	 */
 	public ReleaseNotFoundException(String releaseName, int version) {
 		super(getExceptionMessage(releaseName, version));
 	}
 
+	/**
+	 * Instantiates a new {@code ReleaseNotFoundException}.
+	 *
+	 * @param releaseName the release name
+	 * @param cause the cause
+	 */
 	public ReleaseNotFoundException(String releaseName, Throwable cause) {
 		super(getExceptionMessage(releaseName), cause);
 	}
 
-	public static String getExceptionMessage(String releaseName) {
+	private static String getExceptionMessage(String releaseName) {
 		return String.format("Release with the name [%s] doesn't exist", releaseName);
 	}
 
-	public static String getExceptionMessage(String releaseName, int version) {
+	private static String getExceptionMessage(String releaseName, int version) {
 		return String.format("Release with the name [%s] and version [%s] doesn't exist", releaseName, version);
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/SkipperException.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/SkipperException.java
@@ -16,15 +16,30 @@
 package org.springframework.cloud.skipper;
 
 /**
+ * Generic exception indicating a problem in components interacting with
+ * {@code Skipper}.
+ *
  * @author Mark Pollack
+ * @author Janne Valkealahti
  */
 @SuppressWarnings("serial")
 public class SkipperException extends RuntimeException {
 
+	/**
+	 * Instantiates a new {@code SkipperException}.
+	 *
+	 * @param message the message
+	 */
 	public SkipperException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Instantiates a new {@code SkipperException}.
+	 *
+	 * @param message the message
+	 * @param cause the cause
+	 */
 	public SkipperException(String message, Throwable cause) {
 		super(message, cause);
 	}


### PR DESCRIPTION
- As these exceptions are not only server related, move
  to common shared package so that we can use same
  classes in a client as well. This would be to
  i.e. propagate ReleaseNotFoundException from server
  to client via rest.
- Made some static methods in ReleaseNotFoundException
  private as if those are only accessed in tests then
  its better to hardcode asserts in tests.
- Bit of polish and javadocs.
- Fixes #146