### PR TITLE
Make RedBlackUpgrdeStrategy async

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -17,7 +17,12 @@ package org.springframework.cloud.skipper.server.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.web.ErrorAttributes;
@@ -36,6 +41,11 @@ import org.springframework.cloud.skipper.server.deployer.AppDeployerReleaseManag
 import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalyzer;
 import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
+import org.springframework.cloud.skipper.server.deployer.strategies.DeleteStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckAndDeleteStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckProperties;
+import org.springframework.cloud.skipper.server.deployer.strategies.SimpleRedBlackUpgradeStrategy;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
 import org.springframework.cloud.skipper.server.index.PackageMetadataResourceProcessor;
 import org.springframework.cloud.skipper.server.index.PackageSummaryResourceProcessor;
 import org.springframework.cloud.skipper.server.index.SkipperControllerResourceProcessor;
@@ -55,6 +65,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
@@ -68,12 +81,15 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @Configuration
 @EnableConfigurationProperties({ SkipperServerProperties.class, CloudFoundryPlatformProperties.class,
 		LocalPlatformProperties.class, KubernetesPlatformProperties.class,
-		MavenConfigurationProperties.class })
+		MavenConfigurationProperties.class, HealthCheckProperties.class })
 @EntityScan({ "org.springframework.cloud.skipper.domain", "org.springframework.cloud.skipper.server.domain" })
 @EnableMapRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
 @EnableJpaRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
 @EnableTransactionManagement
-public class SkipperServerConfiguration {
+@EnableAsync
+public class SkipperServerConfiguration implements AsyncConfigurer {
+
+	private final Logger logger = LoggerFactory.getLogger(SkipperServerConfiguration.class);
 
 	@Bean
 	public ErrorAttributes errorAttributes() {
@@ -172,9 +188,51 @@ public class SkipperServerConfiguration {
 			AppDeployerDataRepository appDeployerDataRepository,
 			DeployerRepository deployerRepository,
 			ReleaseAnalyzer releaseAnalyzer,
-			AppDeploymentRequestFactory appDeploymentRequestFactory) {
+			AppDeploymentRequestFactory appDeploymentRequestFactory,
+			UpgradeStrategy updateStrategy) {
 		return new AppDeployerReleaseManager(releaseRepository, appDeployerDataRepository, deployerRepository,
-				releaseAnalyzer, appDeploymentRequestFactory);
+				releaseAnalyzer, appDeploymentRequestFactory, updateStrategy);
+	}
+
+	@Bean
+	public DeleteStep deleteStep(ReleaseRepository releaseRepository,
+			DeployerRepository deployerRepository,
+			AppDeployerDataRepository appDeployerDataRepository) {
+		return new DeleteStep(releaseRepository, deployerRepository, appDeployerDataRepository);
+	}
+
+	@Bean
+	public UpgradeStrategy updateStrategy(ReleaseRepository releaseRepository,
+			DeployerRepository deployerRepository,
+			AppDeployerDataRepository appDeployerDataRepository,
+			AppDeploymentRequestFactory appDeploymentRequestFactory,
+			HealthCheckAndDeleteStep healthCheckAndDeleteStep) {
+		return new SimpleRedBlackUpgradeStrategy(releaseRepository, deployerRepository,
+				appDeployerDataRepository, appDeploymentRequestFactory, healthCheckAndDeleteStep);
+	}
+
+	@Bean
+	public HealthCheckAndDeleteStep healthCheckAndDeleteStep(ReleaseRepository releaseRepository,
+			DeployerRepository deployerRepository,
+			AppDeployerDataRepository appDeployerDataRepository,
+			DeleteStep deleteStep,
+			HealthCheckProperties healthCheckProperties) {
+		return new HealthCheckAndDeleteStep(releaseRepository,
+				deployerRepository,
+				deleteStep,
+				healthCheckProperties);
+	}
+
+	@Bean(name = "skipperThreadPoolTaskExecutor")
+	@Override
+	public Executor getAsyncExecutor() {
+		return new ThreadPoolTaskExecutor();
+	}
+
+	@Override
+	public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+		return (throwable, method, objects) -> logger.error("Exception thrown in @Async Method " + method.getName(),
+				throwable);
 	}
 
 	@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeleteStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeleteStep.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer.strategies;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.AppStatus;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
+import org.springframework.cloud.skipper.server.repository.DeployerRepository;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Responsible for deleting the provided list of applications and updating the status of
+ * the release.
+ * @author Mark Pollack
+ */
+public class DeleteStep {
+
+	private final Logger logger = LoggerFactory.getLogger(DeleteStep.class);
+
+	private final ReleaseRepository releaseRepository;
+
+	private final DeployerRepository deployerRepository;
+
+	private final AppDeployerDataRepository appDeployerDataRepository;
+
+	public DeleteStep(ReleaseRepository releaseRepository, DeployerRepository deployerRepository,
+			AppDeployerDataRepository appDeployerDataRepository) {
+		this.releaseRepository = releaseRepository;
+		this.deployerRepository = deployerRepository;
+		this.appDeployerDataRepository = appDeployerDataRepository;
+	}
+
+	@Transactional
+	public Release delete(Release release, AppDeployerData existingAppDeployerData,
+			List<String> applicationNamesToDelete) {
+
+		AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
+				.getAppDeployer();
+
+		Map<String, String> appNamesAndDeploymentIds = existingAppDeployerData.getDeploymentDataAsMap();
+
+		for (Map.Entry<String, String> appNameAndDeploymentId : appNamesAndDeploymentIds.entrySet()) {
+			if (applicationNamesToDelete.contains(appNameAndDeploymentId.getKey())) {
+				AppStatus appStatus = appDeployer.status(appNameAndDeploymentId.getValue());
+				if (appStatus.getState().equals(DeploymentState.deployed)) {
+					appDeployer.undeploy(appNameAndDeploymentId.getValue());
+				}
+				else {
+					logger.warn("For Release name {}, did not undeploy existing app {} as it status is not 'deployed'.",
+							release.getName(),
+							appNameAndDeploymentId.getKey());
+				}
+			}
+		}
+
+		Status deletedStatus = new Status();
+		deletedStatus.setStatusCode(StatusCode.DELETED);
+		release.getInfo().setStatus(deletedStatus);
+		release.getInfo().setDescription("Delete complete");
+		this.releaseRepository.save(release);
+		return release;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckAndDeleteStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckAndDeleteStep.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer.strategies;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.deployer.spi.app.AppStatus;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.repository.DeployerRepository;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Reponsible for checking the health of the latest deployed release, and then deleting
+ * those applications from the previous release. Executed asynchronously to avoid the
+ * client waiting a long time, potentially minutes, when executing update.
+ * @author Mark Pollack
+ */
+public class HealthCheckAndDeleteStep {
+
+	private final Logger logger = LoggerFactory.getLogger(SimpleRedBlackUpgradeStrategy.class);
+
+	private final ReleaseRepository releaseRepository;
+
+	private final DeployerRepository deployerRepository;
+
+	private final DeleteStep deleteStep;
+
+	private final HealthCheckProperties healthCheckProperties;
+
+	public HealthCheckAndDeleteStep(ReleaseRepository releaseRepository,
+			DeployerRepository deployerRepository,
+			DeleteStep deleteStep,
+			HealthCheckProperties healthCheckProperties) {
+		this.releaseRepository = releaseRepository;
+		this.deployerRepository = deployerRepository;
+		this.deleteStep = deleteStep;
+		this.healthCheckProperties = healthCheckProperties;
+	}
+
+	@Async("skipperThreadPoolTaskExecutor")
+	@Transactional
+	public CompletableFuture<Void> waitForNewAppsToDeploy(Release existingRelease,
+			AppDeployerData existingAppDeployerData,
+			List<String> applicationNamesToUpgrade, Release replacingRelease,
+			AppDeployerData replacingAppDeployerData) {
+		try {
+			logger.info("Waiting for apps in release {}-v{} to be healthy.", replacingRelease.getName(),
+					replacingRelease.getVersion());
+			boolean healthy = this.isHealthy(replacingRelease, replacingAppDeployerData);
+
+			if (healthy) {
+				logger.info("Apps in release {}-v{} are healthy.", replacingRelease.getName(),
+						replacingRelease.getVersion());
+				logger.info("Deleting changed applications from previous release {}-v{}",
+						existingRelease.getName(),
+						existingRelease.getVersion());
+
+				this.deleteStep.delete(existingRelease, existingAppDeployerData, applicationNamesToUpgrade);
+
+				// Update Status in DB
+				Status status = new Status();
+				status.setStatusCode(StatusCode.DEPLOYED);
+				replacingRelease.getInfo().setStatus(status);
+				replacingRelease.getInfo().setDescription("Upgrade complete");
+				this.releaseRepository.save(replacingRelease);
+				logger.info("Release {}-v{} has been DEPLOYED", replacingRelease.getName(),
+						replacingRelease.getVersion());
+			}
+			else {
+				logger.error("New release " + replacingRelease.getName() + " was not detected as healthy." +
+						"Keeping existing releases.");
+				Status status = new Status();
+				status.setStatusCode(StatusCode.DEPLOYED);
+				replacingRelease.getInfo().setStatus(status);
+				replacingRelease.getInfo().setStatus(status);
+				replacingRelease.getInfo().setDescription("Did not detect apps in release as healthy.");
+				this.releaseRepository.save(replacingRelease);
+			}
+		}
+		catch (Exception e) {
+			logger.error("Error upgrading new app", e);
+			// Update Status in DB
+			Status status = new Status();
+			status.setStatusCode(StatusCode.FAILED);
+			replacingRelease.getInfo().setStatus(status);
+			replacingRelease.getInfo().setDescription("Failed upgrade. Exception = [" +
+					e.getClass().getName() + "], Message = [" + e.getMessage() + "]");
+			this.releaseRepository.save(replacingRelease);
+		}
+		return null;
+	}
+
+	private boolean isHealthy(Release replacingRelease, AppDeployerData replacingAppDeployerData) {
+		boolean isHealthy = false;
+		long timeout = System.currentTimeMillis() + this.healthCheckProperties.getTimeoutInMillis();
+		Map<String, String> appNamesAndDeploymentIds = replacingAppDeployerData.getDeploymentDataAsMap();
+
+		while (!isHealthy && System.currentTimeMillis() < timeout) {
+			logger.debug("Health check for replacing release {}-v{}, sleeping for {} milliseconds.",
+					replacingRelease.getName(),
+					replacingRelease.getVersion(),
+					this.healthCheckProperties.getTimeoutInMillis());
+			sleep();
+			AppDeployer appDeployer = this.deployerRepository.findByNameRequired(replacingRelease.getPlatformName())
+					.getAppDeployer();
+
+			logger.debug("Getting status for apps in replacing release {}-v{}", replacingRelease.getName(),
+					replacingRelease.getVersion());
+			for (Map.Entry<String, String> appNameAndDeploymentId : appNamesAndDeploymentIds.entrySet()) {
+				AppStatus status = appDeployer.status(appNameAndDeploymentId.getValue());
+				if (status.getState() == DeploymentState.deployed) {
+					isHealthy = true;
+				}
+			}
+		}
+		return isHealthy;
+	}
+
+	private void sleep() {
+		try {
+			Thread.currentThread().sleep(healthCheckProperties.getSleepInMillis());
+		}
+		catch (InterruptedException e) {
+			logger.info("Interrupted exception ", e);
+			Thread.currentThread().interrupt();
+		}
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckProperties.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer.strategies;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Mark Pollack
+ */
+@ConfigurationProperties("spring.cloud.skipper.server.strategies.healthcheck")
+public class HealthCheckProperties {
+
+	private long timeoutInMillis = 12000;
+
+	private long sleepInMillis = 5000;
+
+	public long getTimeoutInMillis() {
+		return timeoutInMillis;
+	}
+
+	public void setTimeoutInMillis(long timeoutInMillis) {
+		this.timeoutInMillis = timeoutInMillis;
+	}
+
+	public long getSleepInMillis() {
+		return sleepInMillis;
+	}
+
+	public void setSleepInMillis(long sleepInMillis) {
+		this.sleepInMillis = sleepInMillis;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepository.java
@@ -21,7 +21,8 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 /**
  * @author Mark Pollack
  */
-public interface AppDeployerDataRepository extends PagingAndSortingRepository<AppDeployerData, Long> {
+public interface AppDeployerDataRepository
+		extends PagingAndSortingRepository<AppDeployerData, Long>, AppDeployerDataRepositoryCustom {
 
 	AppDeployerData findByReleaseNameAndReleaseVersion(String releaseName, Integer releaseVersion);
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepositoryCustom.java
@@ -15,24 +15,13 @@
  */
 package org.springframework.cloud.skipper.server.repository;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.Deployer;
+import org.springframework.cloud.skipper.server.domain.AppDeployerData;
 
 /**
  * @author Mark Pollack
  */
-public class DeployerRepositoryImpl implements DeployerRepositoryCustom {
+public interface AppDeployerDataRepositoryCustom {
 
-	@Autowired
-	private DeployerRepository deployerRepository;
+	AppDeployerData findByReleaseNameAndReleaseVersionRequired(String releaseName, Integer releaseVersion);
 
-	@Override
-	public Deployer findByNameRequired(String name) {
-		Deployer deployer = deployerRepository.findByName(name);
-		if (deployer == null) {
-			throw new SkipperException(String.format("No deployer named '%s'", name));
-		}
-		return deployer;
-	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepositoryImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Mark Pollack
+ */
+public class AppDeployerDataRepositoryImpl implements AppDeployerDataRepositoryCustom {
+
+	@Autowired
+	private AppDeployerDataRepository appDeployerDataRepository;
+
+	@Override
+	public AppDeployerData findByReleaseNameAndReleaseVersionRequired(String releaseName, Integer releaseVersion) {
+		AppDeployerData appDeployerData = appDeployerDataRepository.findByReleaseNameAndReleaseVersion(releaseName,
+				releaseVersion);
+		if (appDeployerData == null) {
+			List<AppDeployerData> appDeployerDataList = StreamSupport
+					.stream(appDeployerDataRepository.findAll().spliterator(), false)
+					.collect(Collectors.toList());
+			String existingDeployerData = StringUtils.collectionToCommaDelimitedString(appDeployerDataList);
+			throw new SkipperException(String.format("No AppDeployerData found for release '%s' version '%s'." +
+					"AppDeployerData = %s",
+					releaseName, releaseVersion, existingDeployerData));
+		}
+		return appDeployerData;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/DeployerInitializationService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/DeployerInitializationService.java
@@ -183,7 +183,7 @@ public class DeployerInitializationService {
 				logger.info("Adding CF Deployer account " + entry.getKey() + " into Deployer Repository.");
 			}
 			catch (Exception e) {
-				logger.warn("CloudFoundry Deployer account" + entry.getKey() + " could not be added." + e.getMessage());
+				logger.error("CloudFoundry Platform account" + entry.getKey() + " could not be registered." + e.getMessage());
 			}
 		}
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -303,7 +303,8 @@ public class ReleaseService {
 	 * to the previous release.
 	 *
 	 * @param releaseName the name of the release
-	 * @param rollbackVersion the version of the release to rollback to
+	 * @param rollbackVersion the version of the release to rollback to.  If the version is 0, then rollback
+	 *                        to the previous release.
 	 * @return the Release
 	 */
 	public Release rollback(final String releaseName, final int rollbackVersion) {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/SkipperControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/SkipperControllerTests.java
@@ -120,6 +120,8 @@ public class SkipperControllerTests extends AbstractControllerTests {
 		releaseVersion = "3";
 		mockMvc.perform(post("/api/rollback/" + releaseName + "/" + 1)).andDo(print())
 				.andExpect(status().isCreated()).andReturn();
+		sleep();
+
 		release = this.releaseRepository.findByNameAndVersion(releaseName, Integer.valueOf(releaseVersion));
 		assertReleaseIsDeployedSuccessfully(releaseName, "3");
 
@@ -163,6 +165,7 @@ public class SkipperControllerTests extends AbstractControllerTests {
 	private class ErrorDispatcher implements RequestBuilder {
 
 		private MvcResult result;
+
 		private String path;
 
 		ErrorDispatcher(MvcResult result, String path) {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
@@ -59,21 +59,20 @@ public class StatusDocumentation extends BaseDocumentation {
 		final Release release = installPackage(installRequest);
 
 		this.mockMvc.perform(
-			get("/api/status/{releaseName}", release.getName())).andDo(print())
+				get("/api/status/{releaseName}", release.getName())).andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-					responseFields(
-						fieldWithPath("status.statusCode").description(
-							String.format("StatusCode of the release's status (%s)",
-								StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-						),
-						fieldWithPath("status.platformStatus").description("Status from the underlying platform"),
-						fieldWithPath("firstDeployed").description("Date/Time of first deployment"),
-						fieldWithPath("lastDeployed").description("Date/Time of last deployment"),
-						fieldWithPath("deleted").description("Date/Time of when the release was deleted"),
-						fieldWithPath("description").description("Human-friendly 'log entry' about this release")
-					)
-				));
+						responseFields(
+								fieldWithPath("status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("description")
+										.description("Human-friendly 'log entry' about this release"))));
 	}
 
 	@Test
@@ -93,22 +92,21 @@ public class StatusDocumentation extends BaseDocumentation {
 		final Release release = installPackage(installRequest);
 
 		this.mockMvc.perform(
-			get("/api/status/{releaseName}/{releaseVersion}",
-					release.getName(), release.getVersion()))
+				get("/api/status/{releaseName}/{releaseVersion}",
+						release.getName(), release.getVersion()))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-					responseFields(
-						fieldWithPath("status.statusCode").description(
-							String.format("StatusCode of the release's status (%s)",
-								StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-						),
-						fieldWithPath("status.platformStatus").description("Status from the underlying platform"),
-						fieldWithPath("firstDeployed").description("Date/Time of first deployment"),
-						fieldWithPath("lastDeployed").description("Date/Time of last deployment"),
-						fieldWithPath("deleted").description("Date/Time of when the release was deleted"),
-						fieldWithPath("description").description("Human-friendly 'log entry' about this release")
-					)
-				));
+						responseFields(
+								fieldWithPath("status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("description")
+										.description("Human-friendly 'log entry' about this release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
@@ -60,7 +60,7 @@ public class UpgradeDocumentation extends BaseDocumentation {
 		installRequest.setInstallProperties(installProperties);
 
 		installPackage(installRequest);
-
+		sleep();
 		final String packageVersion = "1.1.0";
 		final String packageName = "log";
 
@@ -114,5 +114,7 @@ public class UpgradeDocumentation extends BaseDocumentation {
 					fieldWithPath("platformName").description("Platform name of the release")
 				)
 			));
+		sleep();
 	}
+
 }


### PR DESCRIPTION
* Make SimpleRedBlackUpgradeStrategy asychronous for status check of new apps and delete of old
* Make SimpleRedBlackUpgradeStrategy a managed Bean
* Add configuration properties for timeout and sleep time of health check
* Break out SimpleRedBlackUpgradeStrategy into two steps
* Add AppDeployerDataRepository.findByReleaseNameAndReleaseVersionRequired to avoid NPEs
* Check for fast fail on route-path deployment property for CF not having leading 'slash' /
* Catch exception inside for loop when deleting releases on test cleanup
* Update tests to deal with async behavior

Fixes #244

Unfortunately increases test time, maybe RESTDocs can use mocks.

Running Skipper with this config file
```
spring:
  cloud:
    skipper:
      server:
        synchonizeIndexOnContextRefresh: true      
        packageRepositories:
          -
            name: experimental
            url: "http://localhost:8080/repository/experimental"
            description: Sample Skipper Repository      
          -
            name: test
            url: "file:///home/mpollack/projects/spring-cloud-skipper/spring-cloud-skipper-server-core/src/test/resources/repositories/binaries/test/"
          -
            name: local
            url: "http://localhost:7577"
            local: true
            description: Default local database backed repository
        platform:
          cloudfoundry:
            accounts:
              cf-dev:
                connection:
                  url: https://api.run.pivotal.io
                  org: scdf-ci
                  space: space-mark
                  domain: cfapps.io
                  username: your@email.com
                  password: xxxx
                  skipSslValidation: false
                deployment:
                  deleteRoutes: false
```

Of note is the `deployment.deleteRoutes = false`.  That is important to have a seamless transition to the new app when hitting the http route during the transition.

I deployed as such 
```
install --release-name myhelloworld --package-name helloworld --package-version 1.0.0 --platform-name cf-dev --file /home/mpollack/helloworld-deployment.yml
```
Where the file `helloworld-deployment.yml` was
```
spec:
  deploymentProperties:
    spring.cloud.deployer.cloudfoundry.route: mlp-helloworld.cfapps.io
```
and then upgraded
```
upgrade --release-name myhelloworld --package-name helloworld --package-version 1.0.0 --file /home/mpollack/helloworld-upgrade.yml
```
where `helloworld-upgrade.yml` was
```
 spec:
  applicationProperties:
    helloworld.greeting: yo
  deploymentProperties:
    spring.cloud.deployer.cloudfoundry.route: mlp-helloworld.cfapps.io
```

