### PR TITLE
Search package metadata across repositories

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepository.java
@@ -28,13 +28,14 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
  * @author Janne Valkealahti
  */
 @RepositoryRestResource(path = "packageMetadata", collectionResourceRel = "packageMetadata")
-public interface PackageMetadataRepository extends PagingAndSortingRepository<PackageMetadata, String> {
+public interface PackageMetadataRepository extends PagingAndSortingRepository<PackageMetadata, String>,
+		PackageMetadataRepositoryCustom {
 
 	List<PackageMetadata> findByName(@Param("name") String name);
 
 	List<PackageMetadata> findByNameContainingIgnoreCase(@Param("name") String name);
 
-	PackageMetadata findByNameAndVersion(@Param("name") String name, @Param("version") String version);
+	List<PackageMetadata> findByNameAndVersionOrderByApiVersionDesc(@Param("name") String name, @Param("version") String version);
 
 	PackageMetadata findFirstByNameOrderByVersionDesc(@Param("name") String name);
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryCustom.java
@@ -15,27 +15,22 @@
  */
 package org.springframework.cloud.skipper.server.repository;
 
-import java.util.List;
-
-import org.springframework.cloud.skipper.domain.Repository;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 /**
- * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  */
-@RepositoryRestResource(path = "repositories", collectionResourceRel = "repositories")
-public interface RepositoryRepository extends PagingAndSortingRepository<Repository, String> {
-
-	Repository findByName(@Param("name") String name);
+public interface PackageMetadataRepositoryCustom {
 
 	/**
-	 * Get all the repositories with their repository order in descending order.
+	 * Find the {@link PackageMetadata} with the given name, version and also from the repository that has the
+	 * highest order set.
 	 *
-	 * @return the list of repositories
+	 * @param name the name of the package metadata
+	 * @param version the version of the package metadata
+	 * @return the package metadata
 	 */
-	List<Repository> findAllByOrderByRepoOrderDesc();
+	PackageMetadata findByNameAndVersionByMaxRepoOrder(@Param("name") String name, @Param("version") String version);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.repository;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.util.StringUtils;
+
+/**
+ * Implementation for the {@link PackageMetadataRepositoryCustom} methods.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class PackageMetadataRepositoryImpl implements PackageMetadataRepositoryCustom {
+
+	@Autowired
+	private PackageMetadataRepository packageMetadataRepository;
+
+	@Autowired
+	private RepositoryRepository repositoryRepository;
+
+	@Override
+	public PackageMetadata findByNameAndVersionByMaxRepoOrder(String packageName, String packageVersion) {
+		List<PackageMetadata> packageMetadataList = this.packageMetadataRepository.findByNameAndVersionOrderByApiVersionDesc(packageName,
+				packageVersion);
+		if (packageMetadataList.size() == 0) {
+			return null;
+		}
+		if (packageMetadataList.size() == 1) {
+			return packageMetadataList.get(0);
+		}
+		List<Repository> repositoriesByRepoOrder = this.repositoryRepository.findAllByOrderByRepoOrderDesc();
+		for (Repository repository: repositoriesByRepoOrder) {
+			String repoId = repository.getId();
+			for (PackageMetadata packageMetadata: packageMetadataList) {
+				if (StringUtils.hasText(packageMetadata.getOrigin()) && packageMetadata.getOrigin().equals(repoId)) {
+					return packageMetadata;
+				}
+			}
+		}
+		// if no repoId matches, then return the first package that matches (which has the highest api version set).
+		return packageMetadataList.get(0);
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -139,18 +139,12 @@ public class ReleaseService {
 	}
 
 	PackageMetadata getPackageMetadata(String packageName, String packageVersion) {
-		PackageMetadata packageMetadata;
-		try {
-			packageMetadata = this.packageMetadataRepository.findByNameAndVersion(packageName,
+		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder(packageName,
 					packageVersion);
-			if (packageMetadata == null) {
+		if (packageMetadata == null) {
 				throw new SkipperException(String.format("Can not find package '%s', version '%s'",
 						packageName, packageVersion));
 			}
-		}
-		catch (org.springframework.dao.IncorrectResultSizeDataAccessException e) {
-			throw new SkipperException("Same name package in different repositories.  Need to support.");
-		}
 		return packageMetadata;
 	}
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/AbstractControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/AbstractControllerTests.java
@@ -77,7 +77,7 @@ public abstract class AbstractControllerTests extends AbstractMockMvcTests {
 	protected Release deploy(String packageName, String packageVersion, String releaseName) throws Exception {
 		// Deploy
 		InstallProperties installProperties = createDeployProperties(releaseName);
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersion(packageName,
+		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder(packageName,
 				packageVersion);
 		assertThat(packageMetadata).isNotNull();
 		mockMvc.perform(post("/api/install/" + packageMetadata.getId())
@@ -95,7 +95,7 @@ public abstract class AbstractControllerTests extends AbstractMockMvcTests {
 
 		String releaseName = installRequest.getInstallProperties().getReleaseName();
 		Release deployedRelease = this.releaseRepository.findByNameAndVersion(releaseName, 1);
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersion(
+		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder(
 				installRequest.getPackageIdentifier().getPackageName(),
 				installRequest.getPackageIdentifier().getPackageVersion());
 		commonReleaseAssertions(releaseName, packageMetadata, deployedRelease);
@@ -110,7 +110,7 @@ public abstract class AbstractControllerTests extends AbstractMockMvcTests {
 		packageIdentifier.setPackageVersion(packageVersion);
 		upgradeRequest.setPackageIdentifier(packageIdentifier);
 		upgradeRequest.setUpgradeProperties(upgradeProperties);
-		PackageMetadata updatePackageMetadata = this.packageMetadataRepository.findByNameAndVersion(packageName,
+		PackageMetadata updatePackageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder(packageName,
 				packageVersion);
 		assertThat(updatePackageMetadata).isNotNull();
 		mockMvc.perform(post("/api/upgrade")

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataCreator.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataCreator.java
@@ -87,4 +87,29 @@ public class PackageMetadataCreator {
 		packageMetadata.setDescription("Another very cool project");
 		repository.save(packageMetadata);
 	}
+
+	public static void createTwoPackages(PackageMetadataRepository repository, String repoId, String apiVersion) {
+		PackageMetadata packageMetadata = new PackageMetadata();
+		packageMetadata.setApiVersion(apiVersion);
+		packageMetadata.setOrigin(repoId);
+		packageMetadata.setKind("skipper");
+		packageMetadata.setName("package1");
+		packageMetadata.setVersion("1.0.0");
+		packageMetadata.setIconUrl("http://www.gilligansisle.com/images/a2.gif");
+		packageMetadata.setDescription("A very cool project");
+		packageMetadata.setMaintainer("Alan Hale Jr.");
+		repository.save(packageMetadata);
+		packageMetadata = new PackageMetadata();
+		packageMetadata.setApiVersion(apiVersion);
+		packageMetadata.setOrigin(repoId);
+		packageMetadata.setKind("skipper");
+		packageMetadata.setName("package2");
+		packageMetadata.setVersion("2.0.0");
+		packageMetadata.setIconUrl("http://www.gilligansisle.com/images/a1.gif");
+		packageMetadata.setMaintainer("Bob Denver");
+		packageMetadata.setDescription("Another very cool project");
+		repository.save(packageMetadata);
+	}
+
+
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataMvcTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataMvcTests.java
@@ -47,9 +47,9 @@ public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 	@Test
 	public void testProjection() throws Exception {
 		PackageMetadataCreator.createTwoPackages(packageMetadataRepository);
-		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersion("package1", "1.0.0");
+		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("package1", "1.0.0");
 		assertThat(packageMetadata.getId()).isNotNull();
-		packageMetadata = packageMetadataRepository.findByNameAndVersion("package2", "2.0.0");
+		packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("package2", "2.0.0");
 		assertThat(packageMetadata.getId()).isNotNull();
 		mockMvc.perform(get("/api/packageMetadata?projection=summary")).andDo(print()).andExpect(status().isOk())
 				.andExpect(jsonPath("$._embedded.packageMetadata[0].version").value("1.0.0"))

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
@@ -151,7 +151,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		assertThat(releases).isNotEmpty();
 		assertThat(releases).hasSize(9);
 
-		// findByNameAndVersion
+		// findByNameAndVersionOrderByApiVersionDesc
 		Release foundByNameAndVersion = this.releaseRepository.findByNameAndVersion(release1.getName(), 2);
 		assertThat(foundByNameAndVersion).isNotNull();
 		assertThat(foundByNameAndVersion.getInfo().getStatus().getStatusCode()).isEqualTo(release2.getInfo().getStatus()

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryCreator.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryCreator.java
@@ -19,6 +19,7 @@ import org.springframework.cloud.skipper.domain.Repository;
 
 /**
  * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
  */
 public class RepositoryCreator {
 
@@ -30,6 +31,16 @@ public class RepositoryCreator {
 		repository = new Repository();
 		repository.setName("unstable");
 		repository.setUrl("http://www.example.com/skipper/repository/unstable");
+		repositoryRepository.save(repository);
+	}
+
+	public static void createRepository(RepositoryRepository repositoryRepository, String repoName,
+			Integer repoOrder) {
+		Repository repository = new Repository();
+		repository.setName(repoName);
+		repository.setUrl("http://www.example.com/skipper/repository/" + repoName);
+		repositoryRepository.save(repository);
+		repository.setRepoOrder(repoOrder);
 		repositoryRepository.save(repository);
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageServiceTests.java
@@ -78,14 +78,14 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 
 	@Test
 	public void download() {
-		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersion("log", "1.0.0");
+		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "1.0.0");
 		// Other tests may have caused the file to be loaded into the database, ensure we start
 		// fresh.
 		if (packageMetadata.getPackageFileBytes() != null) {
 			packageMetadata.setPackageFileBytes(null);
 			packageMetadataRepository.save(packageMetadata);
 		}
-		packageMetadata = packageMetadataRepository.findByNameAndVersion("log", "1.0.0");
+		packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "1.0.0");
 		assertThat(packageMetadata).isNotNull();
 		assertThat(packageMetadata.getPackageFileBytes()).isNullOrEmpty();
 		assertThat(packageService).isNotNull();
@@ -99,7 +99,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 		assertThat(downloadedPackage.getMetadata()).isEqualToIgnoringGivenFields(packageMetadata);
 		assertThat(downloadedPackage.getTemplates()).isNotNull();
 		assertThat(downloadedPackage.getConfigValues()).isNotNull();
-		packageMetadata = packageMetadataRepository.findByNameAndVersion("log", "1.0.0");
+		packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "1.0.0");
 		assertThat(packageMetadata.getPackageFileBytes()).isNotNull();
 	}
 
@@ -112,7 +112,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 		this.repositoryRepository.save(repository);
 
 		// Package log 9.9.9 should not exist, since it hasn't been uploaded yet.
-		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersion("log", "9.9.9");
+		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "9.9.9");
 		assertThat(packageMetadata).isNull();
 
 		UploadRequest uploadProperties = new UploadRequest();
@@ -135,7 +135,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 		assertThat(uploadedPackageMetadata.getVersion().equals("9.9.9")).isTrue();
 
 		// Retrieve new package
-		PackageMetadata retrievedPackageMetadata = packageMetadataRepository.findByNameAndVersion("log", "9.9.9");
+		PackageMetadata retrievedPackageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "9.9.9");
 		assertThat(retrievedPackageMetadata.getName().equals("log")).isTrue();
 		assertThat(retrievedPackageMetadata.getVersion().equals("9.9.9")).isTrue();
 		assertThat(retrievedPackageMetadata).isNotNull();
@@ -153,7 +153,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 
 	@Test
 	public void deserializePackage() {
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersion("log", "1.0.0");
+		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "1.0.0");
 		assertThat(packageService).isNotNull();
 		Package pkg = packageService.downloadPackage(packageMetadata);
 		assertThat(pkg).isNotNull();
@@ -167,7 +167,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 
 	@Test
 	public void deserializeNestedPackage() {
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersion("ticktock", "1.0.0");
+		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("ticktock", "1.0.0");
 		assertThat(packageService).isNotNull();
 		Package pkg = packageService.downloadPackage(packageMetadata);
 		assertThat(pkg).isNotNull();

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -129,27 +129,6 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 	}
 
 	@Test
-	public void testPackageDuplicateFound() {
-		PackageMetadata packageMetadata = new PackageMetadata();
-		packageMetadata.setApiVersion("v1");
-		packageMetadata.setOrigin("1");
-		packageMetadata.setKind("skipper");
-		packageMetadata.setName("log");
-		packageMetadata.setVersion("1.0.0");
-		packageMetadataRepository.save(packageMetadata);
-
-		boolean exceptionFired = false;
-		try {
-			this.releaseService.getPackageMetadata("log", "1.0.0");
-		}
-		catch (SkipperException se) {
-			assertThat(se.getMessage()).isEqualTo("Same name package in different repositories.  Need to support.");
-			exceptionFired = true;
-		}
-		assertThat(exceptionFired).isTrue();
-	}
-
-	@Test
 	public void testStatusReleaseExist() {
 		InstallProperties installProperties = new InstallProperties();
 		installProperties.setReleaseName("testexists");


### PR DESCRIPTION
 - When finding package metadata by name and version, following algorithm is used:
  - If there is a single package metadata found, then return
  - If there are multiple package metadata, then return the package metadata that belongs to the higher order repository
  - If there are no repository order information found, then return the package metadata that has the higher api version
  - Add custom repository method in PackageMetadataRepository and RepositoryRepository
  - Add tests

Resolves #212