### PR TITLE
Remove component scan

### DIFF
--- a/spring-cloud-skipper-server/pom.xml
+++ b/spring-cloud-skipper-server/pom.xml
@@ -166,6 +166,7 @@
                 <filtering>true</filtering>
                 <includes>
                     <include>application.yml</include>
+                    <include>META-INF/spring.factories</include>
                 </includes>
             </resource>
         </resources>

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/EnableSkipperServer.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/EnableSkipperServer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.cloud.skipper.server.config.EnableSkipperServerConfiguration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Activates a Spring Cloud Skipper Server features.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Import(EnableSkipperServerConfiguration.class)
+public @interface EnableSkipperServer {
+}

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/app/SkipperServerApplication.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/app/SkipperServerApplication.java
@@ -13,24 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server;
+package org.springframework.cloud.skipper.server.app;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeployerAutoConfiguration;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesAutoConfiguration;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfiguration;
-import org.springframework.data.map.repository.config.EnableMapRepositories;
+import org.springframework.cloud.skipper.server.EnableSkipperServer;
 
-@SpringBootApplication
-@EnableAutoConfiguration(exclude = { CloudFoundryDeployerAutoConfiguration.class,
-		LocalDeployerAutoConfiguration.class, KubernetesAutoConfiguration.class })
-@EnableMapRepositories
+@SpringBootApplication(exclude = { CloudFoundryDeployerAutoConfiguration.class, LocalDeployerAutoConfiguration.class,
+		KubernetesAutoConfiguration.class })
+@EnableSkipperServer
 public class SkipperServerApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(SkipperServerApplication.class, args);
 	}
-
 }

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/EnableSkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/EnableSkipperServerConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.config;
+
+import org.springframework.cloud.skipper.server.EnableSkipperServer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for {@link EnableSkipperServer} which adds a marker bean which
+ * auto-config classes can use to conditionally check if auto configuration should be
+ * activated.
+ *
+ * @author Janne Valkealahti
+ */
+@Configuration
+public class EnableSkipperServerConfiguration {
+
+	@Bean
+	public Marker enableSkipperServerMarker() {
+		return new Marker();
+	}
+
+	class Marker {
+	}
+}

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerAutoConfiguration.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerAutoConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Auto-configuration for skipper server.
+ *
+ * @author Janne Valkealahti
+ */
+@Configuration
+@ConditionalOnBean(EnableSkipperServerConfiguration.Marker.class)
+@Import(SkipperServerConfiguration.class)
+@ConditionalOnProperty(prefix = "spring.cloud.skipper.server", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class SkipperServerAutoConfiguration {
+}

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -28,10 +28,13 @@ import org.springframework.cloud.skipper.io.DefaultPackageReader;
 import org.springframework.cloud.skipper.io.DefaultPackageWriter;
 import org.springframework.cloud.skipper.io.PackageReader;
 import org.springframework.cloud.skipper.io.PackageWriter;
+import org.springframework.cloud.skipper.server.controller.SkipperController;
 import org.springframework.cloud.skipper.server.deployer.AppDeployerReleaseManager;
 import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalyzer;
 import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
+import org.springframework.cloud.skipper.server.index.PackageMetadataResourceProcessor;
+import org.springframework.cloud.skipper.server.index.PackageSummaryResourceProcessor;
 import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
 import org.springframework.cloud.skipper.server.repository.DeployerRepository;
 import org.springframework.cloud.skipper.server.repository.PackageMetadataRepository;
@@ -46,19 +49,39 @@ import org.springframework.cloud.skipper.server.service.RepositoryInitialization
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.map.repository.config.EnableMapRepositories;
 
 /**
  * Main configuration class for the server.
  *
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
 @Configuration
 @EnableConfigurationProperties({ SkipperServerProperties.class, CloudFoundryPlatformProperties.class,
 		LocalPlatformProperties.class, KubernetesPlatformProperties.class,
 		MavenConfigurationProperties.class })
 @EntityScan({"org.springframework.cloud.skipper.domain", "org.springframework.cloud.skipper.server.domain"})
+@EnableMapRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
+@EnableJpaRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
 public class SkipperServerConfiguration {
+
+	@Bean
+	public PackageSummaryResourceProcessor packageSummaryResourceProcessor() {
+		return new PackageSummaryResourceProcessor();
+	}
+
+	@Bean
+	public PackageMetadataResourceProcessor packageMetadataResourceProcessor() {
+		return new PackageMetadataResourceProcessor();
+	}
+
+	@Bean
+	public SkipperController skipperController(ReleaseService releaseService, PackageService packageService) {
+		return new SkipperController(releaseService, packageService);
+	}
 
 	// Services
 

--- a/spring-cloud-skipper-server/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-skipper-server/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  org.springframework.cloud.skipper.server.config.SkipperServerAutoConfiguration

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
@@ -21,14 +21,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import static org.springframework.cloud.skipper.server.AbstractIntegrationTest.TestConfig;
 
 /**
  * Base class to implement transactional integration tests using the root application
@@ -38,7 +48,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @Transactional
-@SpringBootTest
+@SpringBootTest(classes = TestConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public abstract class AbstractIntegrationTest {
 
@@ -65,5 +75,13 @@ public abstract class AbstractIntegrationTest {
 		catch (Exception e) {
 			logger.error("error cleaning up resource in integration test");
 		}
+	}
+
+	@Configuration
+	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
+			HibernateJpaAutoConfiguration.class })
+	@Import(SkipperServerConfiguration.class)
+	@EnableWebMvc
+	static class TestConfig {
 	}
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/AbstractMockMvcTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/AbstractMockMvcTests.java
@@ -30,27 +30,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ErrorMvcAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.skipper.server.AbstractMockMvcTests.TestConfig;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 /**
  * @author Mark Pollack
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = TestConfig.class)
 @AutoConfigureMockMvc
 public abstract class AbstractMockMvcTests {
 
@@ -134,4 +145,11 @@ public abstract class AbstractMockMvcTests {
 		}
 	}
 
+	@Configuration
+	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
+			HibernateJpaAutoConfiguration.class, RepositoryRestMvcAutoConfiguration.class, ErrorMvcAutoConfiguration.class })
+	@Import(SkipperServerConfiguration.class)
+	@EnableWebMvc
+	static class TestConfig {
+	}
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/config/PlatformPropertiesTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/config/PlatformPropertiesTests.java
@@ -22,22 +22,29 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;
 import org.springframework.cloud.deployer.spi.kubernetes.ImagePullPolicy;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesDeployerProperties;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.skipper.server.config.PlatformPropertiesTests.TestConfig;
 
 /**
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = TestConfig.class)
 @ActiveProfiles("platform-properties")
 public class PlatformPropertiesTests {
 
@@ -84,4 +91,9 @@ public class PlatformPropertiesTests {
 		assertThat(k8sAccounts.get("qa").getLimits().getMemory()).isEqualTo("1024m");
 	}
 
+	@Configuration
+	@ImportAutoConfiguration(classes = { EmbeddedDataSourceConfiguration.class, HibernateJpaAutoConfiguration.class })
+	@Import(SkipperServerConfiguration.class)
+	static class TestConfig {
+	}
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/ConfigValueUtilsTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/ConfigValueUtilsTests.java
@@ -26,11 +26,18 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.io.PackageReader;
 import org.springframework.cloud.skipper.server.TestResourceUtils;
+import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -38,11 +45,13 @@ import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.springframework.cloud.skipper.server.service.ConfigValueUtilsTests.TestConfig;
+
 /**
  * @author Mark Pollack
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes  = TestConfig.class)
 public class ConfigValueUtilsTests {
 
 	@Autowired
@@ -74,5 +83,12 @@ public class ConfigValueUtilsTests {
 				TestResourceUtils.qualifiedResource(getClass(), "merged.yaml").getInputStream(),
 				Charset.defaultCharset());
 		assertThat(mergedYaml).isEqualTo(expectedYaml);
+	}
+
+	@Configuration
+	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
+			HibernateJpaAutoConfiguration.class })
+	@Import(SkipperServerConfiguration.class)
+	static class TestConfig {
 	}
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/PackageMetadataServiceTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/PackageMetadataServiceTests.java
@@ -21,17 +21,26 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.UrlResource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.springframework.cloud.skipper.server.service.PackageMetadataServiceTests.TestConfig;
+
 /**
  * @author Mark Pollack
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = TestConfig.class)
 public class PackageMetadataServiceTests {
 
 	@Autowired
@@ -54,5 +63,12 @@ public class PackageMetadataServiceTests {
 		urlResource = new UrlResource("http://www.example.com/index.yml");
 		filename = packageMetadataService.computeFilename(urlResource);
 		assertThat(filename).isEqualTo("www.example.com_index.yml");
+	}
+
+	@Configuration
+	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
+			HibernateJpaAutoConfiguration.class })
+	@Import(SkipperServerConfiguration.class)
+	static class TestConfig {
 	}
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/templates/PackageTemplateTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/templates/PackageTemplateTests.java
@@ -28,7 +28,15 @@ import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
+import org.springframework.cloud.skipper.server.templates.PackageTemplateTests.TestConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
@@ -36,11 +44,12 @@ import org.springframework.util.StreamUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+
 /**
  * @author Mark Pollack
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(classes = TestConfig.class)
 public class PackageTemplateTests {
 
 	private final Logger logger = LoggerFactory.getLogger(PackageTemplateTests.class);
@@ -72,5 +81,12 @@ public class PackageTemplateTests {
 		Map deploymentProperties = (Map) deploymentMap.get("deploymentProperties");
 		assertThat(deploymentProperties).contains(entry("app.time.producer.partitionKeyExpression", "payload"),
 				entry("app.log.spring.cloud.stream.bindings.input.consumer.maxAttempts", 5));
+	}
+
+	@Configuration
+	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
+			HibernateJpaAutoConfiguration.class })
+	@Import(SkipperServerConfiguration.class)
+	static class TestConfig {
 	}
 }


### PR DESCRIPTION
- Similarly as in scdf server, introduce EnableSkipperServer,
  its Marker auto-config bean with EnableSkipperServerConfiguration
  and SkipperServerAutoConfiguration which imports SkipperServerConfiguration
  which have manually defined beans which used to be scanned.
- Fix tests which relied on full auto-config. These tests now
  add only needed auto-config classes and further tests
  can have better control what tests actually do.
- SkipperServerApplication was moved under `app` package for
  scan not to happen with @SpringBootApplication. This now uses
  @EnableSkipperServer.
- NOTE: SkipperServerApplication should be in its own module which
  only produces a fat-jar. I didn't want to do this now as it needs
  a rename of `spring-cloud-skipper-server` to `spring-cloud-skipper-server-core`
  causing impossible review as every path changes. When this rename is done
  in future, then only SkipperServerApplication stays in `spring-cloud-skipper-server`.
- Fixes #134