### PR TITLE
gh-124 Add RESTDocs based documentation

### DIFF
--- a/spring-cloud-skipper-docs/pom.xml
+++ b/spring-cloud-skipper-docs/pom.xml
@@ -13,9 +13,28 @@
     <properties>
         <main.basedir>${basedir}/..</main.basedir>
     </properties>
-    <dependencies>
-
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.restdocs</groupId>
+			<artifactId>spring-restdocs-mockmvc</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.restdocs</groupId>
+			<artifactId>spring-restdocs-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
     <profiles>
         <profile>
             <id>full</id>
@@ -80,7 +99,7 @@
                                 <project-version>${project.version}</project-version>
                                 <project-artifactId>${project.artifactId}</project-artifactId>
                                 <version-type-lowercase>${version-type-lowercase}</version-type-lowercase>
-                                <snippets>${basedir}/target/generated-snippets</snippets>
+                                <snippets>${main.basedir}/spring-cloud-skipper-server/target/generated-snippets</snippets>
                             </attributes>
                         </configuration>
                         <executions>

--- a/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
@@ -1,0 +1,290 @@
+[[api-guide]]
+= REST API Guide
+
+[partintro]
+--
+In this section you will learn all about the Spring Cloud Skipper REST API.
+--
+
+[[api-guide-overview]]
+== Overview
+
+Spring Cloud Skipper provides a  REST API allowing you to access all aspects of
+the server. In fact the Spring Cloud Skipper Shell is a first-class consumer of
+that API.
+
+[[api-guide-overview-http-verbs]]
+=== HTTP verbs
+
+Spring Cloud Skipper tries to adhere as closely as possible to standard HTTP and
+REST conventions in its use of HTTP verbs.
+
+|===
+| Verb | Usage
+
+| `GET`
+| Used to retrieve a resource
+
+| `POST`
+| Used to create a new resource
+
+| `PUT`
+| Used to update an existing resource, including partial updates. Also used for
+resources that imply the concept of `restarts`.
+
+| `DELETE`
+| Used to delete an existing resource
+|===
+
+[[api-guide-overview-http-status-codes]]
+=== HTTP status codes
+
+RESTful note tries to adhere as closely as possible to standard HTTP and REST conventions in its use of HTTP status codes.
+
+|===
+| Status code | Usage
+
+| `200 OK`
+| The request completed successfully
+
+| `201 Created`
+| A new resource has been created successfully. The resource's URI is available from the response's `Location` header
+
+| `204 No Content`
+| An update to an existing resource has been applied successfully
+
+| `400 Bad Request`
+| The request was malformed. The response body will include an error providing further information
+
+| `404 Not Found`
+| The requested resource did not exist
+
+|===
+
+[[api-guide-overview-headers]]
+=== Headers
+
+Every response has the following header(s):
+
+include::{snippets}/api-documentation/headers/response-headers.adoc[]
+
+[[api-guide-overview-errors]]
+=== Errors
+
+include::{snippets}/api-documentation/errors/response-fields.adoc[]
+
+[[api-guide-overview-hypermedia]]
+=== Hypermedia
+
+Spring Cloud Skipper uses hypermedia and resources include links to other resources
+in their responses. Responses are in http://stateless.co/hal_specification.html[Hypertext Application from resource to resource Language (HAL)] format. Links can be found beneath the `_links` key. Users of the API should not create URIs themselves, instead they should use the above-described links to navigate.
+
+[[api-guide-resources]]
+== Resources
+
+[[api-guide-resources-index]]
+=== Index
+
+The index provides the entry point into Spring Cloud Data Flow's REST API.
+
+[[api-guide-resources-index-access]]
+==== Accessing the index
+
+A `GET` request is used to access the index
+
+===== Request structure
+
+include::{snippets}/api-documentation/index/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/api-documentation/index/curl-request.adoc[]
+
+===== Example response
+
+include::{snippets}/api-documentation/index/http-response.adoc[]
+
+[[api-guide-resources-index-links]]
+===== Links
+
+The main element of the index are the links as they allow you to traverse the API
+and execute the desired functionality:
+
+include::{snippets}/api-documentation/index/links.adoc[]
+
+[[resources-about]]
+=== Server Meta Information
+
+==== Retrieving information about the server
+A `GET` request will return meta information for Spring Cloud Skipper. This includes:
+
+* Server name, typically `spring-cloud-skipper-server`
+* Version of the server, e.g. `{project-version}`
+
+===== Request structure
+
+include::{snippets}/about-documentation/get-meta-information/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/about-documentation/get-meta-information/curl-request.adoc[]
+
+===== Response structure
+
+include::{snippets}/about-documentation/get-meta-information/http-response.adoc[]
+
+===== Response fields
+
+include::{snippets}/about-documentation/get-meta-information/response-fields.adoc[]
+
+[[resources-repositories]]
+=== Resources Repositories
+
+==== Retrieving a list of repositories
+A `GET` request will return a paginated list for all Spring Cloud Skipper repositories.
+
+===== Request structure
+
+include::{snippets}/repositories-documentation/get-all-repositories/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/repositories-documentation/get-all-repositories/curl-request.adoc[]
+
+===== Response structure
+
+include::{snippets}/repositories-documentation/get-all-repositories/http-response.adoc[]
+
+===== Response fields
+
+include::{snippets}/repositories-documentation/get-all-repositories/response-fields.adoc[]
+
+==== Retrieving a single repository
+
+A `GET` request will return a single Spring Cloud Skipper repositories.
+
+===== Request structure
+
+include::{snippets}/repositories-documentation/get-single-repository/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/repositories-documentation/get-single-repository/curl-request.adoc[]
+
+===== Response structure
+
+include::{snippets}/repositories-documentation/get-single-repository/http-response.adoc[]
+
+===== Response fields
+
+include::{snippets}/repositories-documentation/get-single-repository/response-fields.adoc[]
+
+[[resources-app-deployers-datas]]
+=== App Deployers Datas
+
+==== Retrieving a list of app deployer datas
+A `GET` request will return a paginated list for all Spring Cloud Skipper repositories.
+
+===== Request structure
+
+include::{snippets}/app-deployers-datas-documentation/get-all-app-deployer-datas/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/app-deployers-datas-documentation/get-all-app-deployer-datas/curl-request.adoc[]
+
+===== Response structure
+
+include::{snippets}/app-deployers-datas-documentation/get-all-app-deployer-datas/http-response.adoc[]
+
+===== Response fields
+
+include::{snippets}/app-deployers-datas-documentation/get-all-app-deployer-datas/response-fields.adoc[]
+
+[[resources-app-deployers-datas]]
+=== Deployers
+
+==== Retrieving a list of app deployer datas
+A `GET` request will return a paginated list for all Spring Cloud Skipper repositories.
+
+===== Request structure
+
+include::{snippets}/deployers-documentation/get-all-deployers/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/deployers-documentation/get-all-deployers/curl-request.adoc[]
+
+===== Response structure
+
+include::{snippets}/deployers-documentation/get-all-deployers/http-response.adoc[]
+
+===== Response fields
+
+include::{snippets}/deployers-documentation/get-all-deployers/response-fields.adoc[]
+
+[[resources-app-deployers-datas]]
+=== Releases
+
+==== Retrieving a list of releases
+A `GET` request will return a paginated list for all Spring Cloud Skipper releases.
+
+===== Request structure
+
+include::{snippets}/releases-documentation/get-all-releases/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/releases-documentation/get-all-releases/curl-request.adoc[]
+
+===== Response structure
+
+include::{snippets}/releases-documentation/get-all-releases/http-response.adoc[]
+
+===== Response fields
+
+include::{snippets}/releases-documentation/get-all-releases/response-fields.adoc[]
+
+[[resources-package-metadata]]
+=== Package Metadata
+
+==== Retrieving a list of package metadata
+
+A `GET` request will return a paginated list for all Spring Cloud Skipper releases.
+
+===== Request structure
+
+include::{snippets}/package-metadata-documentation/get-all-package-metadata/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/package-metadata-documentation/get-all-package-metadata/curl-request.adoc[]
+
+===== Response structure
+
+include::{snippets}/package-metadata-documentation/get-all-package-metadata/http-response.adoc[]
+
+===== Response fields
+
+include::{snippets}/package-metadata-documentation/get-all-package-metadata/response-fields.adoc[]
+
+==== Package metadata details
+
+A `GET` request will return details of a package using the _id_ of the package.
+
+===== Request structure
+
+include::{snippets}/package-metadata-documentation/get-package-metadata-details/http-request.adoc[]
+
+===== Example request
+
+include::{snippets}/package-metadata-documentation/get-package-metadata-details/curl-request.adoc[]
+
+===== Response structure
+
+include::{snippets}/package-metadata-documentation/get-package-metadata-details/http-response.adoc[]
+
+===== Response fields
+
+include::{snippets}/package-metadata-documentation/get-package-metadata-details/response-fields.adoc[]
+

--- a/spring-cloud-skipper-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/index.adoc
@@ -1,5 +1,6 @@
 = Spring Cloud Skipper Reference Guide
-Mark Pollack, Ilayaperumal Gopinathan, Janne Valkealahti
+Mark Pollack; Ilayaperumal Gopinathan; Janne Valkealahti; Gunnar Hillert
+
 :doctype: book
 :toc:
 :toclevels: 4
@@ -33,6 +34,7 @@ include::preface.adoc[]
 include::spring-cloud-skipper-overview.adoc[]
 include::architecture.adoc[]
 include::getting-started.adoc[]
+include::api-guide.adoc[]
 include::appendix.adoc[]
 
 

--- a/spring-cloud-skipper-server/pom.xml
+++ b/spring-cloud-skipper-server/pom.xml
@@ -16,6 +16,8 @@
         <spring-cloud-deployer-kubernetes.version>1.2.2.RELEASE</spring-cloud-deployer-kubernetes.version>
         <reactor.version>3.0.7.RELEASE</reactor.version>
         <zeroturnaround.version>1.11</zeroturnaround.version>
+        <!-- <spring-restdocs.version>1.2.2.RELEASE</spring-restdocs.version> -->
+        <spring-restdocs.version>1.2.2.RELEASE</spring-restdocs.version>
     </properties>
 
     <dependencies>
@@ -143,10 +145,20 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>23.1-jre</version>
+         </dependency>
+         <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-mockmvc</artifactId>
+            <version>${spring-restdocs.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-core</artifactId>
+            <version>${spring-restdocs.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
-
-
     <build>
         <resources>
             <resource>
@@ -158,6 +170,16 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Documentation.java</include>
+                        <include>**/*Tests.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
@@ -172,6 +194,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/AboutDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/AboutDocumentation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.controller.docs;
+
+import org.junit.Test;
+
+import org.springframework.http.MediaType;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Gunnar Hillert
+ */
+public class AboutDocumentation extends BaseDocumentation {
+
+	@Test
+	public void getMetaInformation() throws Exception {
+		this.mockMvc.perform(get("/about").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				responseFields(
+					fieldWithPath("name").description("Name of the Skipper server."),
+					fieldWithPath("version").description(
+						"Version of the Skipper server.")
+				)
+			)
+		);
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/ApiDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/ApiDocumentation.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.controller.docs;
+
+import javax.servlet.RequestDispatcher;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Gunnar Hillert
+ */
+public class ApiDocumentation extends BaseDocumentation {
+
+	@Test
+	public void headers() throws Exception {
+		this.mockMvc.perform(get("/")).andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(responseHeaders(headerWithName("Content-Type")
+						.description("The Content-Type of the payload, e.g. " + "`application/hal+json`"))));
+	}
+
+	@Test
+	public void errors() throws Exception {
+		this.mockMvc
+				.perform(get("/error").requestAttr(RequestDispatcher.ERROR_STATUS_CODE, 400)
+						.requestAttr(RequestDispatcher.ERROR_REQUEST_URI, "/path/not/there").requestAttr(
+								RequestDispatcher.ERROR_MESSAGE,
+								"The path 'http://localhost:8080/path/not/there' does not exist"))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("error", is("Bad Request")))
+				.andExpect(jsonPath("timestamp", is(notNullValue()))).andExpect(jsonPath("status", is(400)))
+				.andExpect(jsonPath("path", is(notNullValue())))
+				.andDo(this.documentationHandler.document(responseFields(
+						fieldWithPath("error").description(
+								"The HTTP error that occurred, e.g. `Bad Request`"),
+						fieldWithPath("message").description("A description of the cause of the error"),
+						fieldWithPath("path").description("The path to which the request was made"),
+						fieldWithPath("status").description("The HTTP status code, e.g. `400`"),
+						fieldWithPath("timestamp")
+								.description("The time, in milliseconds, at which the error occurred"))));
+	}
+
+	@Test
+	public void index() throws Exception {
+		this.mockMvc.perform(get("/")).andExpect(status().isOk()).andDo(this.documentationHandler.document(links(
+			linkWithRel("appDeployerDatas").description("Exposes App Deployer Data"),
+			linkWithRel("repositories").description("Exposes package repositories"),
+			linkWithRel("deployers").description("Exposes deployer"),
+			linkWithRel("releases").description("Exposes release information"),
+			linkWithRel("packageMetadata").description("Provides details for Package Metadata"),
+			linkWithRel("profile").description("Entrypoint to provide ALPS metadata defining simple descriptions of application-level semantics.")
+		)));
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/ApiDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/ApiDocumentation.java
@@ -22,11 +22,12 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/AppDeployersDatasDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/AppDeployersDatasDocumentation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.controller.docs;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * @author Gunnar Hillert
+ */
+@ActiveProfiles("repo-test")
+@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
+		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
+public class AppDeployersDatasDocumentation extends BaseDocumentation {
+
+	@Test
+	public void getAllAppDeployerDatas() throws Exception {
+		this.mockMvc.perform(
+			get("/appDeployerDatas")
+				.param("page", "0")
+				.param("size", "10"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				super.paginationRequestParameterProperties,
+				super.paginationProperties.and(
+					fieldWithPath("_embedded.appDeployerDatas").description("Array of App Deployer Data objects.")
+				).and(super.defaultLinkProperties),
+				super.linksForSkipper()
+			)
+		);
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/AppDeployersDatasDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/AppDeployersDatasDocumentation.java
@@ -16,14 +16,15 @@
 
 package org.springframework.cloud.skipper.controller.docs;
 
+import org.junit.Test;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import org.junit.Test;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * @author Gunnar Hillert

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/BaseDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/BaseDocumentation.java
@@ -16,13 +16,18 @@
 
 package org.springframework.cloud.skipper.controller.docs;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Rule;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.controller.AbstractControllerTests;
 import org.springframework.restdocs.JUnitRestDocumentation;
-
+import org.springframework.restdocs.hypermedia.HypermediaDocumentation;
+import org.springframework.restdocs.hypermedia.LinkDescriptor;
+import org.springframework.restdocs.hypermedia.LinksSnippet;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
@@ -30,10 +35,8 @@ import org.springframework.restdocs.request.RequestParametersSnippet;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.restdocs.hypermedia.HypermediaDocumentation;
-import org.springframework.restdocs.hypermedia.LinkDescriptor;
-import org.springframework.restdocs.hypermedia.LinksSnippet;
 
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -43,11 +46,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 
 /**
  * Sets up Spring Rest Docs via {@link #setupMocks()} and also provides common snippets to be used by

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/BaseDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/BaseDocumentation.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.controller.docs;
+
+import org.junit.Before;
+import org.junit.Rule;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.controller.AbstractControllerTests;
+import org.springframework.restdocs.JUnitRestDocumentation;
+
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.request.RequestParametersSnippet;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.restdocs.hypermedia.HypermediaDocumentation;
+import org.springframework.restdocs.hypermedia.LinkDescriptor;
+import org.springframework.restdocs.hypermedia.LinksSnippet;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+
+/**
+ * Sets up Spring Rest Docs via {@link #setupMocks()} and also provides common snippets to be used by
+ * the various documentation tests.
+ *
+ * @author Gunnar Hillert
+ */
+public abstract class BaseDocumentation extends AbstractControllerTests {
+
+	@Autowired
+	WebApplicationContext context;
+
+	@Rule
+	public final JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation();
+
+	protected RestDocumentationResultHandler documentationHandler;
+
+	protected MockMvc mockMvc;
+
+	@Before
+	public void setupMocks() {
+		this.prepareDocumentationTests(this.context);
+	}
+
+	private void prepareDocumentationTests(WebApplicationContext context) {
+		this.documentationHandler = document("{class-name}/{method-name}",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()));
+
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
+				.apply(documentationConfiguration(this.restDocumentation).uris()
+				.withScheme("http")
+				.withHost("localhost")
+				.withPort(7577))
+				.alwaysDo(this.documentationHandler)
+		.build();
+	}
+
+	/**
+	 * Snippet, documenting common pagination properties.
+	 */
+	protected final ResponseFieldsSnippet paginationProperties = responseFields(
+		fieldWithPath("page").description("Pagination properties"),
+		fieldWithPath("page.size").description("The size of the page being returned"),
+		fieldWithPath("page.totalElements").description("Total elements available for pagination"),
+		fieldWithPath("page.totalPages").description("Total amount of pages"),
+		fieldWithPath("page.number").description("Page number of the page returned (zero-based)")
+	);
+
+	/**
+	 * Snippet for link properties. Set to ignore common links.
+	 */
+	protected final List<FieldDescriptor> defaultLinkProperties = Arrays.asList(
+		fieldWithPath("_links.self.href").ignored().optional(),
+		fieldWithPath("_links.self.templated").ignored().optional(),
+		fieldWithPath("_links.profile.href").ignored().optional(),
+		fieldWithPath("_links.repository.href").ignored().optional(),
+		fieldWithPath("_links.search.href").ignored().optional()
+	);
+
+	/**
+	 * Snippet for common pagination-related request parameters.
+	 */
+	protected final RequestParametersSnippet paginationRequestParameterProperties = requestParameters(
+		parameterWithName("page").description("The zero-based page number (optional)"),
+		parameterWithName("size").description("The requested page size (optional)")
+	);
+
+	/**
+	 * {@link LinksSnippet} for common links. Common links are set to be ignored.
+	 *
+	 * @param descriptors Provide addition link descriptors
+	 * @return the link snipped
+	 */
+	public static LinksSnippet linksForSkipper(LinkDescriptor... descriptors) {
+		return HypermediaDocumentation.links(
+			linkWithRel("self").ignored(),
+			linkWithRel("profile").ignored(),
+			linkWithRel("search").ignored(),
+			linkWithRel("deployer").ignored().optional(),
+			linkWithRel("curies").ignored().optional()
+		).and(descriptors);
+	}
+
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/DeployersDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/DeployersDocumentation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.controller.docs;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * @author Gunnar Hillert
+ */
+@ActiveProfiles("repo-test")
+@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
+		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
+public class DeployersDocumentation extends BaseDocumentation {
+
+	@Test
+	public void getAllDeployers() throws Exception {
+		this.mockMvc.perform(
+			get("/deployers")
+				.param("page", "0")
+				.param("size", "10"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				super.paginationRequestParameterProperties,
+				super.paginationProperties.and(
+					fieldWithPath("_embedded.deployers").description("Array containing Deployer objects"),
+					fieldWithPath("_embedded.deployers[].name").description("Name of the deployer"),
+					fieldWithPath("_embedded.deployers[].type").description("Type of the deployer (e.g. 'local')"),
+					fieldWithPath("_embedded.deployers[]._links.self.href").ignored(),
+					fieldWithPath("_embedded.deployers[]._links.deployer.href").ignored()
+				).and(super.defaultLinkProperties),
+				super.linksForSkipper()
+			)
+		);
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/DeployersDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/DeployersDocumentation.java
@@ -16,14 +16,15 @@
 
 package org.springframework.cloud.skipper.controller.docs;
 
+import org.junit.Test;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import org.junit.Test;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * @author Gunnar Hillert

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/PackageMetadataDocumentation.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.controller.docs;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * @author Gunnar Hillert
+ */
+@ActiveProfiles("repo-test")
+@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
+		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
+public class PackageMetadataDocumentation extends BaseDocumentation {
+
+	@Test
+	public void getAllPackageMetadata() throws Exception {
+		this.mockMvc.perform(
+			get("/packageMetadata")
+				.param("page", "0")
+				.param("size", "10"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				super.paginationRequestParameterProperties,
+				super.paginationProperties.and(
+					fieldWithPath("_embedded.packageMetadata").description("Contains a collection of Package Metadata items"),
+					fieldWithPath("_embedded.packageMetadata[].apiVersion").description("The Package Index spec version this file is based on"),
+					fieldWithPath("_embedded.packageMetadata[].origin").description("The repository ID this Package Index file belongs to"),
+					fieldWithPath("_embedded.packageMetadata[].kind").description("What type of package system is being used"),
+					fieldWithPath("_embedded.packageMetadata[].name").description("The name of the package"),
+					fieldWithPath("_embedded.packageMetadata[].version").description("The version of the package"),
+					fieldWithPath("_embedded.packageMetadata[].appVersion").description("The version of the application in the package (assuming package maps to one app)"),
+					fieldWithPath("_embedded.packageMetadata[].packageSourceUrl").description("Location to source code for this package"),
+					fieldWithPath("_embedded.packageMetadata[].packageHomeUrl").description("The home page of the package"),
+					fieldWithPath("_embedded.packageMetadata[].tags").description("A comma separated list of tags to use for searching"),
+					fieldWithPath("_embedded.packageMetadata[].maintainer").description("Who is maintaining this package"),
+					fieldWithPath("_embedded.packageMetadata[].description").description("Brief description of the package"),
+					fieldWithPath("_embedded.packageMetadata[].sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+					fieldWithPath("_embedded.packageMetadata[].iconUrl").description("Url location of a icon"),
+					fieldWithPath("_embedded.packageMetadata[].packageFileBytes").description("Size of the file in bytes"),
+					fieldWithPath("_embedded.packageMetadata[]._links.self.href").ignored(),
+					fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.href").ignored(),
+					fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.templated").ignored(),
+					fieldWithPath("_embedded.packageMetadata[]._links.install.href").ignored()
+				).and(super.defaultLinkProperties),
+				super.linksForSkipper()
+			)
+		);
+	}
+
+	@Test
+	public void getPackageMetadataDetails() throws Exception {
+		deploy("log", "1.0.0", "test2");
+
+		this.mockMvc.perform(
+			get("/packageMetadata/{packageMetadataId}", 1))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				pathParameters(
+					parameterWithName("packageMetadataId").description("The id of the package to query")
+				),
+				responseFields(
+					fieldWithPath("apiVersion").description("The Package Index spec version this file is based on"),
+					fieldWithPath("origin").description("The repository ID this Package Index file belongs to"),
+					fieldWithPath("kind").description("What type of package system is being used"),
+					fieldWithPath("name").description("The name of the package"),
+					fieldWithPath("version").description("The version of the package"),
+					fieldWithPath("appVersion").description("The version of the application in the package (assuming package maps to one app)"),
+					fieldWithPath("packageSourceUrl").description("Location to source code for this package"),
+					fieldWithPath("packageHomeUrl").description("The home page of the package"),
+					fieldWithPath("tags").description("A comma separated list of tags to use for searching"),
+					fieldWithPath("maintainer").description("Who is maintaining this package"),
+					fieldWithPath("description").description("Brief description of the package"),
+					fieldWithPath("sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+					fieldWithPath("iconUrl").description("Url location of a icon"),
+					fieldWithPath("packageFileBytes").description("Size of the file in bytes"),
+					fieldWithPath("_links.packageMetadata.href").ignored(),
+					fieldWithPath("_links.packageMetadata.templated").ignored(),
+					fieldWithPath("_links.install.href").ignored()
+				).and(super.defaultLinkProperties)
+			));
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/PackageMetadataDocumentation.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.skipper.controller.docs;
 
+import org.junit.Test;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -23,10 +28,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import org.junit.Test;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * @author Gunnar Hillert
@@ -53,7 +54,6 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 					fieldWithPath("_embedded.packageMetadata[].kind").description("What type of package system is being used"),
 					fieldWithPath("_embedded.packageMetadata[].name").description("The name of the package"),
 					fieldWithPath("_embedded.packageMetadata[].version").description("The version of the package"),
-					fieldWithPath("_embedded.packageMetadata[].appVersion").description("The version of the application in the package (assuming package maps to one app)"),
 					fieldWithPath("_embedded.packageMetadata[].packageSourceUrl").description("Location to source code for this package"),
 					fieldWithPath("_embedded.packageMetadata[].packageHomeUrl").description("The home page of the package"),
 					fieldWithPath("_embedded.packageMetadata[].tags").description("A comma separated list of tags to use for searching"),
@@ -90,7 +90,6 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 					fieldWithPath("kind").description("What type of package system is being used"),
 					fieldWithPath("name").description("The name of the package"),
 					fieldWithPath("version").description("The version of the package"),
-					fieldWithPath("appVersion").description("The version of the application in the package (assuming package maps to one app)"),
 					fieldWithPath("packageSourceUrl").description("Location to source code for this package"),
 					fieldWithPath("packageHomeUrl").description("The home page of the package"),
 					fieldWithPath("tags").description("A comma separated list of tags to use for searching"),

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/ReleasesDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/ReleasesDocumentation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.controller.docs;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * @author Gunnar Hillert
+ */
+@ActiveProfiles("repo-test")
+@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
+		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
+public class ReleasesDocumentation extends BaseDocumentation {
+
+	@Test
+	public void getAllReleases() throws Exception {
+		this.mockMvc.perform(
+			get("/releases")
+				.param("page", "0")
+				.param("size", "10"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				super.paginationRequestParameterProperties,
+				super.paginationProperties.and(
+					fieldWithPath("_embedded.releases").description("Provides a list of releases")
+				).and(super.defaultLinkProperties),
+				super.linksForSkipper()
+			)
+		);
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/ReleasesDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/ReleasesDocumentation.java
@@ -16,14 +16,15 @@
 
 package org.springframework.cloud.skipper.controller.docs;
 
+import org.junit.Test;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import org.junit.Test;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * @author Gunnar Hillert

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/RepositoriesDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/RepositoriesDocumentation.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.controller.docs;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * @author Gunnar Hillert
+ */
+@ActiveProfiles("repo-test")
+@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
+		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
+public class RepositoriesDocumentation extends BaseDocumentation {
+
+	@Test
+	public void getAllRepositories() throws Exception {
+		this.mockMvc.perform(
+			get("/repositories")
+				.param("page", "0")
+				.param("size", "10"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				super.paginationRequestParameterProperties,
+				super.paginationProperties.and(
+					fieldWithPath("_embedded.repositories").description("Contains a collection of Repositories"),
+					fieldWithPath("_embedded.repositories[].name").description("Name of the Repository"),
+					fieldWithPath("_embedded.repositories[].url").description("Url of the Repository"),
+					fieldWithPath("_embedded.repositories[].sourceUrl").description("Source Url of the repository"),
+					fieldWithPath("_embedded.repositories[]._links.self.href").ignored(),
+					fieldWithPath("_embedded.repositories[]._links.repository.href").ignored()
+				).and(super.defaultLinkProperties))
+			);
+	}
+
+	@Test
+	public void getSingleRepository() throws Exception {
+		deploy("log", "1.0.0", "test2");
+
+		this.mockMvc.perform(
+			get("/repositories/{repositoryId}", 1))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(this.documentationHandler.document(
+				pathParameters(
+					parameterWithName("repositoryId").description("The id of the repository to query")
+				),
+				responseFields(
+					fieldWithPath("name").description("Name of the Repository"),
+					fieldWithPath("url").description("URL of the Repository"),
+					fieldWithPath("sourceUrl").description("Source URL of the repository")
+				).and(super.defaultLinkProperties))
+			);
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/RepositoriesDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/controller/docs/RepositoriesDocumentation.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.skipper.controller.docs;
 
+import org.junit.Test;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -23,10 +28,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import org.junit.Test;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 /**
  * @author Gunnar Hillert

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -87,7 +87,7 @@ public class PackageMetadata extends AbstractEntity {
 	private String description;
 
 	/**
-	 * Hash of package binary that will be donwloaded using SHA256 hash algorithm.
+	 * Hash of package binary that will be downloaded using SHA256 hash algorithm.
 	 */
 	private String sha256;
 


### PR DESCRIPTION
* RestDoc tests are run as part of the `spring-cloud-skipper-server` tests

resolves https://github.com/spring-cloud/spring-cloud-skipper/issues/124