### PR TITLE
Release update on deleted/deployed releases only

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepository.java
@@ -47,6 +47,8 @@ public interface ReleaseRepository extends PagingAndSortingRepository<Release, L
 	@RestResource(exported = false)
 	void deleteAll();
 
+	List<Release> findByNameOrderByVersionDesc(@Param("name") String name);
+
 	List<Release> findByNameIgnoreCaseContainingOrderByNameAscVersionDesc(@Param("name") String name);
 
 	List<Release> findByNameAndVersionBetweenOrderByNameAscVersionDesc(@Param("name") String name,

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
@@ -36,6 +36,16 @@ public interface ReleaseRepositoryCustom {
 	Release findLatestRelease(String releaseName);
 
 	/**
+	 * Find the lasted in time, release object, by name whose status is neither unknown nor failed.
+	 * This release can be used for upgrade/rollback operations.
+	 * @param releaseName the name of the release
+	 * @return the Release object
+	 * @throws {@link ReleaseNotFoundException} if no latest Release (with the deployed/deleted status) for the given
+	 * name can be found.
+	 */
+	Release findLatestReleaseForUpdate(String releaseName);
+
+	/**
 	 * Find the release for the given release name and version
 	 * @param releaseName the name of the release
 	 * @param version the version of the release

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
@@ -42,6 +42,18 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
+	public Release findLatestReleaseForUpdate(String releaseName) {
+		List<Release> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
+		for (Release release : releases) {
+			if (release.getInfo().getStatus().getStatusCode().equals(StatusCode.DEPLOYED) ||
+					release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
+				return release;
+			}
+		}
+		throw new ReleaseNotFoundException(releaseName);
+	}
+
+	@Override
 	public Release findByNameAndVersion(String releaseName, int version) {
 		Iterable<Release> releases = this.releaseRepository.findAll();
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -299,11 +299,12 @@ public class ReleaseService {
 		Assert.notNull(upgradeRequest.getUpgradeProperties(), "UpgradeProperties can not be null");
 		Assert.notNull(upgradeRequest.getPackageIdentifier(), "PackageIdentifier can not be null");
 		UpgradeProperties upgradeProperties = upgradeRequest.getUpgradeProperties();
-		Release existingRelease = this.releaseRepository.findLatestRelease(upgradeProperties.getReleaseName());
+		Release existingRelease = this.releaseRepository.findLatestReleaseForUpdate(upgradeProperties.getReleaseName());
+		Release latestRelease = this.releaseRepository.findLatestRelease(upgradeProperties.getReleaseName());
 		PackageIdentifier packageIdentifier = upgradeRequest.getPackageIdentifier();
 		PackageMetadata packageMetadata = getPackageMetadata(packageIdentifier.getPackageName(), packageIdentifier
 				.getPackageVersion());
-		Release replacingRelease = createReleaseForUpgrade(packageMetadata, existingRelease.getVersion() + 1,
+		Release replacingRelease = createReleaseForUpgrade(packageMetadata, latestRelease.getVersion() + 1,
 				upgradeProperties,
 				existingRelease.getPlatformName());
 		Map<String, Object> model = ConfigValueUtils.mergeConfigValues(replacingRelease.getPkg(),
@@ -357,7 +358,7 @@ public class ReleaseService {
 		Assert.isTrue(rollbackVersion >= 0,
 				"Rollback version can not be less than zero.  Value = " + rollbackVersion);
 
-		Release currentRelease = this.releaseRepository.findLatestRelease(releaseName);
+		Release currentRelease = this.releaseRepository.findLatestReleaseForUpdate(releaseName);
 		Assert.notNull(currentRelease, "Could not find release = [" + releaseName + "]");
 
 		// Determine with version to rollback to

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
@@ -35,8 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Java6Assertions.fail;
 
 /**
- * Uses @Transactional for ease of re-using existing JPA managed objects within
- * Spring's managed test method transaction
+ * Uses @Transactional for ease of re-using existing JPA managed objects within Spring's
+ * managed test method transaction
  * @author Ilayaperumal Gopinathan
  */
 @ActiveProfiles("repo-test")
@@ -71,6 +71,12 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		deployedStatus.setPlatformStatus("Deployed successfully");
 		deployedStatus.setStatusCode(StatusCode.DEPLOYED);
 		deployedInfo.setStatus(deployedStatus);
+
+		Info unknownInfo = new Info();
+		Status unknownStatus = new Status();
+		unknownStatus.setPlatformStatus("Unknown");
+		unknownStatus.setStatusCode(StatusCode.UNKNOWN);
+		unknownInfo.setStatus(unknownStatus);
 
 		Info failedInfo = new Info();
 		Status failedStatus = new Status();
@@ -150,10 +156,74 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release9.setInfo(deletedInfo);
 		this.releaseRepository.save(release9);
 
+		Release release10 = new Release();
+		release10.setName("multipleRevisions1");
+		release10.setVersion(1);
+		release10.setPlatformName("platform2");
+		release10.setPkg(pkg1);
+		release10.setInfo(deployedInfo);
+		this.releaseRepository.save(release10);
+
+		Release release11 = new Release();
+		release11.setName(release10.getName());
+		release11.setVersion(2);
+		release11.setPlatformName(release10.getPlatformName());
+		release11.setPkg(pkg2);
+		release11.setInfo(failedInfo);
+		this.releaseRepository.save(release11);
+
+		Release release12 = new Release();
+		release12.setName(release10.getName());
+		release12.setVersion(3);
+		release12.setPlatformName(release10.getPlatformName());
+		release12.setPkg(pkg2);
+		release12.setInfo(failedInfo);
+		this.releaseRepository.save(release12);
+
+		Release release13 = new Release();
+		release13.setName("multipleRevisions2");
+		release13.setVersion(1);
+		release13.setPlatformName("platform2");
+		release13.setPkg(pkg1);
+		release13.setInfo(deployedInfo);
+		this.releaseRepository.save(release13);
+
+		Release release14 = new Release();
+		release14.setName(release13.getName());
+		release14.setVersion(2);
+		release14.setPlatformName(release13.getPlatformName());
+		release14.setPkg(pkg2);
+		release14.setInfo(deletedInfo);
+		this.releaseRepository.save(release14);
+
+		Release release15 = new Release();
+		release15.setName(release13.getName());
+		release15.setVersion(3);
+		release15.setPlatformName(release13.getPlatformName());
+		release15.setPkg(pkg2);
+		release15.setInfo(unknownInfo);
+		this.releaseRepository.save(release15);
+
+		Release release16 = new Release();
+		release16.setName("multipleRevisions3");
+		release16.setVersion(1);
+		release16.setPlatformName(release16.getPlatformName());
+		release16.setPkg(pkg2);
+		release16.setInfo(failedInfo);
+		this.releaseRepository.save(release16);
+
+		Release release17 = new Release();
+		release17.setName(release16.getName());
+		release17.setVersion(2);
+		release17.setPlatformName(release16.getPlatformName());
+		release17.setPkg(pkg2);
+		release17.setInfo(unknownInfo);
+		this.releaseRepository.save(release17);
+
 		// findAll
 		Iterable<Release> releases = this.releaseRepository.findAll();
 		assertThat(releases).isNotEmpty();
-		assertThat(releases).hasSize(9);
+		assertThat(releases).hasSize(17);
 
 		// findByNameAndVersionOrderByApiVersionDesc
 		Release foundByNameAndVersion = this.releaseRepository.findByNameAndVersion(release1.getName(), 2);
@@ -214,13 +284,29 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 
 		List<Release> deployedOrFailedAll = this.releaseRepository.findLatestDeployedOrFailed("");
 		assertThat(deployedOrFailedAll).isNotEmpty();
-		assertThat(deployedOrFailedAll).hasSize(4);
+		assertThat(deployedOrFailedAll).hasSize(9);
 
 		Release latestDeletedRelease1 = this.releaseRepository.findLatestReleaseIfDeleted(release1.getName());
 		assertThat(latestDeletedRelease1).isNull();
 
 		Release latestDeletedRelease2 = this.releaseRepository.findLatestReleaseIfDeleted(release6.getName());
 		assertThat(latestDeletedRelease2.getVersion()).isEqualTo(4);
+
+		// deployed -> failed -> failed
+		Release latestReleaseForUpdate1 = this.releaseRepository.findLatestReleaseForUpdate(release10.getName());
+		assertThat(latestReleaseForUpdate1.getVersion()).isEqualTo(1);
+		// deployed -> deleted -> unknown
+		Release latestReleaseForUpdate2 = this.releaseRepository.findLatestReleaseForUpdate(release13.getName());
+		assertThat(latestReleaseForUpdate2.getVersion()).isEqualTo(2);
+
+		try {
+			this.releaseRepository.findLatestReleaseForUpdate(release16.getName());
+			fail("ReleaseNotFoundException is expected");
+		}
+		catch (ReleaseNotFoundException e) {
+			assertThat(e.getMessage())
+					.isEqualTo(String.format("Release with the name [%s] doesn't exist", release16.getName()));
+		}
 	}
 
 	@Test
@@ -248,5 +334,4 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 					String.format("Release with the name [%s] and version [%s] doesn't exist", releaseName, version)));
 		}
 	}
-
 }


### PR DESCRIPTION
 - When the release is updated (via upgrade/rollback), when finding the latest revision of the existing release by the given name, only `deleted` or `deployed` releases should be considered
 - Add custom ReleaseRepository method to query only the latest `deleted` or `deployed` release by the given name
   - Throw SkipperException if there is no release found with that criteria
 - Make sure to increment the latest release (not the latest deleted/deployed) when calculating the release version for the replacing release
 - Add tests

Resolves #267