### PR TITLE
gh-282 DefaultPackageReader - Fix template files handling under Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring-cloud.version>Dalston.RELEASE</spring-cloud.version>
         <spring-cloud-deployer.version>1.2.1.RELEASE</spring-cloud-deployer.version>
-        <spring-cloud-deployer-local.version>1.2.1.RELEASE</spring-cloud-deployer-local.version>
+        <spring-cloud-deployer-local.version>1.3.0.M1</spring-cloud-deployer-local.version>
         <reactor.version>3.0.7.RELEASE</reactor.version>
         <spring-shell.version>2.0.0.M2</spring-shell.version>
         <jsonpath.version>2.2.0</jsonpath.version>

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/io/DefaultPackageReader.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/io/DefaultPackageReader.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Mark Pollack
+ * @author Gunnar Hillert
  */
 public class DefaultPackageReader implements PackageReader {
 
@@ -56,6 +57,7 @@ public class DefaultPackageReader implements PackageReader {
 		for (File file : files) {
 			// Package metadata
 			if (file.getName().equalsIgnoreCase("package.yaml") || file.getName().equalsIgnoreCase("package.yml")) {
+
 				pkg.setMetadata(loadPackageMetadata(file));
 				continue;
 			}
@@ -68,8 +70,8 @@ public class DefaultPackageReader implements PackageReader {
 			}
 
 			// The template files
-			String absFileName = file.getAbsoluteFile().toString();
-			if (absFileName.endsWith("/templates")) {
+			final File absoluteFile = file.getAbsoluteFile();
+			if (absoluteFile.isDirectory() && absoluteFile.getName().equals("templates")) {
 				pkg.setTemplates(loadTemplates(file));
 				continue;
 			}


### PR DESCRIPTION
* Update `spring-cloud-deployer-local` dependency version to `1.3.0.M1`
  - Otherwise the Java executable is not found under Windows

resolves https://github.com/spring-cloud/spring-cloud-skipper/issues/282