### PR TITLE
gh-175 Redirect root access to /api

### DIFF
--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.skipper.io.DefaultPackageReader;
 import org.springframework.cloud.skipper.io.DefaultPackageWriter;
 import org.springframework.cloud.skipper.io.PackageReader;
 import org.springframework.cloud.skipper.io.PackageWriter;
+import org.springframework.cloud.skipper.server.controller.RootController;
 import org.springframework.cloud.skipper.server.controller.SkipperController;
 import org.springframework.cloud.skipper.server.deployer.AppDeployerReleaseManager;
 import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
@@ -88,6 +89,11 @@ public class SkipperServerConfiguration {
 	@Bean
 	public SkipperController skipperController(ReleaseService releaseService, PackageService packageService) {
 		return new SkipperController(releaseService, packageService);
+	}
+
+	@Bean
+	public RootController rootController() {
+		return new RootController();
 	}
 
 	// Services

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/controller/RootController.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/controller/RootController.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.view.RedirectView;
+
+/**
+ * Main UI root controller. For now it's only task is to redirect
+ * the root URL to the Rest API endpoint {@code /api }
+ *
+ * @author Gunnar Hillert
+ */
+@Controller
+public class RootController {
+
+	/**
+	 * Handles the root URL of Skipper. Redirects users to the
+	 * REST API entry point at {@code /api }.
+	 *
+	 * @return
+	 */
+	@RequestMapping("/")
+	public RedirectView index() {
+		return new RedirectView("/api");
+	}
+}

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/RootControllerTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/RootControllerTests.java
@@ -13,25 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.repository;
+package org.springframework.cloud.skipper.server.controller;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.server.AbstractMockMvcTests;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * @author Mark Pollack
+ * @author Gunnar Hillert
  */
-public class RepositoryMvcTests extends AbstractMockMvcTests {
+public class RootControllerTests extends AbstractControllerTests {
 
 	@Test
-	public void shouldReturnRepositoryIndex() throws Exception {
-		mockMvc.perform(get("/api")).andDo(print()).andExpect(status().isOk()).andExpect(
-				jsonPath("$._links.repositories").exists());
+	public void indexUrlShouldRedirect() throws Exception {
+		mockMvc.perform(get("/")).andDo(print())
+				.andExpect(status().is3xxRedirection())
+				.andExpect(redirectedUrl("/api"));
 	}
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
@@ -40,7 +40,7 @@ public class ApiDocumentation extends BaseDocumentation {
 
 	@Test
 	public void headers() throws Exception {
-		this.mockMvc.perform(get("/")).andExpect(status().isOk())
+		this.mockMvc.perform(get("/api")).andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(responseHeaders(headerWithName("Content-Type")
 						.description("The Content-Type of the payload, e.g. " + "`application/hal+json`"))));
 	}
@@ -67,7 +67,7 @@ public class ApiDocumentation extends BaseDocumentation {
 
 	@Test
 	public void index() throws Exception {
-		this.mockMvc.perform(get("/")).andExpect(status().isOk()).andDo(this.documentationHandler.document(links(
+		this.mockMvc.perform(get("/api")).andExpect(status().isOk()).andDo(this.documentationHandler.document(links(
 			linkWithRel("about").description("Provides meta information of the server"),
 			linkWithRel("upload").description("Uploads a package"),
 			linkWithRel("install").description("Installs a package"),

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/AppDeployersDatasDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/AppDeployersDatasDocumentation.java
@@ -37,7 +37,7 @@ public class AppDeployersDatasDocumentation extends BaseDocumentation {
 	@Test
 	public void getAllAppDeployerDatas() throws Exception {
 		this.mockMvc.perform(
-			get("/appDeployerDatas")
+			get("/api/appDeployerDatas")
 				.param("page", "0")
 				.param("size", "10"))
 			.andDo(print())

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
@@ -37,7 +37,7 @@ public class DeployersDocumentation extends BaseDocumentation {
 	@Test
 	public void getAllDeployers() throws Exception {
 		this.mockMvc.perform(
-			get("/deployers")
+			get("/api/deployers")
 				.param("page", "0")
 				.param("size", "10"))
 			.andDo(print())

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
@@ -40,7 +40,7 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 	@Test
 	public void getAllPackageMetadata() throws Exception {
 		this.mockMvc.perform(
-			get("/packageMetadata")
+			get("/api/packageMetadata")
 				.param("page", "0")
 				.param("size", "10"))
 			.andDo(print())
@@ -76,7 +76,7 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 		deploy("log", "1.0.0", "test2");
 
 		this.mockMvc.perform(
-			get("/packageMetadata/{packageMetadataId}", 1))
+			get("/api/packageMetadata/{packageMetadataId}", 1))
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(this.documentationHandler.document(

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
@@ -37,7 +37,7 @@ public class ReleasesDocumentation extends BaseDocumentation {
 	@Test
 	public void getAllReleases() throws Exception {
 		this.mockMvc.perform(
-			get("/releases")
+			get("/api/releases")
 				.param("page", "0")
 				.param("size", "10"))
 			.andDo(print())

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoriesDocumentation.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoriesDocumentation.java
@@ -40,7 +40,7 @@ public class RepositoriesDocumentation extends BaseDocumentation {
 	@Test
 	public void getAllRepositories() throws Exception {
 		this.mockMvc.perform(
-			get("/repositories")
+			get("/api/repositories")
 				.param("page", "0")
 				.param("size", "10"))
 			.andDo(print())
@@ -66,7 +66,7 @@ public class RepositoriesDocumentation extends BaseDocumentation {
 		deploy("log", "1.0.0", "test2");
 
 		this.mockMvc.perform(
-			get("/repositories/{repositoryId}", 1))
+			get("/api/repositories/{repositoryId}", 1))
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(this.documentationHandler.document(

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataMvcTests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataMvcTests.java
@@ -40,7 +40,7 @@ public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 
 	@Test
 	public void shouldReturnRepositoryIndex() throws Exception {
-		mockMvc.perform(get("/")).andDo(print()).andExpect(status().isOk()).andExpect(
+		mockMvc.perform(get("/api")).andDo(print()).andExpect(status().isOk()).andExpect(
 				jsonPath("$._links.packageMetadata").exists());
 	}
 
@@ -51,7 +51,7 @@ public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 		assertThat(packageMetadata.getId()).isNotNull();
 		packageMetadata = packageMetadataRepository.findByNameAndVersion("package2", "2.0.0");
 		assertThat(packageMetadata.getId()).isNotNull();
-		mockMvc.perform(get("/packageMetadata?projection=summary")).andDo(print()).andExpect(status().isOk())
+		mockMvc.perform(get("/api/packageMetadata?projection=summary")).andDo(print()).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.packageMetadata[0].version").value("1.0.0"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[0].iconUrl")
 						.value("http://www.gilligansisle.com/images/a2.gif"))
@@ -65,7 +65,7 @@ public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 						.value("http://localhost/api/install/2"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[1].maintainer").doesNotExist());
 
-		mockMvc.perform(get("/packageMetadata")).andDo(print()).andExpect(status().isOk())
+		mockMvc.perform(get("/api/packageMetadata")).andDo(print()).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.packageMetadata[0].version").value("1.0.0"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[0].description").value("A very cool project"))
 				.andExpect(jsonPath("$._embedded.packageMetadata[0]._links.install.href")

--- a/spring-cloud-skipper-server/src/test/resources/application.yml
+++ b/spring-cloud-skipper-server/src/test/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   main:
     banner-mode: "off"
+  data:
+    rest:
+      base-path: /api
   cloud:
     skipper:
       server:


### PR DESCRIPTION
* Add test
* Add base-path `/api` to `spring-cloud-skipper-server/src/test/resources/application.yml`
  - Ensure that all controller tests (incl. documentation) use the `/api` prefix

resolves https://github.com/spring-cloud/spring-cloud-skipper/issues/175