### PR TITLE
Transaction handling during health check

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckAndDeleteStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckAndDeleteStep.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.skipper.server.repository.AppDeployerDataReposi
 import org.springframework.cloud.skipper.server.repository.DeployerRepository;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 import org.springframework.context.event.EventListener;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Responsible for checking the health of the latest deployed release, and then deleting
@@ -71,6 +72,7 @@ public class HealthCheckAndDeleteStep {
 		this.healthCheckProperties = healthCheckProperties;
 	}
 
+	@Transactional
 	public void waitForNewAppsToDeploy(Release existingRelease,
 			List<String> applicationNamesToUpgrade, Release replacingRelease) {
 		try {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
@@ -33,7 +33,6 @@ import org.springframework.cloud.skipper.server.domain.SpringBootAppKindReader;
 import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
 import org.springframework.cloud.skipper.server.repository.DeployerRepository;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.cloud.skipper.server.config.SkipperServerConfiguration.SKIPPER_THREAD_POOL_EXECUTOR;
 
@@ -67,10 +66,8 @@ public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 
 	@Override
 	@Async(SKIPPER_THREAD_POOL_EXECUTOR)
-	@Transactional
 	public Release upgrade(Release existingRelease, Release replacingRelease,
 			ReleaseAnalysisReport releaseAnalysisReport) {
-
 		List<String> applicationNamesToUpgrade = releaseAnalysisReport.getApplicationNamesToUpgrade();
 		AppDeployer appDeployer = this.deployerRepository.findByNameRequired(replacingRelease.getPlatformName())
 				.getAppDeployer();


### PR DESCRIPTION
 - Add @Transactional only to the health check method
 - Setting appdeployer data for th release being replaced doesn't belong to transaction as it is similar to the release report saving the replacing release

Resolves #280