### PR TITLE
Fail release if no upgrade performed

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckAndDeleteStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckAndDeleteStep.java
@@ -111,7 +111,6 @@ public class HealthCheckAndDeleteStep {
 				Status status = new Status();
 				status.setStatusCode(StatusCode.FAILED);
 				replacingRelease.getInfo().setStatus(status);
-				replacingRelease.getInfo().setStatus(status);
 				replacingRelease.getInfo().setDescription("Did not detect apps in repalcing release as healthy after " +
 						this.healthCheckProperties.getSleepInMillis() + " ms.");
 				this.releaseRepository.save(replacingRelease);


### PR DESCRIPTION
 - When there is no upgrade based on the ReleaseDifference, then the corresponding replacing release should be set to `FAILED` status.
 - Also, fail the upgrade before setting the manifest if there is no difference found

Resolves #268