### PR TITLE
Add collapsable TOC infrastructure for the reference guide

### DIFF
--- a/spring-cloud-skipper-docs/src/main/asciidoc/docinfo.html
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/docinfo.html
@@ -1,0 +1,74 @@
+<!-- Generate a nice TOC -->
+<script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
+<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tocify/1.9.0/javascripts/jquery.tocify.min.js"></script>
+<!-- We do not need the tocify CSS because the asciidoc CSS already provides most of what we neeed -->
+
+<style>
+.tocify-header {
+    font-style: italic;
+}
+
+.tocify-subheader {
+    font-style: normal;
+}
+
+.tocify ul {
+    margin: 0;
+ }
+
+.tocify-focus {
+    color: #7a2518; 
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.tocify-focus > a {
+    color: #7a2518; 
+}
+</style>
+
+<script type="text/javascript">
+    $(function () {
+        // Add a new container for the tocify toc into the existing toc so we can re-use its
+        // styling
+        $("#toc").append("<div id='generated-toc'></div>");
+        $("#generated-toc").tocify({
+            extendPage: false,
+            context: "#content",
+            highlightOnScroll: false,
+            hideEffect: "slideUp",
+            // Use the IDs that asciidoc already provides so that TOC links and intra-document
+            // links are the same. Anything else might confuse users when they create bookmarks.
+            hashGenerator: function(text, element) {
+                return $(element).attr("id");
+            },
+            // Smooth scrolling doesn't work properly if we use the asciidoc IDs
+            smoothScroll: false,
+            // Set to 'none' to use the tocify classes
+            theme: "none",
+            // Handle book (may contain h1) and article (only h2 deeper)
+            selectors: $( "#content" ).has( "h1" ).size() > 0 ? "h1,h2,h3,h4,h5" : "h2,h3,h4,h5",
+            ignoreSelector: ".discrete"
+        });
+
+        // Switch between static asciidoc toc and dynamic tocify toc based on browser size
+        // This is set to match the media selectors in the asciidoc CSS
+        // Without this, we keep the dynamic toc even if it is moved from the side to preamble
+        // position which will cause odd scrolling behavior
+        var handleTocOnResize = function() {
+            if ($(document).width() < 768) {
+                $("#generated-toc").hide();
+                $(".sectlevel0").show();
+                $(".sectlevel1").show();
+            }
+            else {
+                $("#generated-toc").show();
+                $(".sectlevel0").hide();
+                $(".sectlevel1").hide();
+            }
+        }
+
+        $(window).resize(handleTocOnResize);
+        handleTocOnResize();
+    });
+</script>

--- a/spring-cloud-skipper-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/index.adoc
@@ -1,6 +1,5 @@
 = Spring Cloud Skipper Reference Guide
 Mark Pollack; Ilayaperumal Gopinathan; Janne Valkealahti; Gunnar Hillert; Sabby Anandan
-
 :doctype: book
 :toc: left
 :toclevels: 4

--- a/spring-cloud-skipper-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/index.adoc
@@ -1,13 +1,14 @@
 = Spring Cloud Skipper Reference Guide
-Mark Pollack; Ilayaperumal Gopinathan; Janne Valkealahti; Gunnar Hillert
+Mark Pollack; Ilayaperumal Gopinathan; Janne Valkealahti; Gunnar Hillert; Sabby Anandan
 
 :doctype: book
-:toc:
+:toc: left
 :toclevels: 4
 :source-highlighter: prettify
 :numbered:
 :icons: font
 :hide-uri-scheme:
+:docinfo: shared
 
 :spring-cloud-skipper-docs: http://docs.spring.io/spring-cloud-skipper/docs/{project-version}/reference
 :spring-cloud-skipper-docs-current: http://docs.spring.io/spring-cloud-skipper/docs/current-SNAPSHOT/reference/html/


### PR DESCRIPTION
This PR adds collapsable TOC experience for the reference guide. 

Locally verified with:

> ./mvnw -DskipTests -Pfull package -pl spring-cloud-skipper-docs

![image](https://user-images.githubusercontent.com/1562654/32065829-ba3b77c6-ba32-11e7-99cf-e8611e9c870e.png)


Resolves spring-cloud/spring-cloud-skipper#287