### PR TITLE
Use findByNameRequired for packagemetadata by name

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryCustom.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.cloud.skipper.server.repository;
 
+import java.util.List;
+
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.data.repository.query.Param;
 
@@ -24,13 +27,23 @@ import org.springframework.data.repository.query.Param;
 public interface PackageMetadataRepositoryCustom {
 
 	/**
-	 * Find the {@link PackageMetadata} with the given name, version and also from the
-	 * repository that has the highest order set.
+	 * Find the {@link PackageMetadata} with the given name, version and also from the repository that has the highest
+	 * order set.
 	 *
 	 * @param name the name of the package metadata
 	 * @param version the version of the package metadata
 	 * @return the package metadata
 	 */
 	PackageMetadata findByNameAndVersionByMaxRepoOrder(@Param("name") String name, @Param("version") String version);
+
+	/**
+	 * Find the list of {@link PackageMetadata} by the given package name.
+	 *
+	 * @param name the package name
+	 * @return the list of package metadata by the given name
+	 * @throws {@link org.springframework.cloud.skipper.SkipperException} if there is no
+	 * package exists with the given name.
+	 */
+	List<PackageMetadata> findByNameRequired(@Param("name") String name) throws SkipperException;
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryImpl.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.repository;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Repository;
 
@@ -54,8 +55,16 @@ public class PackageMetadataRepositoryImpl implements PackageMetadataRepositoryC
 				}
 			}
 		}
-		// if no repoId matches, then return the first package that matches (which has the highest
-		// api version set).
+		// if no repoId matches, then return the first package that matches (which has the highest api version set).
 		return packageMetadataList.get(0);
+	}
+
+	@Override
+	public List<PackageMetadata> findByNameRequired(String packageName) {
+		List<PackageMetadata> packageMetadata = this.packageMetadataRepository.findByName(packageName);
+		if (packageMetadata.isEmpty()) {
+			throw new SkipperException(String.format("Can not find a package named '%s'", packageName));
+		}
+		return packageMetadata;
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -116,12 +116,9 @@ public class ReleaseService {
 		String packageName = packageIdentifier.getPackageName();
 		PackageMetadata packageMetadata;
 		if (!StringUtils.hasText(packageVersion)) {
-			List<PackageMetadata> packageMetadataList = this.packageMetadataRepository.findByName(packageName);
+			List<PackageMetadata> packageMetadataList = this.packageMetadataRepository.findByNameRequired(packageName);
 			if (packageMetadataList.size() == 1) {
 				packageMetadata = packageMetadataList.get(0);
-			}
-			else if (packageMetadataList == null) {
-				throw new SkipperException("Can not find a package named " + packageName);
 			}
 			else {
 				packageMetadata = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc(packageName);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryTests.java
@@ -43,12 +43,12 @@ public class PackageMetadataRepositoryTests extends AbstractIntegrationTest {
 		Iterable<PackageMetadata> packages = this.packageMetadataRepository.findAll();
 		assertThat(packages).isNotEmpty();
 		assertThat(packages).hasSize(2);
-		List<PackageMetadata> packagesNamed1 = this.packageMetadataRepository.findByName("package1");
+		List<PackageMetadata> packagesNamed1 = this.packageMetadataRepository.findByNameRequired("package1");
 		assertThat(packagesNamed1).isNotEmpty();
 		assertThat(packagesNamed1).hasSize(1);
 		assertThat(packagesNamed1.get(0).getOrigin()).isEqualTo("www.package-repos.com/repo1");
 		assertThat(packagesNamed1.get(0).getMaintainer()).isEqualTo("Alan Hale Jr.");
-		List<PackageMetadata> packagesNamed2 = this.packageMetadataRepository.findByName("package2");
+		List<PackageMetadata> packagesNamed2 = this.packageMetadataRepository.findByNameRequired("package2");
 		assertThat(packagesNamed2).isNotEmpty();
 		assertThat(packagesNamed2).hasSize(1);
 		assertThat(packagesNamed2.get(0).getMaintainer()).isEqualTo("Bob Denver");

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -135,6 +135,25 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 	}
 
 	@Test
+	public void testInstallPackageNotFound() {
+		InstallProperties installProperties = new InstallProperties();
+		installProperties.setReleaseName("latestPackage");
+		installProperties.setPlatformName("default");
+		InstallRequest installRequest = new InstallRequest();
+		installRequest.setInstallProperties(installProperties);
+		PackageIdentifier packageIdentifier = new PackageIdentifier();
+		packageIdentifier.setPackageName("random");
+		installRequest.setPackageIdentifier(packageIdentifier);
+		try {
+			releaseService.install(installRequest);
+			fail("SkipperException is expected for non existing package");
+		}
+		catch (Exception se) {
+			assertThat(se.getMessage()).isEqualTo("Can not find a package named 'random'");
+		}
+	}
+
+	@Test
 	public void testLatestPackageByName() {
 		String packageName = "log";
 		PackageMetadata packageMetadata = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc(packageName);


### PR DESCRIPTION
 - When packageMetadata is queried by the given name, we always throw SkipperException
and hence make this a custom repository method `findByNameRequired`
 - Add test

Resolves #256