### PR TITLE
Reuse deleted release history

### DIFF
--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
@@ -85,8 +85,7 @@ public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 
 		// Carry over the applicationDeployment information for apps that were not updated.
 		AppDeployerData existingAppDeployerData = this.appDeployerDataRepository.findByReleaseNameAndReleaseVersion(
-				existingRelease.getName(),
-				existingRelease.getVersion());
+				existingRelease.getName(), existingRelease.getVersion());
 		Map<String, String> existingAppNamesAndDeploymentIds = existingAppDeployerData.getDeploymentDataAsMap();
 
 		for (Map.Entry<String, String> existingEntry : existingAppNamesAndDeploymentIds.entrySet()) {

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
@@ -69,4 +69,13 @@ public interface ReleaseRepositoryCustom {
 	 */
 	List<Release> findLatestDeployedOrFailed();
 
+	/**
+	 * Return the release by the given name if the most recent status of the release is
+	 * {@link org.springframework.cloud.skipper.domain.StatusCode.DELETED}.
+	 *
+	 * @param releaseName the name of the release
+	 * @return if the latest status of the release is deleted then the release is returned, otherwise null.
+	 */
+	Release findLatestReleaseIfDeleted(String releaseName);
+
 }

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
@@ -86,4 +86,11 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 		}
 		return releases;
 	}
+
+	@Override
+	public Release findLatestReleaseIfDeleted(String releaseName) {
+		Release latestRelease = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
+		return (latestRelease != null &&
+				latestRelease.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) ? latestRelease : null;
+	}
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
@@ -114,10 +114,42 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release5.setInfo(failedInfo);
 		this.releaseRepository.save(release5);
 
+		Release release6 = new Release();
+		release6.setName("multipleDeleted");
+		release6.setVersion(1);
+		release6.setPlatformName("platform2");
+		release6.setPkg(pkg1);
+		release6.setInfo(deployedInfo);
+		this.releaseRepository.save(release6);
+
+		Release release7 = new Release();
+		release7.setName(release6.getName());
+		release7.setVersion(2);
+		release7.setPlatformName(release6.getPlatformName());
+		release7.setPkg(pkg2);
+		release7.setInfo(deletedInfo);
+		this.releaseRepository.save(release7);
+
+		Release release8 = new Release();
+		release8.setName(release6.getName());
+		release8.setVersion(3);
+		release8.setPlatformName(release6.getPlatformName());
+		release8.setPkg(pkg2);
+		release8.setInfo(failedInfo);
+		this.releaseRepository.save(release8);
+
+		Release release9 = new Release();
+		release9.setName(release6.getName());
+		release9.setVersion(4);
+		release9.setPlatformName(release6.getPlatformName());
+		release9.setPkg(pkg2);
+		release9.setInfo(deletedInfo);
+		this.releaseRepository.save(release9);
+
 		// findAll
 		Iterable<Release> releases = this.releaseRepository.findAll();
 		assertThat(releases).isNotEmpty();
-		assertThat(releases).hasSize(5);
+		assertThat(releases).hasSize(9);
 
 		// findByNameAndVersion
 		Release foundByNameAndVersion = this.releaseRepository.findByNameAndVersion(release1.getName(), 2);
@@ -178,7 +210,13 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 
 		List<Release> deployedOrFailedAll = this.releaseRepository.findLatestDeployedOrFailed("");
 		assertThat(deployedOrFailedAll).isNotEmpty();
-		assertThat(deployedOrFailedAll).hasSize(2);
+		assertThat(deployedOrFailedAll).hasSize(4);
+
+		Release latestDeletedRelease1 = this.releaseRepository.findLatestReleaseIfDeleted(release1.getName());
+		assertThat(latestDeletedRelease1).isNull();
+
+		Release latestDeletedRelease2 = this.releaseRepository.findLatestReleaseIfDeleted(release6.getName());
+		assertThat(latestDeletedRelease2.getVersion()).isEqualTo(4);
 	}
 
 	@Test

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -126,9 +126,52 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		packageIdentifier.setPackageName("log");
 		packageIdentifier.setPackageVersion("1.0.0");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		releaseService.install(installRequest);
-		Info info = releaseService.status("testexists");
+		this.releaseService.install(installRequest);
+		Info info = this.releaseService.status("testexists");
 		assertThat(info).isNotNull();
+	}
+
+	@Test
+	public void testInstallReleaseThatIsNotDeleted() {
+		InstallProperties installProperties = new InstallProperties();
+		String releaseName = "installDeployedRelease";
+		installProperties.setReleaseName(releaseName);
+		installProperties.setPlatformName("default");
+		InstallRequest installRequest = new InstallRequest();
+		installRequest.setInstallProperties(installProperties);
+		PackageIdentifier packageIdentifier = new PackageIdentifier();
+		packageIdentifier.setPackageName("log");
+		packageIdentifier.setPackageVersion("1.0.0");
+		installRequest.setPackageIdentifier(packageIdentifier);
+		Release release = this.releaseService.install(installRequest);
+		assertThat(release).isNotNull();
+		try {
+			this.releaseService.install(installRequest);
+			fail("Expected to fail when installin already deployed release.");
+		}
+		catch (SkipperException e) {
+			assertThat(e.getMessage()).isEqualTo("Release with the name [" + releaseName + "] already exists "
+					+ "and it is not deleted.");
+		}
+	}
+
+	@Test
+	public void testInstallDeletedRelease() {
+		InstallProperties installProperties = new InstallProperties();
+		String releaseName = "deletedRelease";
+		installProperties.setReleaseName(releaseName);
+		installProperties.setPlatformName("default");
+		InstallRequest installRequest = new InstallRequest();
+		installRequest.setInstallProperties(installProperties);
+		PackageIdentifier packageIdentifier = new PackageIdentifier();
+		packageIdentifier.setPackageName("log");
+		packageIdentifier.setPackageVersion("1.0.0");
+		installRequest.setPackageIdentifier(packageIdentifier);
+		Release release = releaseService.install(installRequest);
+		assertThat(release).isNotNull();
+		this.releaseService.delete(releaseName);
+		Release release2 = releaseService.install(installRequest);
+		assertThat(release2.getVersion()).isEqualTo(2);
 	}
 
 	@Test


### PR DESCRIPTION
 - If the release is deleted, allow creation of subsequent releases with the same release name. This way, the releases with the previously deleted one can be re-created and the history is preserved as well.
 - Add custom release repository method to get the latest release by the given name and the status of the release is `deleted`. This can further be used by the subsequent release creation methods to increment the release versions
 - Implement the repository method
 - Update ReleaseService to check for previously deleted releases by the given name and use the last revision version to calculate the currently installed version
 - Add tests for release repository and Release service methods

Resolves #193