### PR TITLE
Refine upgrade support

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -182,6 +182,7 @@ public class DefaultSkipperClient implements SkipperClient {
 	@Override
 	public Release upgrade(UpgradeRequest upgradeRequest) {
 		String url = String.format("%s/%s", baseUri, "upgrade");
+		log.debug("Posting UpgradeRequest to " + url + ". UpgradeRequest = " + upgradeRequest);
 		return this.restTemplate.postForObject(url, upgradeRequest, Release.class);
 	}
 

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.cloud.skipper.server.service.PackageService;
 import org.springframework.cloud.skipper.server.service.ReleaseService;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -117,6 +118,8 @@ public class SkipperController {
 	@RequestMapping(path = "/upgrade", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public Release upgrade(@RequestBody UpgradeRequest upgradeRequest) {
+		Assert.notNull(upgradeRequest.getUpgradeProperties(), "UpgradeProperties can not be null");
+		Assert.notNull(upgradeRequest.getPackageIdentifier(), "PackageIdentifier can not be null");
 		return this.releaseService.upgrade(upgradeRequest);
 	}
 

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/service/PackageService.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/service/PackageService.java
@@ -234,9 +234,13 @@ public class PackageService implements ResourceLoaderAware {
 
 	private Repository getRepositoryToUpload(String repoName) {
 		Repository localRepositoryToUpload = this.repositoryRepository.findByName(repoName);
-		// todo: should we enforce the existence of the local repository always?
-		// TODO: Verify the repo name set to package upload properties always belong to local
-		// repository type.
+		// TODO: Verify the repo name set to package upload properties always belong to local repository type.
+		if (localRepositoryToUpload == null) {
+			throw new SkipperException("Could not find local repository to upload to named " + repoName);
+		}
+		if (!localRepositoryToUpload.isLocal()) {
+			throw new SkipperException("Repository to upload to is not a local database hosted repository.");
+		}
 		return localRepositoryToUpload;
 	}
 

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/service/RepositoryInitializationService.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/service/RepositoryInitializationService.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Repository;
 import org.springframework.cloud.skipper.server.config.SkipperServerProperties;
@@ -72,8 +73,13 @@ public class RepositoryInitializationService {
 	}
 
 	private void loadAllPackageMetadata() {
-		List<PackageMetadata> packageMetadataList = this.packageMetadataService.downloadPackageMetadata();
-		this.packageMetadataRepository.save(packageMetadataList);
+		try {
+			List<PackageMetadata> packageMetadataList = this.packageMetadataService.downloadPackageMetadata();
+			this.packageMetadataRepository.save(packageMetadataList);
+		}
+		catch (SkipperException e) {
+			logger.warn("Could not load package metadata from remote repositories", e);
+		}
 	}
 
 	private void synchronizeRepositories() {

--- a/spring-cloud-skipper-server/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server/src/main/resources/application.yml
@@ -10,12 +10,26 @@ spring:
   data:
     rest:
       base-path: /api
+  cloud:
+    skipper:
+      server:
+        synchonizeIndexOnContextRefresh: false
+        packageRepositories:
+          -
+            name: local
+            url: "http://localhost:7577"
+            local: true
+            description: Default local database backed repository
 
-# TODO - remove, pre M1 development simplicity
+
+# TODO - remove libs-snapshot maven repo , pre M1 development simplicity
 maven:
   remoteRepositories:
     springRepo:
       url: https://repo.spring.io/libs-snapshot
+
+
+
 
 logging:
   level:

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
@@ -40,36 +40,48 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 	@Test
 	public void getAllPackageMetadata() throws Exception {
 		this.mockMvc.perform(
-			get("/packageMetadata")
-				.param("page", "0")
-				.param("size", "10"))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				super.paginationRequestParameterProperties,
-				super.paginationProperties.and(
-					fieldWithPath("_embedded.packageMetadata").description("Contains a collection of Package Metadata items"),
-					fieldWithPath("_embedded.packageMetadata[].apiVersion").description("The Package Index spec version this file is based on"),
-					fieldWithPath("_embedded.packageMetadata[].origin").description("The repository ID this Package Index file belongs to"),
-					fieldWithPath("_embedded.packageMetadata[].kind").description("What type of package system is being used"),
-					fieldWithPath("_embedded.packageMetadata[].name").description("The name of the package"),
-					fieldWithPath("_embedded.packageMetadata[].version").description("The version of the package"),
-					fieldWithPath("_embedded.packageMetadata[].packageSourceUrl").description("Location to source code for this package"),
-					fieldWithPath("_embedded.packageMetadata[].packageHomeUrl").description("The home page of the package"),
-					fieldWithPath("_embedded.packageMetadata[].tags").description("A comma separated list of tags to use for searching"),
-					fieldWithPath("_embedded.packageMetadata[].maintainer").description("Who is maintaining this package"),
-					fieldWithPath("_embedded.packageMetadata[].description").description("Brief description of the package"),
-					fieldWithPath("_embedded.packageMetadata[].sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-					fieldWithPath("_embedded.packageMetadata[].iconUrl").description("Url location of a icon"),
-					fieldWithPath("_embedded.packageMetadata[].packageFileBytes").description("Size of the file in bytes"),
-					fieldWithPath("_embedded.packageMetadata[]._links.self.href").ignored(),
-					fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.href").ignored(),
-					fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.templated").ignored(),
-					fieldWithPath("_embedded.packageMetadata[]._links.install.href").ignored()
-				).and(super.defaultLinkProperties),
-				super.linksForSkipper()
-			)
-		);
+				get("/packageMetadata")
+						.param("page", "0")
+						.param("size", "10"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						super.paginationRequestParameterProperties,
+						super.paginationProperties.and(
+								fieldWithPath("_embedded.packageMetadata")
+										.description("Contains a collection of Package Metadata items"),
+								fieldWithPath("_embedded.packageMetadata[].apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("_embedded.packageMetadata[].origin")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("_embedded.packageMetadata[].kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("_embedded.packageMetadata[].name")
+										.description("The name of the package"),
+								fieldWithPath("_embedded.packageMetadata[].version")
+										.description("The version of the package"),
+								fieldWithPath("_embedded.packageMetadata[].packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("_embedded.packageMetadata[].packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("_embedded.packageMetadata[].tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("_embedded.packageMetadata[].maintainer")
+										.description("Who is maintaining this package"),
+								fieldWithPath("_embedded.packageMetadata[].description")
+										.description("Brief description of the package"),
+								fieldWithPath("_embedded.packageMetadata[].sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("_embedded.packageMetadata[].iconUrl")
+										.description("Url location of a icon"),
+								// fieldWithPath("_embedded.packageMetadata[].packageFileBytes").description("Size of
+								// the file in bytes"),
+								fieldWithPath("_embedded.packageMetadata[]._links.self.href").ignored(),
+								fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.href").ignored(),
+								fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.templated").ignored(),
+								fieldWithPath("_embedded.packageMetadata[]._links.install.href").ignored())
+								.and(super.defaultLinkProperties),
+						super.linksForSkipper()));
 	}
 
 	@Test
@@ -77,31 +89,33 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 		deploy("log", "1.0.0", "test2");
 
 		this.mockMvc.perform(
-			get("/packageMetadata/{packageMetadataId}", 1))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				pathParameters(
-					parameterWithName("packageMetadataId").description("The id of the package to query")
-				),
-				responseFields(
-					fieldWithPath("apiVersion").description("The Package Index spec version this file is based on"),
-					fieldWithPath("origin").description("The repository ID this Package Index file belongs to"),
-					fieldWithPath("kind").description("What type of package system is being used"),
-					fieldWithPath("name").description("The name of the package"),
-					fieldWithPath("version").description("The version of the package"),
-					fieldWithPath("packageSourceUrl").description("Location to source code for this package"),
-					fieldWithPath("packageHomeUrl").description("The home page of the package"),
-					fieldWithPath("tags").description("A comma separated list of tags to use for searching"),
-					fieldWithPath("maintainer").description("Who is maintaining this package"),
-					fieldWithPath("description").description("Brief description of the package"),
-					fieldWithPath("sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-					fieldWithPath("iconUrl").description("Url location of a icon"),
-					fieldWithPath("packageFileBytes").description("Size of the file in bytes"),
-					fieldWithPath("_links.packageMetadata.href").ignored(),
-					fieldWithPath("_links.packageMetadata.templated").ignored(),
-					fieldWithPath("_links.install.href").ignored()
-				).and(super.defaultLinkProperties)
-			));
+				get("/packageMetadata/{packageMetadataId}", 1))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						pathParameters(
+								parameterWithName("packageMetadataId").description("The id of the package to query")),
+						responseFields(
+								fieldWithPath("apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("origin")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("kind").description("What type of package system is being used"),
+								fieldWithPath("name").description("The name of the package"),
+								fieldWithPath("version").description("The version of the package"),
+								fieldWithPath("packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("packageHomeUrl").description("The home page of the package"),
+								fieldWithPath("tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("maintainer").description("Who is maintaining this package"),
+								fieldWithPath("description").description("Brief description of the package"),
+								fieldWithPath("sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("iconUrl").description("Url location of a icon"),
+								// fieldWithPath("packageFileBytes").description("Size of the file in bytes"),
+								fieldWithPath("_links.packageMetadata.href").ignored(),
+								fieldWithPath("_links.packageMetadata.templated").ignored(),
+								fieldWithPath("_links.install.href").ignored()).and(super.defaultLinkProperties)));
 	}
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/PackageServiceTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/PackageServiceTests.java
@@ -116,7 +116,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 		assertThat(packageMetadata).isNull();
 
 		UploadRequest uploadProperties = new UploadRequest();
-		uploadProperties.setRepoName("database-repo");
+		uploadProperties.setRepoName("local");
 		uploadProperties.setName("log");
 		uploadProperties.setVersion("9.9.9");
 		uploadProperties.setExtension("zip");

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/RepositoryInitializationServiceTest.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/RepositoryInitializationServiceTest.java
@@ -39,7 +39,7 @@ public class RepositoryInitializationServiceTest extends AbstractIntegrationTest
 
 	@Test
 	public void intialize() throws Exception {
-		assertThat(repositoryRepository.count()).isEqualTo(1);
+		assertThat(repositoryRepository.count()).isEqualTo(2);
 		assertThat(repositoryRepository.findByName("test").getUrl()).isEqualTo("classpath:/repositories/binaries/test");
 		// Note, this is a brittle assertion.
 		assertThat(packageMetadataRepository.count()).isEqualTo(5);

--- a/spring-cloud-skipper-server/src/test/resources/application-repo-test.yml
+++ b/spring-cloud-skipper-server/src/test/resources/application-repo-test.yml
@@ -4,6 +4,12 @@ spring:
       server:
         synchonizeIndexOnContextRefresh: true
         packageRepositories:
-         -
-           name: test
-           url: "classpath:/repositories/binaries/test"
+          -
+            name: test
+            url: "classpath:/repositories/binaries/test"
+            description: test repository with a few packages
+          -
+            name: local
+            url: "http://localhost:7577"
+            local: true
+            description: Default local database backed repository

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -157,10 +157,12 @@ public class PackageMetadata extends AbstractEntity {
 		this.packageHomeUrl = packageHomeUrl;
 	}
 
+	@JsonIgnore
 	public byte[] getPackageFileBytes() {
 		return packageFile;
 	}
 
+	@JsonIgnore
 	public void setPackageFileBytes(byte[] packageFileBytes) {
 		this.packageFile = packageFileBytes;
 	}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
@@ -100,10 +100,10 @@ public class Release extends AbstractEntity {
 
 	public void setPkg(Package pkg) {
 		this.pkg = pkg;
-		// TODO Do we want to store the package file at this specific moment in time?
-		this.pkg.getMetadata().setPackageFileBytes(null);
 		ObjectMapper mapper = new ObjectMapper();
 		try {
+			// TODO verify this behavior
+			// Note that @JsonIgnore is on the package file byte array field.
 			this.pkgJsonString = mapper.writeValueAsString(pkg);
 		}
 		catch (JsonProcessingException e) {


### PR DESCRIPTION
* When synchronizing package metadata at startup, only attempt
  remote repos and if resource exists.  Log failures.
* Add checks to verify the repository to upload exists and is local.
* Add a package repository named "local" to application.yml
* Fix bug setting package metdata to null in Release.setPkg method
* Before returning release objects in controller, explicitly null packageFile
* Update doc tests to not check for packageFileBytes
* Add @JsonIgnore to getter/setter of packageFileBytes in PackageMetadata.

Needed for testing of SCDF stream update command PR

Fixes #170