### PR TITLE
Delete the latest deployed release only

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
@@ -28,7 +28,7 @@ import org.springframework.cloud.skipper.domain.Release;
 public interface ReleaseRepositoryCustom {
 
 	/**
-	 * Find the lasted in time, release object, by name.
+	 * Find the latest in time, release object, by name.
 	 * @param releaseName the name of the release
 	 * @return the Release object
 	 * @throws {@link ReleaseNotFoundException} if no Release for the given name can be found.
@@ -36,7 +36,15 @@ public interface ReleaseRepositoryCustom {
 	Release findLatestRelease(String releaseName);
 
 	/**
-	 * Find the lasted in time, release object, by name whose status is neither unknown nor failed.
+	 * Find the latest in time, release object, by name and with the deployed status.
+	 * @param releaseName the name of the release
+	 * @return the Release object
+	 * @throws {@link ReleaseNotFoundException} if no deployed Release for the given name can be found.
+	 */
+	Release findLatestDeployedRelease(String releaseName);
+
+	/**
+	 * Find the latest in time, release object, by name whose status is neither unknown nor failed.
 	 * This release can be used for upgrade/rollback operations.
 	 * @param releaseName the name of the release
 	 * @return the Release object

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
@@ -42,6 +42,17 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
+	public Release findLatestDeployedRelease(String releaseName) {
+		List<Release> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
+		for (Release release : releases) {
+			if (release.getInfo().getStatus().getStatusCode().equals(StatusCode.DEPLOYED)) {
+				return release;
+			}
+		}
+		throw new ReleaseNotFoundException(releaseName);
+	}
+
+	@Override
 	public Release findLatestReleaseForUpdate(String releaseName) {
 		List<Release> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
 		for (Release release : releases) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -194,7 +194,7 @@ public class ReleaseService {
 	@Transactional
 	public Release delete(String releaseName) {
 		Assert.notNull(releaseName, "Release name must not be null");
-		Release release = this.releaseRepository.findLatestRelease(releaseName);
+		Release release = this.releaseRepository.findLatestDeployedRelease(releaseName);
 		return this.releaseManager.delete(release);
 	}
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
@@ -35,8 +35,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Java6Assertions.fail;
 
 /**
- * Uses @Transactional for ease of re-using existing JPA managed objects within Spring's
- * managed test method transaction
  * @author Ilayaperumal Gopinathan
  */
 @ActiveProfiles("repo-test")
@@ -299,6 +297,18 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		Release latestReleaseForUpdate2 = this.releaseRepository.findLatestReleaseForUpdate(release13.getName());
 		assertThat(latestReleaseForUpdate2.getVersion()).isEqualTo(2);
 
+		// deployed -> deleted -> unknown
+		Release latestDeployedRelease = this.releaseRepository.findLatestDeployedRelease(release13.getName());
+		assertThat(latestDeployedRelease.getVersion()).isEqualTo(1);
+
+		try {
+			this.releaseRepository.findLatestDeployedRelease(release4.getName());
+			fail("ReleaseNotFoundException is expected");
+		}
+		catch (ReleaseNotFoundException e) {
+			assertThat(e.getMessage())
+					.isEqualTo(String.format("Release with the name [%s] doesn't exist", release4.getName()));
+		}
 		try {
 			this.releaseRepository.findLatestReleaseForUpdate(release16.getName());
 			fail("ReleaseNotFoundException is expected");


### PR DESCRIPTION
 - When release delete is invoked, find the latest deployed release
  - If no `deployed` release found, then throw ReleaseNotFoundException
 - Add tests

Resolves #264