### PR TITLE
Rollback preserving config

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/AppDeployerReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/AppDeployerReleaseManager.java
@@ -163,6 +163,10 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 	@Override
 	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease) {
 		ReleaseAnalysisReport releaseAnalysisReport = this.releaseAnalyzer.analyze(existingRelease, replacingRelease);
+		if (releaseAnalysisReport.getReleaseDifference().areEqual()) {
+			throw new SkipperException(
+					"Package to upgrade has no difference than existing deployed/deleted package. Not upgrading.");
+		}
 		AppDeployerData existingAppDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(
 						existingRelease.getName(), existingRelease.getVersion());
@@ -176,10 +180,6 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 		String manifest = ManifestUtils.createManifest(replacingRelease.getPkg(), model);
 		replacingRelease.setManifest(manifest);
 		this.releaseRepository.save(replacingRelease);
-		if (releaseAnalysisReport.getReleaseDifference().areEqual()) {
-			throw new SkipperException(
-					"Package to upgrade has no difference than existing deployed package. Not upgrading.");
-		}
 		return releaseAnalysisReport;
 	}
 
@@ -196,33 +196,45 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 	private Map<String, Object> calculateAppCountsForRelease(Release replacingRelease,
 			Map<String, String> existingAppNamesAndDeploymentIds, List<String> applicationNamesToUpgrade,
 			List<AppStatus> appStatuses) {
-		Map<String, String> appsCount = new HashMap<>();
+		Map<String, Object> model = ConfigValueUtils.mergeConfigValues(replacingRelease.getPkg(),
+				replacingRelease.getConfigValues());
 		for (Map.Entry<String, String> existingEntry : existingAppNamesAndDeploymentIds.entrySet()) {
 			String existingName = existingEntry.getKey();
 			if (applicationNamesToUpgrade.contains(existingName)) {
 				String deploymentId = existingAppNamesAndDeploymentIds.get(existingName);
 				for (AppStatus appStatus : appStatuses) {
 					if (appStatus.getDeploymentId().equals(deploymentId)) {
-						appsCount.put(existingName, String.valueOf(appStatus.getInstances().size()));
+						String appsCount = String.valueOf(appStatus.getInstances().size());
+						if (replacingRelease.getPkg().getDependencies().isEmpty()) {
+							updateCountProperty(model, appsCount);
+						}
+						else {
+							for (Map.Entry<String, Object> entry : model.entrySet()) {
+								if (existingName.contains(entry.getKey())) {
+									Map<String, Object> appModel = (Map<String, Object>) model.getOrDefault(entry.getKey(),
+											new TreeMap<String, Object>());
+									updateCountProperty(appModel, appsCount);
+								}
+							}
+						}
 					}
 				}
 			}
 		}
-		Map<String, Object> model = ConfigValueUtils.mergeConfigValues(replacingRelease.getPkg(),
-				replacingRelease.getConfigValues());
-		for (Map.Entry<String, Object> entry : model.entrySet()) {
-			if (appsCount.keySet().contains(entry.getKey())) {
-				Map<String, Object> modelValue = (Map<String, Object>) model.getOrDefault(entry.getKey(),
-						new TreeMap<String, Object>());
-				Map<String, Object> specMap = (Map<String, Object>) modelValue.getOrDefault(
-						SpringBootAppKind.SPEC_STRING,
-						new TreeMap<String, Object>());
-				Map<String, Object> deploymentPropertiesMap = (Map<String, Object>) specMap
-						.getOrDefault(SpringBootAppSpec.DEPLOYMENT_PROPERTIES_STRING, new TreeMap<String, Object>());
-				deploymentPropertiesMap.put(SPRING_CLOUD_DEPLOYER_COUNT, appsCount.get(entry.getKey()));
-			}
-		}
+
 		return model;
+	}
+
+	private void updateCountProperty(Map<String, Object> model, String appsCount) {
+		Map<String, Object> specMap = (Map<String, Object>) model.getOrDefault(SpringBootAppKind.SPEC_STRING,
+				new TreeMap<String, Object>());
+		Map<String, Object> deploymentPropertiesMap = (Map<String, Object>) specMap.get(SpringBootAppSpec.DEPLOYMENT_PROPERTIES_STRING);
+		// explicit null check instead of getOrDefault is required as deploymentProperties could have been explicitly
+		// set to null.
+		if (deploymentPropertiesMap == null) {
+			deploymentPropertiesMap = new TreeMap<String, Object>();
+		}
+		deploymentPropertiesMap.put(SPRING_CLOUD_DEPLOYER_COUNT, appsCount);
 	}
 
 	public Release status(Release release) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalyzer.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalyzer.java
@@ -186,6 +186,10 @@ public class ReleaseAnalyzer {
 		if (replacingDeploymentProperties == null) {
 			replacingDeploymentProperties = new TreeMap<>();
 		}
+		// exclude deployer count from computing the difference
+		existingDeploymentProperties.remove(AppDeployerReleaseManager.SPRING_CLOUD_DEPLOYER_COUNT);
+		replacingDeploymentProperties.remove(AppDeployerReleaseManager.SPRING_CLOUD_DEPLOYER_COUNT);
+
 		MapDifference<String, String> deploymentPropertiesDifference = Maps.difference(existingDeploymentProperties,
 				replacingDeploymentProperties);
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
@@ -46,6 +46,15 @@ public interface ReleaseRepositoryCustom {
 	Release findLatestReleaseForUpdate(String releaseName);
 
 	/**
+	 * Find the release to rollback from the existing version.
+	 *
+	 * @param releaseName the name of the release to rollback
+	 * @return the Release object to rollback to
+	 * @throws {@link ReleaseNotFoundException} if no latest Release found to rollback to.
+	 */
+	Release findReleaseToRollback(String releaseName);
+
+	/**
 	 * Find the release for the given release name and version
 	 * @param releaseName the name of the release
 	 * @param version the version of the release

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
@@ -54,6 +54,20 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
+	public Release findReleaseToRollback(String releaseName) {
+		Release latestRelease = this.releaseRepository.findLatestReleaseForUpdate(releaseName);
+		List<Release> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
+		for (Release release : releases) {
+			if ((release.getInfo().getStatus().getStatusCode().equals(StatusCode.DEPLOYED) ||
+					release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) &&
+					release.getVersion() != latestRelease.getVersion()) {
+				return release;
+			}
+		}
+		throw new ReleaseNotFoundException(releaseName);
+	}
+
+	@Override
 	public Release findByNameAndVersion(String releaseName, int version) {
 		Iterable<Release> releases = this.releaseRepository.findAll();
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -272,7 +272,7 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		// Rollback
 		Release rolledBackRelease = this.releaseService.rollback(releaseName, 0);
 		sleep();
-		assertThat(rolledBackRelease.getManifest()).isEqualTo(upgradedRelease.getManifest());
+		assertThat(rolledBackRelease.getManifest()).isEqualTo(release.getManifest());
 		assertThat(rolledBackRelease.getInfo().getStatus().getStatusCode().equals(StatusCode.DEPLOYED));
 
 		deletedRelease = releaseRepository.findByNameAndVersion(releaseName, 2);


### PR DESCRIPTION
 - Make sure to set the config values from the existing release so that they can be merged when setting manifest for the replacing release
 - Add a custom repository method to get the release to rollback to
 - Remove `spring.cloud.deployer.count` from deployment properties comparision

Resolves #266