### PR TITLE
Handle null platform status values

### DIFF
--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/SkipperCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/SkipperCommands.java
@@ -235,8 +235,18 @@ public class SkipperCommands extends AbstractSkipperCommand {
 		StringBuilder sb = new StringBuilder();
 		sb.append(release.getName() + " has been upgraded.\n");
 		sb.append("Last Deployed: " + release.getInfo().getLastDeployed() + "\n");
-		sb.append("Status: " + release.getInfo().getStatus().getPlatformStatusPrettyPrint() + "\n");
+		updateStatus(sb, release);
 		return sb.toString();
+	}
+
+	private void updateStatus(StringBuilder sb, Release release) {
+		sb.append("Release Status: " + release.getInfo().getStatus().getStatusCode() + "\n");
+		if (StringUtils.hasText(release.getInfo().getStatus().getPlatformStatus())) {
+			sb.append("Platform Status: " + release.getInfo().getStatus().getPlatformStatusPrettyPrint());
+		}
+		else {
+			sb.append("Platform Status: unknown");
+		}
 	}
 
 	private void assertMutuallyExclusiveFileAndProperties(File yamlFile, String properties) {
@@ -278,7 +288,7 @@ public class SkipperCommands extends AbstractSkipperCommand {
 		StringBuilder sb = new StringBuilder();
 		sb.append(release.getName() + " has been rolled back.\n");
 		sb.append("Last Deployed: " + release.getInfo().getLastDeployed() + "\n");
-		sb.append("Status: " + release.getInfo().getStatus().getPlatformStatusPrettyPrint() + "\n");
+		updateStatus(sb, release);
 		return sb.toString();
 	}
 


### PR DESCRIPTION
 - When the upgrade/rollback operations return null platform status (due to the async nature of the method), we need to handle it appropriately
  - Current change shows `unknown` status for both Release and Platform

Resolves #253