### PR TITLE
Fix client rest error handling

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientConfiguration.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.skipper.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +28,9 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * Client's configuration class.
+ *
  * @author Mark Pollack
+ * @author Janne Valkealahti
  */
 @Configuration
 @EnableConfigurationProperties(SkipperClientProperties.class)
@@ -34,8 +38,9 @@ import org.springframework.web.client.RestTemplate;
 public class SkipperClientConfiguration {
 
 	@Bean
-	public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
-		RestTemplate restTemplate = restTemplateBuilder.build();
+	public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
+		RestTemplate restTemplate = restTemplateBuilder
+				.errorHandler(new SkipperClientResponseErrorHandler(objectMapper)).build();
 		return validateRestTemplate(restTemplate);
 	}
 

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientResponseErrorHandler.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientResponseErrorHandler.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.client;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+/**
+ * A {@link ResponseErrorHandler} used in clients RestTemplate to throw
+ * various exceptions.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class SkipperClientResponseErrorHandler extends DefaultResponseErrorHandler {
+
+	private ObjectMapper objectMapper;
+
+	/**
+	 * Instantiates a new skipper client response error handler.
+	 *
+	 * @param objectMapper the object mapper
+	 */
+	public SkipperClientResponseErrorHandler(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "'objectMapper' must be set");
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public void handleError(ClientHttpResponse response) throws IOException {
+		String exceptionClazz = null;
+		Map<String, String> map = new HashMap<>();
+		try {
+			String body = new String(getResponseBody(response));
+			@SuppressWarnings("unchecked")
+			Map<String, String> parsed = objectMapper.readValue(body, Map.class);
+			map.putAll(parsed);
+			exceptionClazz = map.get("exception");
+		}
+		catch (Exception e) {
+			// don't want to error here
+		}
+		if (ObjectUtils.nullSafeEquals(exceptionClazz, ReleaseNotFoundException.class.getName())) {
+			handleReleaseNotFoundException(map);
+		}
+		else if (ObjectUtils.nullSafeEquals(exceptionClazz, SkipperException.class.getName())) {
+			handleSkipperException(map);
+		}
+		super.handleError(response);
+	}
+
+	private void handleReleaseNotFoundException(Map<String, String> map) {
+		String releaseName = map.get("releaseName");
+		Integer releaseVersion = null;
+		if (map.containsKey("releaseVersion")) {
+			try {
+				releaseVersion = Integer.parseInt(map.get("releaseVersion"));
+			}
+			catch (Exception e) {
+			}
+		}
+		if (StringUtils.hasText(releaseName)) {
+			if (releaseVersion != null) {
+				throw new ReleaseNotFoundException(releaseName, releaseVersion);
+			}
+			else {
+				throw new ReleaseNotFoundException(releaseName);
+			}
+		}
+	}
+
+	private void handleSkipperException(Map<String, String> map) {
+		String message = map.get("message");
+		throw new SkipperException(StringUtils.hasText(message) ? message : "");
+	}
+}

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -15,19 +15,87 @@
  */
 package org.springframework.cloud.skipper.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
+ * Tests for {@link DefaultSkipperClient}.
+ *
  * @author Mark Pollack
+ * @author Janne Valkealahti
  */
 public class DefaultSkipperClientTests {
+
+	private final String ERROR1 = "{\"timestamp\":1508161424577," +
+			"\"status\":404," +
+			"\"error\":\"Not Found\"," +
+			"\"exception\":\"org.springframework.cloud.skipper.ReleaseNotFoundException\"," +
+			"\"message\":\"Release not found\",\"path\":\"/api/status/mylog\",\"releaseName\":\"mylog\"}";
+
+	private final String ERROR2 = "{\"timestamp\":1508161424577," +
+			"\"status\":404," +
+			"\"error\":\"Not Found\"," +
+			"\"exception\":\"org.springframework.cloud.skipper.SkipperException\"," +
+			"\"message\":\"Some skipper message\",\"path\":\"/api/status/mylog\"}";
 
 	@Test
 	public void genericTemplateTest() {
 		SkipperClient skipperClient = new DefaultSkipperClient("http://localhost:7577");
 		assertThat(skipperClient.getSpringBootAppTemplate()).isNotNull();
 		assertThat(skipperClient.getSpringBootAppTemplate().getData()).isNotEmpty();
+	}
+
+	@Test
+	public void testStatusReleaseNameFound() {
+		RestTemplate restTemplate = new RestTemplate();
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer.expect(requestTo("/status/mylog")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+		Info status = skipperClient.status("mylog");
+		mockServer.verify();
+
+		assertThat(status).isNotNull();
+		assertThat(status).isInstanceOf(Info.class);
+	}
+
+	@Test(expected = ReleaseNotFoundException.class)
+	public void testStatusReleaseNameNotFound() {
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setErrorHandler(new SkipperClientResponseErrorHandler(new ObjectMapper()));
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer.expect(requestTo("/status/mylog"))
+				.andRespond(withStatus(HttpStatus.NOT_FOUND).body(ERROR1).contentType(MediaType.APPLICATION_JSON));
+
+		skipperClient.status("mylog");
+	}
+
+	@Test(expected = SkipperException.class)
+	public void testSkipperException() {
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setErrorHandler(new SkipperClientResponseErrorHandler(new ObjectMapper()));
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer.expect(requestTo("/status/mylog"))
+				.andRespond(withStatus(HttpStatus.NOT_FOUND).body(ERROR2).contentType(MediaType.APPLICATION_JSON));
+
+		skipperClient.status("mylog");
 	}
 }

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.web.ErrorAttributes;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.deployer.resource.docker.DockerResourceLoader;
 import org.springframework.cloud.deployer.resource.maven.MavenResourceLoader;
@@ -29,6 +30,7 @@ import org.springframework.cloud.skipper.io.DefaultPackageWriter;
 import org.springframework.cloud.skipper.io.PackageReader;
 import org.springframework.cloud.skipper.io.PackageWriter;
 import org.springframework.cloud.skipper.server.controller.SkipperController;
+import org.springframework.cloud.skipper.server.controller.SkipperErrorAttributes;
 import org.springframework.cloud.skipper.server.deployer.AppDeployerReleaseManager;
 import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalyzer;
@@ -69,6 +71,12 @@ import org.springframework.data.map.repository.config.EnableMapRepositories;
 @EnableMapRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
 @EnableJpaRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
 public class SkipperServerConfiguration {
+
+	@Bean
+	public ErrorAttributes errorAttributes() {
+		// override boot's DefaultErrorAttributes
+		return new SkipperErrorAttributes();
+	}
 
 	@Bean
 	public PackageSummaryResourceProcessor packageSummaryResourceProcessor() {

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
@@ -151,9 +151,9 @@ public class SkipperController {
 		return this.releaseService.list(releaseName);
 	}
 
-	@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Release doesn't exist")
+	@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Release not found")
 	@ExceptionHandler(ReleaseNotFoundException.class)
-	public void releaseNotExist() {
-		// handle ReleaseNotFoundException by returning 404
+	public void handleReleaseNotFoundException() {
+		// needed for server not to log 500 errors
 	}
 }

--- a/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperErrorAttributes.java
+++ b/spring-cloud-skipper-server/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperErrorAttributes.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.controller;
+
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes;
+import org.springframework.boot.autoconfigure.web.ErrorAttributes;
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.web.context.request.RequestAttributes;
+
+/**
+ * Custom {@link ErrorAttributes} adding skipper specific fields for its own
+ * errors.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class SkipperErrorAttributes extends DefaultErrorAttributes {
+
+	@Override
+	public Map<String, Object> getErrorAttributes(RequestAttributes requestAttributes, boolean includeStackTrace) {
+		Map<String, Object> errorAttributes = super.getErrorAttributes(requestAttributes, includeStackTrace);
+		Throwable error = getError(requestAttributes);
+		if (error != null) {
+			// pass in name and version if ReleaseNotFoundException
+			if (error instanceof ReleaseNotFoundException) {
+				ReleaseNotFoundException e = ((ReleaseNotFoundException) error);
+				if (e.getReleaseName() != null) {
+					errorAttributes.put("releaseName", e.getReleaseName());
+				}
+				if (e.getReleaseVersion() != null) {
+					errorAttributes.put("version", e.getReleaseVersion());
+				}
+			}
+		}
+		return errorAttributes;
+	}
+}

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/SkipperCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/SkipperCommands.java
@@ -39,6 +39,7 @@ import org.yaml.snakeyaml.Yaml;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Info;
@@ -54,7 +55,6 @@ import org.springframework.cloud.skipper.shell.command.support.DeploymentStateDi
 import org.springframework.cloud.skipper.shell.command.support.TableUtils;
 import org.springframework.cloud.skipper.shell.command.support.YmlUtils;
 import org.springframework.hateoas.Resources;
-import org.springframework.http.HttpStatus;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.standard.ShellOption;
@@ -66,7 +66,6 @@ import org.springframework.shell.table.TableModel;
 import org.springframework.util.Assert;
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.HttpStatusCodeException;
 
 import static org.springframework.shell.standard.ShellOption.NULL;
 
@@ -392,15 +391,8 @@ public class SkipperCommands extends AbstractSkipperCommand {
 				info = this.skipperClient.status(releaseName, releaseVersion);
 			}
 		}
-		catch (HttpStatusCodeException e) {
-			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
-				// 404 means release not found.
-				// TODO it'd be nice to rethrow ReleaseNotFoundException in
-				// SkipperClient but that exception is on server
-				return "Release with name '" + releaseName + "' not found";
-			}
-			// if something else, rethrow
-			throw e;
+		catch (ReleaseNotFoundException e) {
+			return "Release with name '" + e.getReleaseName() + "' not found";
 		}
 		Object[][] data = new Object[3][];
 		data[0] = new Object[] { "Last Deployed", info.getFirstDeployed() };

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/TargetHolder.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/TargetHolder.java
@@ -38,11 +38,15 @@ public class TargetHolder implements ApplicationEventPublisherAware {
 
 	private Target target;
 
-	private RestTemplate restTemplate = new RestTemplate();
+	private final RestTemplate restTemplate;
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
 	private String credentialsProviderCommand;
+
+	public TargetHolder(RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
+	}
 
 	/**
 	 * Return the {@link Target} which encapsulates not only the Target URI but also

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/ReleaseNotFoundException.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/ReleaseNotFoundException.java
@@ -24,6 +24,9 @@ package org.springframework.cloud.skipper;
 @SuppressWarnings("serial")
 public class ReleaseNotFoundException extends SkipperException {
 
+	private final String releaseName;
+	private final Integer releaseVersion;
+
 	/**
 	 * Instantiates a new {@code ReleaseNotFoundException}.
 	 *
@@ -31,6 +34,8 @@ public class ReleaseNotFoundException extends SkipperException {
 	 */
 	public ReleaseNotFoundException(String releaseName) {
 		super(getExceptionMessage(releaseName));
+		this.releaseName = releaseName;
+		this.releaseVersion = null;
 	}
 
 	/**
@@ -41,6 +46,8 @@ public class ReleaseNotFoundException extends SkipperException {
 	 */
 	public ReleaseNotFoundException(String releaseName, int version) {
 		super(getExceptionMessage(releaseName, version));
+		this.releaseName = releaseName;
+		this.releaseVersion = version;
 	}
 
 	/**
@@ -51,6 +58,26 @@ public class ReleaseNotFoundException extends SkipperException {
 	 */
 	public ReleaseNotFoundException(String releaseName, Throwable cause) {
 		super(getExceptionMessage(releaseName), cause);
+		this.releaseName = releaseName;
+		this.releaseVersion = null;
+	}
+
+	/**
+	 * Gets the release name.
+	 *
+	 * @return the release name
+	 */
+	public String getReleaseName() {
+		return releaseName;
+	}
+
+	/**
+	 * Gets the release version.
+	 *
+	 * @return the release version
+	 */
+	public Integer getReleaseVersion() {
+		return releaseVersion;
 	}
 
 	private static String getExceptionMessage(String releaseName) {


### PR DESCRIPTION
- Add custom SkipperErrorAttributes for getting
  skipper related errors for json object.
- Add custom SkipperClientResponseErrorHandler into
  RestTemplate to throw ReleaseNotFoundException
  with releaseName and releaseVersion if those exists
  in error object.
- Fix TargetHolder to use RestTemplate created in
  SkipperClientConfiguration.
- Fixes #192
- Fixes #173