### PR TITLE
Fixes to make tests more robust with async changes to updatestrategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,8 @@
                     </excludes>
                     <!-- see http://stackoverflow.com/questions/18107375/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-upon-exec -->
                     <argLine>${argLine}</argLine>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
             <plugin>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.config;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +72,6 @@ import org.springframework.data.map.repository.config.EnableMapRepositories;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
@@ -94,7 +94,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableScheduling
 public class SkipperServerConfiguration implements AsyncConfigurer {
 
-	public static final String SKIPPER_THREAD_POOL_EXECUTOR = "skipperThreadPoolTaskExecutor";
+	public static final String SKIPPER_EXECUTOR = "skipperThreadPoolTaskExecutor";
 
 	private final Logger logger = LoggerFactory.getLogger(SkipperServerConfiguration.class);
 
@@ -185,8 +185,7 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 	}
 
 	@Bean
-	@ConditionalOnProperty(prefix = "spring.cloud.skipper.server", name = "enableReleaseStateUpdateService",
-			matchIfMissing = true)
+	@ConditionalOnProperty(prefix = "spring.cloud.skipper.server", name = "enableReleaseStateUpdateService", matchIfMissing = true)
 	public ReleaseStateUpdateService releaseStateUpdateService(ReleaseManager releaseManager,
 			ReleaseRepository releaseRepository) {
 		return new ReleaseStateUpdateService(releaseManager, releaseRepository);
@@ -254,10 +253,10 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 				healthCheckProperties);
 	}
 
-	@Bean(name = SKIPPER_THREAD_POOL_EXECUTOR)
+	@Bean(name = SKIPPER_EXECUTOR)
 	@Override
 	public Executor getAsyncExecutor() {
-		return new ThreadPoolTaskExecutor();
+		return Executors.newSingleThreadScheduledExecutor();
 	}
 
 	@Override

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
@@ -22,7 +22,7 @@ import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.scheduling.annotation.Async;
 
-import static org.springframework.cloud.skipper.server.config.SkipperServerConfiguration.SKIPPER_THREAD_POOL_EXECUTOR;
+import static org.springframework.cloud.skipper.server.config.SkipperServerConfiguration.SKIPPER_EXECUTOR;
 
 /**
  * A simple approach to deploying a new application. All the new apps are deployed and a
@@ -48,7 +48,7 @@ public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 	}
 
 	@Override
-	@Async(SKIPPER_THREAD_POOL_EXECUTOR)
+	@Async(SKIPPER_EXECUTOR)
 	public Release upgrade(Release existingRelease, Release replacingRelease,
 			ReleaseAnalysisReport releaseAnalysisReport) {
 		List<String> applicationNamesToUpgrade = this.deployAppStep.deployApps(existingRelease, replacingRelease,

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/DeployerInitializationService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/DeployerInitializationService.java
@@ -110,7 +110,7 @@ public class DeployerInitializationService {
 				Deployer deployer = new Deployer(entry.getKey(), "local", localAppDeployer);
 				deployer.setDescription(prettyPrintLocalDeployerProperties(entry.getValue()));
 				deployerRepository.save(deployer);
-				logger.info("Added Local Deployer account " + entry.getKey() + " into Deployer Repository.");
+				logger.info("Added Local Deployer account named '" + entry.getKey() + "' into Deployer Repository.");
 			}
 		}
 		else {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseStateUpdateService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseStateUpdateService.java
@@ -63,7 +63,7 @@ public class ReleaseStateUpdateService {
 
 	@Scheduled(initialDelay = 5000, fixedRate = 5000)
 	@Transactional
-	public void update() {
+	public synchronized void update() {
 		log.info("Scheduled update state method running...");
 		long now = System.currentTimeMillis();
 		boolean fullPoll = now > nextFullPoll;

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseStateUpdateService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseStateUpdateService.java
@@ -64,35 +64,52 @@ public class ReleaseStateUpdateService {
 	@Scheduled(initialDelay = 5000, fixedRate = 5000)
 	@Transactional
 	public void update() {
-		log.debug("Updating Release stategit.");
+		log.info("Scheduled update state method running...");
 		long now = System.currentTimeMillis();
 		boolean fullPoll = now > nextFullPoll;
 		if (fullPoll) {
 			// setup next full poll
 			nextFullPoll = getNextFullPoll();
-			log.debug("Setup next full poll at {}", new Date(nextFullPoll));
+			log.info("Setup next full poll at {}", new Date(nextFullPoll));
 		}
 		Iterable<Release> releases = releaseRepository.findLatestDeployedOrFailed();
 		for (Release release : releases) {
 			Info info = release.getInfo();
-			if (info != null) {
+			if (checkInfo(info)) {
 				// poll new apps every time or we do full poll anyway
-				boolean poll = fullPoll || (info.getLastDeployed().getTime() > (now - 120000));
+				boolean isNewApp = (info.getLastDeployed().getTime() > (now - 120000));
+				log.info("Considering updating state for {}-v{}", release.getName(), release.getVersion());
+				log.info("fullPoll = {}, isNewApp = {}", fullPoll, isNewApp);
+				boolean poll = fullPoll || (isNewApp);
 				if (poll) {
 					try {
 						release = releaseManager.status(release);
-						log.debug("New Release state {} {}", release.getName(), release.getInfo().getStatus(),
+						log.info("New Release state {} {}", release.getName(), release.getInfo().getStatus(),
 								release.getInfo().getStatus() != null
 										? release.getInfo().getStatus().getPlatformStatusPrettyPrint()
 										: "");
 						releaseRepository.save(release);
 					}
 					catch (Exception e) {
-						log.warn("Unable to update release status", e);
+						log.warn("Unable to update release status for release " + release.getName() + "-v"
+								+ release.getVersion(), e);
 					}
+				}
+				else {
+					log.info("Not updating state for {}-v{}", release.getName(), release.getVersion());
 				}
 			}
 		}
+	}
+
+	private boolean checkInfo(Info info) {
+		if (info == null) {
+			throw new IllegalStateException("Info can not be null.");
+		}
+		if (info.getLastDeployed() == null) {
+			throw new IllegalStateException("Info.LastDeployed can not be null.");
+		}
+		return true;
 	}
 
 	/**

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractAssertReleaseDeployedTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractAssertReleaseDeployedTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.deployer.spi.app.AppStatus;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.skipper.domain.InstallProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * @author Mark Pollack
+ */
+public abstract class AbstractAssertReleaseDeployedTest {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	protected void assertReleaseIsDeployedSuccessfully(String releaseName, int releaseVersion)
+			throws InterruptedException {
+		CountDownLatch latch = new CountDownLatch(1);
+		long startTime = System.currentTimeMillis();
+		while (!isDeployed(releaseName, releaseVersion)) {
+			if ((System.currentTimeMillis() - startTime) > 60000) {
+				logger.info("Stopping polling for deployed status after 60 seconds for release={} version={}",
+						releaseName, releaseVersion);
+				fail("Could not determine if release " + releaseName + "-v" + releaseVersion +
+						"was deployed successfully, timed out polling.");
+			}
+			Thread.sleep(10000);
+		}
+		if (isDeployed(releaseName, releaseVersion)) {
+			logger.info("Deployed! release={} version={}", releaseName, releaseVersion);
+			latch.countDown();
+		}
+		assertThat(latch.await(1, TimeUnit.SECONDS)).describedAs("Status check timed out").isTrue();
+	}
+
+	protected boolean allAppsDeployed(List<AppStatus> appStatusList) {
+		boolean allDeployed = true;
+		for (AppStatus appStatus : appStatusList) {
+			if (appStatus.getState() != DeploymentState.deployed) {
+				allDeployed = false;
+				break;
+			}
+		}
+		return allDeployed;
+	}
+
+	protected abstract boolean isDeployed(String releaseName, int releaseVersion);
+
+	protected InstallProperties createInstallProperties(String releaseName) {
+		InstallProperties installProperties = new InstallProperties();
+		installProperties.setReleaseName(releaseName);
+		installProperties.setPlatformName("default");
+		return installProperties;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/LogTestNameRule.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/LogTestNameRule.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Mark Pollack
+ */
+public class LogTestNameRule extends TestWatcher {
+
+	private final static Logger log = LoggerFactory.getLogger("junit.logTestName");
+
+	@Override
+	protected void starting(Description description) {
+		log.info("Starting Test {}", description.getMethodName());
+	}
+
+	@Override
+	protected void finished(Description description) {
+		log.info("Finished Test {}", description.getMethodName());
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/SkipperControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/SkipperControllerTests.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.skipper.server.controller;
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletContext;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.cloud.skipper.domain.InstallProperties;
@@ -52,7 +51,6 @@ public class SkipperControllerTests extends AbstractControllerTests {
 	}
 
 	@Test
-	@Ignore
 	public void packageDeployRequest() throws Exception {
 		String releaseName = "myLogRelease";
 		InstallRequest installRequest = new InstallRequest();
@@ -70,7 +68,6 @@ public class SkipperControllerTests extends AbstractControllerTests {
 	}
 
 	@Test
-	@Ignore
 	public void checkDeployStatus() throws Exception {
 
 		// Deploy
@@ -86,7 +83,6 @@ public class SkipperControllerTests extends AbstractControllerTests {
 	}
 
 	@Test
-	@Ignore
 	public void releaseRollbackAndUndeploy() throws Exception {
 
 		// Deploy
@@ -131,7 +127,6 @@ public class SkipperControllerTests extends AbstractControllerTests {
 	}
 
 	@Test
-	@Ignore
 	public void packageDeployAndUpgrade() throws Exception {
 		String releaseName = "myLog";
 		Release release = install("log", "1.0.0", releaseName);
@@ -144,7 +139,6 @@ public class SkipperControllerTests extends AbstractControllerTests {
 	}
 
 	@Test
-	@Ignore
 	public void testStatusReportsErrorForMissingRelease() throws Exception {
 		// In a real container the response is carried over into the error dispatcher, but
 		// in the mock a new one is created so we have to assert the status at this

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/AboutDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/AboutDocumentation.java
@@ -33,13 +33,10 @@ public class AboutDocumentation extends BaseDocumentation {
 	@Test
 	public void getMetaInformation() throws Exception {
 		this.mockMvc.perform(get("/api/about").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				responseFields(
-					fieldWithPath("name").description("Name of the Skipper server."),
-					fieldWithPath("version").description(
-						"Version of the Skipper server.")
-				)
-			)
-		);
+				.andDo(this.documentationHandler.document(
+						responseFields(
+								fieldWithPath("name").description("Name of the Skipper server."),
+								fieldWithPath("version").description(
+										"Version of the Skipper server."))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
@@ -68,29 +68,34 @@ public class ApiDocumentation extends BaseDocumentation {
 	@Test
 	public void index() throws Exception {
 		this.mockMvc.perform(get("/api")).andExpect(status().isOk()).andDo(this.documentationHandler.document(links(
-			linkWithRel("about").description("Provides meta information of the server"),
-			linkWithRel("upload").description("Uploads a package"),
-			linkWithRel("install").description("Installs a package"),
-			linkWithRel("install/id").description("Installs a package by also providing the package id"),
-			linkWithRel("appDeployerDatas").description("Exposes App Deployer Data"),
-			linkWithRel("repositories").description("Exposes package repositories"),
-			linkWithRel("deployers").description("Exposes deployer"),
-			linkWithRel("releases").description("Exposes release information"),
-			linkWithRel("packageMetadata").description("Provides details for Package Metadata"),
-			linkWithRel("profile").description("Entrypoint to provide ALPS metadata defining simple descriptions of application-level semantics"),
-			linkWithRel("status/name").description("Get the status for the last known release version of the release "
-					+ "by the given release name"),
-			linkWithRel("status/name/version").description("Get the status for the release by the given release name "
-					+ "and version"),
-			linkWithRel("manifest").description("Get a release's manifest"),
-			linkWithRel("manifest/name/version").description("Get a release's manifest by providing name and version"),
-			linkWithRel("upgrade").description("Upgrade a release"),
-			linkWithRel("rollback").description("Rollback the release to a previous or a specific release"),
-			linkWithRel("delete").description("Delete the release"),
-			linkWithRel("history").description("List the history of versions for a given release"),
-			linkWithRel("list").description("List the latest version of releases with status of deployed or failed"),
-			linkWithRel("list/name").description("List the latest version of releases by release name with status of "
-					+ "deployed or failed")
-		)));
+				linkWithRel("about").description("Provides meta information of the server"),
+				linkWithRel("upload").description("Uploads a package"),
+				linkWithRel("install").description("Installs a package"),
+				linkWithRel("install/id").description("Installs a package by also providing the package id"),
+				linkWithRel("appDeployerDatas").description("Exposes App Deployer Data"),
+				linkWithRel("repositories").description("Exposes package repositories"),
+				linkWithRel("deployers").description("Exposes deployer"),
+				linkWithRel("releases").description("Exposes release information"),
+				linkWithRel("packageMetadata").description("Provides details for Package Metadata"),
+				linkWithRel("profile").description(
+						"Entrypoint to provide ALPS metadata defining simple descriptions of application-level semantics"),
+				linkWithRel("status/name")
+						.description("Get the status for the last known release version of the release "
+								+ "by the given release name"),
+				linkWithRel("status/name/version")
+						.description("Get the status for the release by the given release name "
+								+ "and version"),
+				linkWithRel("manifest").description("Get a release's manifest"),
+				linkWithRel("manifest/name/version")
+						.description("Get a release's manifest by providing name and version"),
+				linkWithRel("upgrade").description("Upgrade a release"),
+				linkWithRel("rollback").description("Rollback the release to a previous or a specific release"),
+				linkWithRel("delete").description("Delete the release"),
+				linkWithRel("history").description("List the history of versions for a given release"),
+				linkWithRel("list")
+						.description("List the latest version of releases with status of deployed or failed"),
+				linkWithRel("list/name")
+						.description("List the latest version of releases by release name with status of "
+								+ "deployed or failed"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/AppDeployersDatasDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/AppDeployersDatasDocumentation.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 import org.junit.Test;
 
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -30,25 +29,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class AppDeployersDatasDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getAllAppDeployerDatas() throws Exception {
 		this.mockMvc.perform(
-			get("/api/appDeployerDatas")
-				.param("page", "0")
-				.param("size", "10"))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				super.paginationRequestParameterProperties,
-				super.paginationProperties.and(
-					fieldWithPath("_embedded.appDeployerDatas").description("Array of App Deployer Data objects.")
-				).and(super.defaultLinkProperties),
-				super.linksForSkipper()
-			)
-		);
+				get("/api/appDeployerDatas")
+						.param("page", "0")
+						.param("size", "10"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						super.paginationRequestParameterProperties,
+						super.paginationProperties.and(
+								fieldWithPath("_embedded.appDeployerDatas")
+										.description("Array of App Deployer Data objects."))
+								.and(super.defaultLinkProperties),
+						super.linksForSkipper()));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/BaseDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/BaseDocumentation.java
@@ -48,22 +48,58 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 
 /**
- * Sets up Spring Rest Docs via {@link #setupMocks()} and also provides common snippets to be used by
- * the various documentation tests.
+ * Sets up Spring Rest Docs via {@link #setupMocks()} and also provides common snippets to
+ * be used by the various documentation tests.
  *
  * @author Gunnar Hillert
  */
 public abstract class BaseDocumentation extends AbstractControllerTests {
 
+	@Rule
+	public final JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation();
+	/**
+	 * Snippet, documenting common pagination properties.
+	 */
+	protected final ResponseFieldsSnippet paginationProperties = responseFields(
+			fieldWithPath("page").description("Pagination properties"),
+			fieldWithPath("page.size").description("The size of the page being returned"),
+			fieldWithPath("page.totalElements").description("Total elements available for pagination"),
+			fieldWithPath("page.totalPages").description("Total amount of pages"),
+			fieldWithPath("page.number").description("Page number of the page returned (zero-based)"));
+	/**
+	 * Snippet for link properties. Set to ignore common links.
+	 */
+	protected final List<FieldDescriptor> defaultLinkProperties = Arrays.asList(
+			fieldWithPath("_links.self.href").ignored().optional(),
+			fieldWithPath("_links.self.templated").ignored().optional(),
+			fieldWithPath("_links.profile.href").ignored().optional(),
+			fieldWithPath("_links.repository.href").ignored().optional(),
+			fieldWithPath("_links.search.href").ignored().optional());
+	/**
+	 * Snippet for common pagination-related request parameters.
+	 */
+	protected final RequestParametersSnippet paginationRequestParameterProperties = requestParameters(
+			parameterWithName("page").description("The zero-based page number (optional)"),
+			parameterWithName("size").description("The requested page size (optional)"));
+	protected RestDocumentationResultHandler documentationHandler;
+	protected MockMvc mockMvc;
 	@Autowired
 	WebApplicationContext context;
 
-	@Rule
-	public final JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation();
-
-	protected RestDocumentationResultHandler documentationHandler;
-
-	protected MockMvc mockMvc;
+	/**
+	 * {@link LinksSnippet} for common links. Common links are set to be ignored.
+	 *
+	 * @param descriptors Provide addition link descriptors
+	 * @return the link snipped
+	 */
+	public static LinksSnippet linksForSkipper(LinkDescriptor... descriptors) {
+		return HypermediaDocumentation.links(
+				linkWithRel("self").ignored(),
+				linkWithRel("profile").ignored(),
+				linkWithRel("search").ignored(),
+				linkWithRel("deployer").ignored().optional(),
+				linkWithRel("curies").ignored().optional()).and(descriptors);
+	}
 
 	@Before
 	public void setupMocks() {
@@ -77,57 +113,11 @@ public abstract class BaseDocumentation extends AbstractControllerTests {
 
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
 				.apply(documentationConfiguration(this.restDocumentation).uris()
-				.withScheme("http")
-				.withHost("localhost")
-				.withPort(7577))
+						.withScheme("http")
+						.withHost("localhost")
+						.withPort(7577))
 				.alwaysDo(this.documentationHandler)
-		.build();
-	}
-
-	/**
-	 * Snippet, documenting common pagination properties.
-	 */
-	protected final ResponseFieldsSnippet paginationProperties = responseFields(
-		fieldWithPath("page").description("Pagination properties"),
-		fieldWithPath("page.size").description("The size of the page being returned"),
-		fieldWithPath("page.totalElements").description("Total elements available for pagination"),
-		fieldWithPath("page.totalPages").description("Total amount of pages"),
-		fieldWithPath("page.number").description("Page number of the page returned (zero-based)")
-	);
-
-	/**
-	 * Snippet for link properties. Set to ignore common links.
-	 */
-	protected final List<FieldDescriptor> defaultLinkProperties = Arrays.asList(
-		fieldWithPath("_links.self.href").ignored().optional(),
-		fieldWithPath("_links.self.templated").ignored().optional(),
-		fieldWithPath("_links.profile.href").ignored().optional(),
-		fieldWithPath("_links.repository.href").ignored().optional(),
-		fieldWithPath("_links.search.href").ignored().optional()
-	);
-
-	/**
-	 * Snippet for common pagination-related request parameters.
-	 */
-	protected final RequestParametersSnippet paginationRequestParameterProperties = requestParameters(
-		parameterWithName("page").description("The zero-based page number (optional)"),
-		parameterWithName("size").description("The requested page size (optional)")
-	);
-
-	/**
-	 * {@link LinksSnippet} for common links. Common links are set to be ignored.
-	 *
-	 * @param descriptors Provide addition link descriptors
-	 * @return the link snipped
-	 */
-	public static LinksSnippet linksForSkipper(LinkDescriptor... descriptors) {
-		return HypermediaDocumentation.links(
-			linkWithRel("self").ignored(),
-			linkWithRel("profile").ignored(),
-			linkWithRel("search").ignored(),
-			linkWithRel("deployer").ignored().optional(),
-			linkWithRel("curies").ignored().optional()
-		).and(descriptors);
+				.build();
 	}
 
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -18,12 +18,10 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -36,8 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class DeleteDocumentation extends BaseDocumentation {
 
 	@Test
@@ -49,51 +45,62 @@ public class DeleteDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		installPackage(installRequest);
 
 		this.mockMvc.perform(
-			post("/api/delete/{releaseName}", releaseName)).andDo(print())
+				post("/api/delete/{releaseName}", releaseName)).andDo(print())
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
-					responseFields(
-						fieldWithPath("name").description("Name of the release"),
-						fieldWithPath("version").description("Version of the release"),
-						fieldWithPath("info.status.statusCode").description(
-							String.format("StatusCode of the release's status (%s)",
-								StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-						),
-						fieldWithPath("info.status.platformStatus").description("Status from the underlying platform"),
-						fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
-						fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
-						fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
-						fieldWithPath("info.description").description("Human-friendly 'log entry' about this release"),
-						fieldWithPath("pkg.metadata.apiVersion").description("The Package Index spec version this file is based on"),
-						fieldWithPath("pkg.metadata.origin").description("Indicates the origin of the repository (free form text)"),
-						fieldWithPath("pkg.metadata.repositoryId").description("The repository ID this Package Index file belongs to"),
-						fieldWithPath("pkg.metadata.kind").description("What type of package system is being used"),
-						fieldWithPath("pkg.metadata.name").description("The name of the package"),
-						fieldWithPath("pkg.metadata.version").description("The version of the package"),
-						fieldWithPath("pkg.metadata.packageSourceUrl").description("Location to source code for this package"),
-						fieldWithPath("pkg.metadata.packageHomeUrl").description("The home page of the package"),
-						fieldWithPath("pkg.metadata.tags").description("A comma separated list of tags to use for searching"),
-						fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
-						fieldWithPath("pkg.metadata.description").description("Brief description of the package"),
-						fieldWithPath("pkg.metadata.sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-						fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
-						fieldWithPath("pkg.templates[].name").description("Name is the path-like name of the template"),
-						fieldWithPath("pkg.templates[].data").description("Data is the template as string data"),
-						fieldWithPath("pkg.dependencies").description("The packages that this package depends upon"),
-						fieldWithPath("pkg.configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("pkg.fileHolders").description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
-						fieldWithPath("configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("manifest").description("The manifest of the release"),
-						fieldWithPath("platformName").description("Platform name of the release")
-					)
-				));
+						responseFields(
+								fieldWithPath("name").description("Name of the release"),
+								fieldWithPath("version").description("Version of the release"),
+								fieldWithPath("info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("pkg.metadata.repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
+								fieldWithPath("pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("manifest").description("The manifest of the release"),
+								fieldWithPath("platformName").description("Platform name of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 import org.junit.Test;
 
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -30,8 +29,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class DeployersDocumentation extends BaseDocumentation {
 
 	@Test

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
@@ -18,12 +18,10 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -36,8 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class HistoryDocumentation extends BaseDocumentation {
 
 	@Test
@@ -49,52 +45,64 @@ public class HistoryDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		installPackage(installRequest);
 
 		this.mockMvc.perform(
-			get("/api//history/{releaseName}/{maxRevisions}", releaseName, 3)).andDo(print())
+				get("/api//history/{releaseName}/{maxRevisions}", releaseName, 3)).andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-					responseFields(
-						fieldWithPath("[].name").description("Name of the release"),
-						fieldWithPath("[].version").description("Version of the release"),
-						fieldWithPath("[].info.status.statusCode").description(
-							String.format("StatusCode of the release's status (%s)",
-								StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-						),
-						fieldWithPath("[].info.status.platformStatus").description("Status from the underlying platform"),
-						fieldWithPath("[].info.firstDeployed").description("Date/Time of first deployment"),
-						fieldWithPath("[].info.lastDeployed").description("Date/Time of last deployment"),
-						fieldWithPath("[].info.deleted").description("Date/Time of when the release was deleted"),
-						fieldWithPath("[].info.description").description("Human-friendly 'log entry' about this release"),
-						fieldWithPath("[].pkg.metadata.apiVersion").description("The Package Index spec version this file is based on"),
-						fieldWithPath("[].pkg.metadata.origin").description("Indicates the origin of the repository (free form text)"),
-						fieldWithPath("[].pkg.metadata.repositoryId").description("The repository ID this Package Index file belongs to"),
-						fieldWithPath("[].pkg.metadata.kind").description("What type of package system is being used"),
-						fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
-						fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
-						fieldWithPath("[].pkg.metadata.packageSourceUrl").description("Location to source code for this package"),
-						fieldWithPath("[].pkg.metadata.packageHomeUrl").description("The home page of the package"),
-						fieldWithPath("[].pkg.metadata.tags").description("A comma separated list of tags to use for searching"),
-						fieldWithPath("[].pkg.metadata.maintainer").description("Who is maintaining this package"),
-						fieldWithPath("[].pkg.metadata.description").description("Brief description of the package"),
-						fieldWithPath("[].pkg.metadata.sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-						fieldWithPath("[].pkg.metadata.iconUrl").description("Url location of a icon"),
-						fieldWithPath("[].pkg.templates[].name").description("Name is the path-like name of the template"),
-						fieldWithPath("[].pkg.templates[].data").description("Data is the template as string data"),
-						fieldWithPath("[].pkg.dependencies").description("The packages that this package depends upon"),
-						fieldWithPath("[].pkg.configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("[].pkg.fileHolders").description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
-						fieldWithPath("[].configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("[].manifest").description("The manifest of the release"),
-						fieldWithPath("[].platformName").description("Platform name of the release")
-					)
-				));
+						responseFields(
+								fieldWithPath("[].name").description("Name of the release"),
+								fieldWithPath("[].version").description("Version of the release"),
+								fieldWithPath("[].info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("[].info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("[].info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("[].info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("[].info.deleted")
+										.description("Date/Time of when the release was deleted"),
+								fieldWithPath("[].info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("[].pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("[].pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("[].pkg.metadata.repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("[].pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("[].pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("[].pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("[].pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("[].pkg.metadata.maintainer")
+										.description("Who is maintaining this package"),
+								fieldWithPath("[].pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("[].pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("[].pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("[].pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("[].pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("[].pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("[].pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("[].pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("[].configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("[].manifest").description("The manifest of the release"),
+								fieldWithPath("[].platformName").description("Platform name of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
@@ -27,7 +27,6 @@ import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -40,9 +39,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot",
-		"spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
 public class InstallDocumentation extends BaseDocumentation {
 
 	@Test
@@ -55,53 +51,64 @@ public class InstallDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
 		mockMvc.perform(post("/api/install").accept(MediaType.APPLICATION_JSON).contentType(contentType)
-			.content(convertObjectToJson(installRequest))).andDo(print())
-			.andExpect(status().isCreated())
-			.andDo(this.documentationHandler.document(
-				responseFields(
-					fieldWithPath("name").description("Name of the release"),
-					fieldWithPath("version").description("Version of the release"),
-					fieldWithPath("info.status.statusCode").description(
-						String.format("StatusCode of the release's status (%s)",
-							StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-					),
-					fieldWithPath("info.status.platformStatus").description("Status from the underlying platform"),
-					fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
-					fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
-					fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
-					fieldWithPath("info.description").description("Human-friendly 'log entry' about this release"),
-					fieldWithPath("pkg.metadata.origin").description("Indicates the origin of the repository (free form text)"),
-					fieldWithPath("pkg.metadata.apiVersion").description("The Package Index spec version this file is based on"),
-					fieldWithPath("pkg.metadata.repositoryId").description("The repository ID this Package Index file belongs to"),
-					fieldWithPath("pkg.metadata.kind").description("What type of package system is being used"),
-					fieldWithPath("pkg.metadata.name").description("The name of the package"),
-					fieldWithPath("pkg.metadata.version").description("The version of the package"),
-					fieldWithPath("pkg.metadata.packageSourceUrl").description("Location to source code for this package"),
-					fieldWithPath("pkg.metadata.packageHomeUrl").description("The home page of the package"),
-					fieldWithPath("pkg.metadata.tags").description("A comma separated list of tags to use for searching"),
-					fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
-					fieldWithPath("pkg.metadata.description").description("Brief description of the package"),
-					fieldWithPath("pkg.metadata.sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-					fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
-					fieldWithPath("pkg.templates[].name").description("Name is the path-like name of the template"),
-					fieldWithPath("pkg.templates[].data").description("Data is the template as string data"),
-					fieldWithPath("pkg.dependencies").description("The packages that this package depends upon"),
-					fieldWithPath("pkg.configValues.raw").description("The raw YAML string of configuration values"),
-					fieldWithPath("pkg.fileHolders").description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
-					fieldWithPath("configValues.raw").description("The raw YAML string of configuration values"),
-					fieldWithPath("manifest").description("The manifest of the release"),
-					fieldWithPath("platformName").description("Platform name of the release")
-				)
-			));
+				.content(convertObjectToJson(installRequest))).andDo(print())
+				.andExpect(status().isCreated())
+				.andDo(this.documentationHandler.document(
+						responseFields(
+								fieldWithPath("name").description("Name of the release"),
+								fieldWithPath("version").description("Version of the release"),
+								fieldWithPath("info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("pkg.metadata.repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
+								fieldWithPath("pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("manifest").description("The manifest of the release"),
+								fieldWithPath("platformName").description("Platform name of the release"))));
 	}
 
 	@Test
@@ -114,59 +121,69 @@ public class InstallDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		final Release release = installPackage(installRequest);
 
 		final String releaseName2 = "myLogReleaseWithInstallProperties";
-		final InstallProperties installProperties2 = new InstallProperties();
-		installProperties2.setReleaseName(releaseName2);
-		installProperties2.setPlatformName("test");
+		final InstallProperties installProperties2 = createInstallProperties(releaseName2);
 
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
-		mockMvc.perform(post("/api/install/{packageMetaDataId}", release.getId()).accept(MediaType.APPLICATION_JSON).contentType(contentType)
-			.content(convertObjectToJson(installProperties2))).andDo(print())
-			.andExpect(status().isCreated())
-			.andDo(this.documentationHandler.document(
-				responseFields(
-					fieldWithPath("name").description("Name of the release"),
-					fieldWithPath("version").description("Version of the release"),
-					fieldWithPath("info.status.statusCode").description(
-						String.format("StatusCode of the release's status (%s)",
-							StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-					),
-					fieldWithPath("info.status.platformStatus").description("Status from the underlying platform"),
-					fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
-					fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
-					fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
-					fieldWithPath("info.description").description("Human-friendly 'log entry' about this release"),
-					fieldWithPath("pkg.metadata.apiVersion").description("The Package Index spec version this file is based on"),
-					fieldWithPath("pkg.metadata.origin").description("Indicates the origin of the repository (free form text)"),
-					fieldWithPath("pkg.metadata.repositoryId").description("The repository ID this Package Index file belongs to"),
-					fieldWithPath("pkg.metadata.kind").description("What type of package system is being used"),
-					fieldWithPath("pkg.metadata.name").description("The name of the package"),
-					fieldWithPath("pkg.metadata.version").description("The version of the package"),
-					fieldWithPath("pkg.metadata.packageSourceUrl").description("Location to source code for this package"),
-					fieldWithPath("pkg.metadata.packageHomeUrl").description("The home page of the package"),
-					fieldWithPath("pkg.metadata.tags").description("A comma separated list of tags to use for searching"),
-					fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
-					fieldWithPath("pkg.metadata.description").description("Brief description of the package"),
-					fieldWithPath("pkg.metadata.sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-					fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
-					fieldWithPath("pkg.templates[].name").description("Name is the path-like name of the template"),
-					fieldWithPath("pkg.templates[].data").description("Data is the template as string data"),
-					fieldWithPath("pkg.dependencies").description("The packages that this package depends upon"),
-					fieldWithPath("pkg.configValues.raw").description("The raw YAML string of configuration values"),
-					fieldWithPath("pkg.fileHolders").description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
-					fieldWithPath("configValues.raw").description("The raw YAML string of configuration values"),
-					fieldWithPath("manifest").description("The manifest of the release"),
-					fieldWithPath("platformName").description("Platform name of the release")
-				)
-			));
+		mockMvc.perform(post("/api/install/{packageMetaDataId}", release.getId()).accept(MediaType.APPLICATION_JSON)
+				.contentType(contentType)
+				.content(convertObjectToJson(installProperties2))).andDo(print())
+				.andExpect(status().isCreated())
+				.andDo(this.documentationHandler.document(
+						responseFields(
+								fieldWithPath("name").description("Name of the release"),
+								fieldWithPath("version").description("Version of the release"),
+								fieldWithPath("info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("pkg.metadata.repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
+								fieldWithPath("pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("manifest").description("The manifest of the release"),
+								fieldWithPath("platformName").description("Platform name of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.StatusCode;
@@ -36,9 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot",
-		"spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
+@TestPropertySource(properties = { "spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
 public class ListDocumentation extends BaseDocumentation {
 
 	@Test
@@ -50,52 +47,65 @@ public class ListDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		installPackage(installRequest);
 
 		this.mockMvc.perform(
-			get("/api/list")).andDo(print())
+				get("/api/list")).andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-					responseFields(
-						fieldWithPath("[].name").description("Name of the release"),
-						fieldWithPath("[].version").description("Version of the release"),
-						fieldWithPath("[].info.status.statusCode").description(
-							String.format("StatusCode of the release's status (%s)",
-								StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-						),
-						fieldWithPath("[].info.status.platformStatus").description("Status from the underlying platform"),
-						fieldWithPath("[].info.firstDeployed").description("Date/Time of first deployment"),
-						fieldWithPath("[].info.lastDeployed").description("Date/Time of last deployment"),
-						fieldWithPath("[].info.deleted").description("Date/Time of when the release was deleted"),
-						fieldWithPath("[].info.description").description("Human-friendly 'log entry' about this release"),
-						fieldWithPath("[].pkg.metadata.apiVersion").description("The Package Index spec version this file is based on"),
-						fieldWithPath("[].pkg.metadata.origin").description("Indicates the origin of the repository (free form text)"),
-						fieldWithPath("[].pkg.metadata.repositoryId").description("The repository ID this Package Index file belongs to"),
-						fieldWithPath("[].pkg.metadata.kind").description("What type of package system is being used"),
-						fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
-						fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
-						fieldWithPath("[].pkg.metadata.packageSourceUrl").description("Location to source code for this package"),
-						fieldWithPath("[].pkg.metadata.packageHomeUrl").description("The home page of the package"),
-						fieldWithPath("[].pkg.metadata.tags").description("A comma separated list of tags to use for searching"),
-						fieldWithPath("[].pkg.metadata.maintainer").description("Who is maintaining this package"),
-						fieldWithPath("[].pkg.metadata.description").description("Brief description of the package"),
-						fieldWithPath("[].pkg.metadata.sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-						fieldWithPath("[].pkg.metadata.iconUrl").description("Url location of a icon"),
-						fieldWithPath("[].pkg.templates[].name").description("Name is the path-like name of the template"),
-						fieldWithPath("[].pkg.templates[].data").description("Data is the template as string data"),
-						fieldWithPath("[].pkg.dependencies").description("The packages that this package depends upon"),
-						fieldWithPath("[].pkg.configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("[].pkg.fileHolders").description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
-						fieldWithPath("[].configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("[].manifest").description("The manifest of the release"),
-						fieldWithPath("[].platformName").description("Platform name of the release")
-					)
-				));
+						responseFields(
+								fieldWithPath("[].name").description("Name of the release"),
+								fieldWithPath("[].version").description("Version of the release"),
+								fieldWithPath("[].info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("[].info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("[].info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("[].info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("[].info.deleted")
+										.description("Date/Time of when the release was deleted"),
+								fieldWithPath("[].info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("[].pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("[].pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("[].pkg.metadata.repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("[].pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("[].pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("[].pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("[].pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("[].pkg.metadata.maintainer")
+										.description("Who is maintaining this package"),
+								fieldWithPath("[].pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("[].pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("[].pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("[].pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("[].pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("[].pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("[].pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("[].pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("[].configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("[].manifest").description("The manifest of the release"),
+								fieldWithPath("[].platformName").description("Platform name of the release"))));
 	}
 
 	@Test
@@ -107,51 +117,64 @@ public class ListDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		installPackage(installRequest);
 
 		this.mockMvc.perform(
-			get("/api/list/{releaseName}", releaseName)).andDo(print())
+				get("/api/list/{releaseName}", releaseName)).andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-					responseFields(
-						fieldWithPath("[].name").description("Name of the release"),
-						fieldWithPath("[].version").description("Version of the release"),
-						fieldWithPath("[].info.status.statusCode").description(
-							String.format("StatusCode of the release's status (%s)",
-								StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-						),
-						fieldWithPath("[].info.status.platformStatus").description("Status from the underlying platform"),
-						fieldWithPath("[].info.firstDeployed").description("Date/Time of first deployment"),
-						fieldWithPath("[].info.lastDeployed").description("Date/Time of last deployment"),
-						fieldWithPath("[].info.deleted").description("Date/Time of when the release was deleted"),
-						fieldWithPath("[].info.description").description("Human-friendly 'log entry' about this release"),
-						fieldWithPath("[].pkg.metadata.apiVersion").description("The Package Index spec version this file is based on"),
-						fieldWithPath("[].pkg.metadata.origin").description("Indicates the origin of the repository (free form text)"),
-						fieldWithPath("[].pkg.metadata.repositoryId").description("The repository ID this Package Index file belongs to"),
-						fieldWithPath("[].pkg.metadata.kind").description("What type of package system is being used"),
-						fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
-						fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
-						fieldWithPath("[].pkg.metadata.packageSourceUrl").description("Location to source code for this package"),
-						fieldWithPath("[].pkg.metadata.packageHomeUrl").description("The home page of the package"),
-						fieldWithPath("[].pkg.metadata.tags").description("A comma separated list of tags to use for searching"),
-						fieldWithPath("[].pkg.metadata.maintainer").description("Who is maintaining this package"),
-						fieldWithPath("[].pkg.metadata.description").description("Brief description of the package"),
-						fieldWithPath("[].pkg.metadata.sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-						fieldWithPath("[].pkg.metadata.iconUrl").description("Url location of a icon"),
-						fieldWithPath("[].pkg.templates[].name").description("Name is the path-like name of the template"),
-						fieldWithPath("[].pkg.templates[].data").description("Data is the template as string data"),
-						fieldWithPath("[].pkg.dependencies").description("The packages that this package depends upon"),
-						fieldWithPath("[].pkg.configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("[].pkg.fileHolders").description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
-						fieldWithPath("[].configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("[].manifest").description("The manifest of the release"),
-						fieldWithPath("[].platformName").description("Platform name of the release")
-					)
-				));
+						responseFields(
+								fieldWithPath("[].name").description("Name of the release"),
+								fieldWithPath("[].version").description("Version of the release"),
+								fieldWithPath("[].info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("[].info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("[].info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("[].info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("[].info.deleted")
+										.description("Date/Time of when the release was deleted"),
+								fieldWithPath("[].info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("[].pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("[].pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("[].pkg.metadata.repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("[].pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("[].pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("[].pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("[].pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("[].pkg.metadata.maintainer")
+										.description("Who is maintaining this package"),
+								fieldWithPath("[].pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("[].pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("[].pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("[].pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("[].pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("[].pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("[].pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("[].pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("[].configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("[].manifest").description("The manifest of the release"),
+								fieldWithPath("[].platformName").description("Platform name of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ManifestDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ManifestDocumentation.java
@@ -20,7 +20,6 @@ import java.nio.charset.Charset;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
@@ -37,9 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot",
-		"spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
+@TestPropertySource(properties = { "spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
 public class ManifestDocumentation extends BaseDocumentation {
 
 	@Test
@@ -51,10 +48,7 @@ public class ManifestDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		final Release release = installPackage(installRequest);
 
@@ -62,12 +56,12 @@ public class ManifestDocumentation extends BaseDocumentation {
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
 		this.mockMvc.perform(
-			get("/api/manifest/{releaseName}", release.getName()).accept(MediaType.APPLICATION_JSON).contentType(contentType)
-				).andDo(print())
+				get("/api/manifest/{releaseName}", release.getName()).accept(MediaType.APPLICATION_JSON)
+						.contentType(contentType))
+				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-					responseBody()
-				));
+						responseBody()));
 	}
 
 	@Test
@@ -79,20 +73,16 @@ public class ManifestDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		final Release release = installPackage(installRequest);
 
 		this.mockMvc.perform(
-			get("/api/manifest/{releaseName}/{releaseVersion}",
-					release.getName(), release.getVersion()))
+				get("/api/manifest/{releaseName}/{releaseVersion}",
+						release.getName(), release.getVersion()))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
-						responseBody()
-				));
+						responseBody()));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 import org.junit.Test;
 
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -33,73 +32,89 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class PackageMetadataDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getAllPackageMetadata() throws Exception {
 		this.mockMvc.perform(
-			get("/api/packageMetadata")
-				.param("page", "0")
-				.param("size", "10"))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				super.paginationRequestParameterProperties,
-				super.paginationProperties.and(
-					fieldWithPath("_embedded.packageMetadata").description("Contains a collection of Package Metadata items"),
-					fieldWithPath("_embedded.packageMetadata[].apiVersion").description("The Package Index spec version this file is based on"),
-					fieldWithPath("_embedded.packageMetadata[].origin").description("Indicates the origin of the repository (free form text)"),
-					fieldWithPath("_embedded.packageMetadata[].repositoryId").description("The repository ID this Package Index file belongs to"),
-					fieldWithPath("_embedded.packageMetadata[].kind").description("What type of package system is being used"),
-					fieldWithPath("_embedded.packageMetadata[].name").description("The name of the package"),
-					fieldWithPath("_embedded.packageMetadata[].version").description("The version of the package"),
-					fieldWithPath("_embedded.packageMetadata[].packageSourceUrl").description("Location to source code for this package"),
-					fieldWithPath("_embedded.packageMetadata[].packageHomeUrl").description("The home page of the package"),
-					fieldWithPath("_embedded.packageMetadata[].tags").description("A comma separated list of tags to use for searching"),
-					fieldWithPath("_embedded.packageMetadata[].maintainer").description("Who is maintaining this package"),
-					fieldWithPath("_embedded.packageMetadata[].description").description("Brief description of the package"),
-					fieldWithPath("_embedded.packageMetadata[].sha256").description(
-							"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-					fieldWithPath("_embedded.packageMetadata[].iconUrl")
-							.description("Url location of a icon"),
-					fieldWithPath("_embedded.packageMetadata[]._links.self.href").ignored(),
-					fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.href").ignored(),
-					fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.templated").ignored(),
-					fieldWithPath("_embedded.packageMetadata[]._links.install.href").ignored())
-					.and(super.defaultLinkProperties),
-				super.linksForSkipper()));
+				get("/api/packageMetadata")
+						.param("page", "0")
+						.param("size", "10"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						super.paginationRequestParameterProperties,
+						super.paginationProperties.and(
+								fieldWithPath("_embedded.packageMetadata")
+										.description("Contains a collection of Package Metadata items"),
+								fieldWithPath("_embedded.packageMetadata[].apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("_embedded.packageMetadata[].origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("_embedded.packageMetadata[].repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("_embedded.packageMetadata[].kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("_embedded.packageMetadata[].name")
+										.description("The name of the package"),
+								fieldWithPath("_embedded.packageMetadata[].version")
+										.description("The version of the package"),
+								fieldWithPath("_embedded.packageMetadata[].packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("_embedded.packageMetadata[].packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("_embedded.packageMetadata[].tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("_embedded.packageMetadata[].maintainer")
+										.description("Who is maintaining this package"),
+								fieldWithPath("_embedded.packageMetadata[].description")
+										.description("Brief description of the package"),
+								fieldWithPath("_embedded.packageMetadata[].sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("_embedded.packageMetadata[].iconUrl")
+										.description("Url location of a icon"),
+								fieldWithPath("_embedded.packageMetadata[]._links.self.href").ignored(),
+								fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.href").ignored(),
+								fieldWithPath("_embedded.packageMetadata[]._links.packageMetadata.templated").ignored(),
+								fieldWithPath("_embedded.packageMetadata[]._links.install.href").ignored())
+								.and(super.defaultLinkProperties),
+						super.linksForSkipper()));
 	}
 
 	@Test
 	public void getPackageMetadataDetails() throws Exception {
-		deploy("log", "1.0.0", "test2");
+		install("log", "1.0.0", "test2");
 
 		this.mockMvc.perform(
-			get("/api/packageMetadata/{packageMetadataId}", 1))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				pathParameters(
-					parameterWithName("packageMetadataId").description("The id of the package to query")),
-				responseFields(
-					fieldWithPath("apiVersion").description("The Package Index spec version this file is based on"),
-					fieldWithPath("origin").description("Indicates the origin of the repository (free form text)"),
-					fieldWithPath("repositoryId").description("The repository ID this Package Index file belongs to"),
-					fieldWithPath("kind").description("What type of package system is being used"),
-					fieldWithPath("name").description("The name of the package"),
-					fieldWithPath("version").description("The version of the package"),
-					fieldWithPath("packageSourceUrl").description("Location to source code for this package"),
-					fieldWithPath("packageHomeUrl").description("The home page of the package"),
-					fieldWithPath("tags").description("A comma separated list of tags to use for searching"),
-					fieldWithPath("maintainer").description("Who is maintaining this package"),
-					fieldWithPath("description").description("Brief description of the package"),
-					fieldWithPath("sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-					fieldWithPath("iconUrl").description("Url location of a icon"),
-					fieldWithPath("_links.packageMetadata.href").ignored(),
-					fieldWithPath("_links.packageMetadata.templated").ignored(),
-					fieldWithPath("_links.install.href").ignored())
-				.and(super.defaultLinkProperties)));
+				get("/api/packageMetadata/{packageMetadataId}", 1))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						pathParameters(
+								parameterWithName("packageMetadataId").description("The id of the package to query")),
+						responseFields(
+								fieldWithPath("apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("kind").description("What type of package system is being used"),
+								fieldWithPath("name").description("The name of the package"),
+								fieldWithPath("version").description("The version of the package"),
+								fieldWithPath("packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("packageHomeUrl").description("The home page of the package"),
+								fieldWithPath("tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("maintainer").description("Who is maintaining this package"),
+								fieldWithPath("description").description("Brief description of the package"),
+								fieldWithPath("sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("iconUrl").description("Url location of a icon"),
+								fieldWithPath("_links.packageMetadata.href").ignored(),
+								fieldWithPath("_links.packageMetadata.templated").ignored(),
+								fieldWithPath("_links.install.href").ignored())
+										.and(super.defaultLinkProperties)));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 import org.junit.Test;
 
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -30,25 +29,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class ReleasesDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getAllReleases() throws Exception {
 		this.mockMvc.perform(
-			get("/api/releases")
-				.param("page", "0")
-				.param("size", "10"))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				super.paginationRequestParameterProperties,
-				super.paginationProperties.and(
-					fieldWithPath("_embedded.releases").description("Provides a list of releases")
-				).and(super.defaultLinkProperties),
-				super.linksForSkipper()
-			)
-		);
+				get("/api/releases")
+						.param("page", "0")
+						.param("size", "10"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						super.paginationRequestParameterProperties,
+						super.paginationProperties.and(
+								fieldWithPath("_embedded.releases").description("Provides a list of releases"))
+								.and(super.defaultLinkProperties),
+						super.linksForSkipper()));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoriesDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoriesDocumentation.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 import org.junit.Test;
 
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -33,54 +32,53 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class RepositoriesDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getAllRepositories() throws Exception {
 		this.mockMvc.perform(
-			get("/api/repositories")
-				.param("page", "0")
-				.param("size", "10"))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				super.paginationRequestParameterProperties,
-				super.paginationProperties.and(
-					fieldWithPath("_embedded.repositories").description("Contains a collection of Repositories"),
-					fieldWithPath("_embedded.repositories[].name").description("Name of the Repository"),
-					fieldWithPath("_embedded.repositories[].url").description("Url of the Repository"),
-					fieldWithPath("_embedded.repositories[].sourceUrl").description("Source Url of the repository"),
-					fieldWithPath("_embedded.repositories[].description").description("Description of the Repository"),
-					fieldWithPath("_embedded.repositories[].local").description("Is the repo local?"),
-					fieldWithPath("_embedded.repositories[].repoOrder").description("Order of the Repository"),
-					fieldWithPath("_embedded.repositories[]._links.self.href").ignored(),
-					fieldWithPath("_embedded.repositories[]._links.repository.href").ignored()
-				).and(super.defaultLinkProperties))
-			);
+				get("/api/repositories")
+						.param("page", "0")
+						.param("size", "10"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						super.paginationRequestParameterProperties,
+						super.paginationProperties.and(
+								fieldWithPath("_embedded.repositories")
+										.description("Contains a collection of Repositories"),
+								fieldWithPath("_embedded.repositories[].name").description("Name of the Repository"),
+								fieldWithPath("_embedded.repositories[].url").description("Url of the Repository"),
+								fieldWithPath("_embedded.repositories[].sourceUrl")
+										.description("Source Url of the repository"),
+								fieldWithPath("_embedded.repositories[].description")
+										.description("Description of the Repository"),
+								fieldWithPath("_embedded.repositories[].local").description("Is the repo local?"),
+								fieldWithPath("_embedded.repositories[].repoOrder")
+										.description("Order of the Repository"),
+								fieldWithPath("_embedded.repositories[]._links.self.href").ignored(),
+								fieldWithPath("_embedded.repositories[]._links.repository.href").ignored())
+								.and(super.defaultLinkProperties)));
 	}
 
 	@Test
 	public void getSingleRepository() throws Exception {
-		deploy("log", "1.0.0", "test2");
+		install("log", "1.0.0", "test2");
 
 		this.mockMvc.perform(
-			get("/api/repositories/{repositoryId}", 1))
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andDo(this.documentationHandler.document(
-				pathParameters(
-					parameterWithName("repositoryId").description("The id of the repository to query")
-				),
-				responseFields(
-					fieldWithPath("name").description("Name of the Repository"),
-					fieldWithPath("url").description("URL of the Repository"),
-					fieldWithPath("description").description("Description of the Repository"),
-					fieldWithPath("local").description("Is the repo local?"),
-					fieldWithPath("repoOrder").description("Order of the Repository"),
-					fieldWithPath("sourceUrl").description("Source URL of the repository")
-				).and(super.defaultLinkProperties))
-			);
+				get("/api/repositories/{repositoryId}", 1))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						pathParameters(
+								parameterWithName("repositoryId").description("The id of the repository to query")),
+						responseFields(
+								fieldWithPath("name").description("Name of the Repository"),
+								fieldWithPath("url").description("URL of the Repository"),
+								fieldWithPath("description").description("Description of the Repository"),
+								fieldWithPath("local").description("Is the repo local?"),
+								fieldWithPath("repoOrder").description("Order of the Repository"),
+								fieldWithPath("sourceUrl").description("Source URL of the repository"))
+										.and(super.defaultLinkProperties)));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
@@ -18,12 +18,12 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
+import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -36,8 +36,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class RollbackDocumentation extends BaseDocumentation {
 
 	@Test
@@ -49,52 +47,66 @@ public class RollbackDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		installPackage(installRequest);
 		upgrade("log", "1.1.0", releaseName);
 
-		this.mockMvc.perform(
-			post("/api/rollback/{releaseName}/1", releaseName)).andDo(print())
+		MvcResult result = this.mockMvc.perform(
+				post("/api/rollback/{releaseName}/1", releaseName)).andDo(print())
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
-					responseFields(
-						fieldWithPath("name").description("Name of the release"),
-						fieldWithPath("version").description("Version of the release"),
-						fieldWithPath("info.status.statusCode").description(
-							String.format("StatusCode of the release's status (%s)",
-								StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-						),
-						fieldWithPath("info.status.platformStatus").description("Status from the underlying platform"),
-						fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
-						fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
-						fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
-						fieldWithPath("info.description").description("Human-friendly 'log entry' about this release"),
-						fieldWithPath("pkg.metadata.apiVersion").description("The Package Index spec version this file is based on"),
-						fieldWithPath("pkg.metadata.origin").description("Indicates the origin of the repository (free form text)"),
-						fieldWithPath("pkg.metadata.repositoryId").description("The repository ID this Package Index file belongs to"),
-						fieldWithPath("pkg.metadata.kind").description("What type of package system is being used"),
-						fieldWithPath("pkg.metadata.name").description("The name of the package"),
-						fieldWithPath("pkg.metadata.version").description("The version of the package"),
-						fieldWithPath("pkg.metadata.packageSourceUrl").description("Location to source code for this package"),
-						fieldWithPath("pkg.metadata.packageHomeUrl").description("The home page of the package"),
-						fieldWithPath("pkg.metadata.tags").description("A comma separated list of tags to use for searching"),
-						fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
-						fieldWithPath("pkg.metadata.description").description("Brief description of the package"),
-						fieldWithPath("pkg.metadata.sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-						fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
-						fieldWithPath("pkg.templates[].name").description("Name is the path-like name of the template"),
-						fieldWithPath("pkg.templates[].data").description("Data is the template as string data"),
-						fieldWithPath("pkg.dependencies").description("The packages that this package depends upon"),
-						fieldWithPath("pkg.configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("pkg.fileHolders").description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
-						fieldWithPath("configValues.raw").description("The raw YAML string of configuration values"),
-						fieldWithPath("manifest").description("The manifest of the release"),
-						fieldWithPath("platformName").description("Platform name of the release")
-					)
-				));
+						responseFields(
+								fieldWithPath("name").description("Name of the release"),
+								fieldWithPath("version").description("Version of the release"),
+								fieldWithPath("info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("pkg.metadata.repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
+								fieldWithPath("pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("manifest").description("The manifest of the release"),
+								fieldWithPath("platformName").description("Platform name of the release"))))
+				.andReturn();
+		Release release = convertContentToRelease(result.getResponse().getContentAsString());
+		assertReleaseIsDeployedSuccessfully(releaseName, release.getVersion());
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
@@ -37,9 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot",
-		"spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
+@TestPropertySource(properties = { "spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
 public class StatusDocumentation extends BaseDocumentation {
 
 	@Test
@@ -51,10 +48,7 @@ public class StatusDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		final Release release = installPackage(installRequest);
 
@@ -84,10 +78,7 @@ public class StatusDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		final Release release = installPackage(installRequest);
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
@@ -20,15 +20,15 @@ import java.nio.charset.Charset;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
+import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -41,8 +41,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
 public class UpgradeDocumentation extends BaseDocumentation {
 
 	@Test
@@ -54,13 +52,10 @@ public class UpgradeDocumentation extends BaseDocumentation {
 		packageIdentifier.setPackageVersion("1.0.0");
 		packageIdentifier.setRepositoryName("notused");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		final InstallProperties installProperties = new InstallProperties();
-		installProperties.setReleaseName(releaseName);
-		installProperties.setPlatformName("test");
-		installRequest.setInstallProperties(installProperties);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
 		installPackage(installRequest);
-		sleep();
+
 		final String packageVersion = "1.1.0";
 		final String packageName = "log";
 
@@ -75,46 +70,64 @@ public class UpgradeDocumentation extends BaseDocumentation {
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
-		this.mockMvc.perform(post("/api/upgrade").accept(MediaType.APPLICATION_JSON).contentType(contentType)
-			.content(convertObjectToJson(upgradeRequest))).andDo(print())
-			.andExpect(status().isCreated())
-			.andDo(this.documentationHandler.document(
-				responseFields(
-					fieldWithPath("name").description("Name of the release"),
-					fieldWithPath("version").description("Version of the release"),
-					fieldWithPath("info.status.statusCode").description(
-						String.format("StatusCode of the release's status (%s)",
-							StringUtils.arrayToCommaDelimitedString(StatusCode.values()))
-					),
-					fieldWithPath("info.status.platformStatus").description("Status from the underlying platform"),
-					fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
-					fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
-					fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
-					fieldWithPath("info.description").description("Human-friendly 'log entry' about this release"),
-					fieldWithPath("pkg.metadata.apiVersion").description("The Package Index spec version this file is based on"),
-					fieldWithPath("pkg.metadata.origin").description("Indicates the origin of the repository (free form text)"),
-					fieldWithPath("pkg.metadata.repositoryId").description("The repository ID this Package Index file belongs to"),
-					fieldWithPath("pkg.metadata.kind").description("What type of package system is being used"),
-					fieldWithPath("pkg.metadata.name").description("The name of the package"),
-					fieldWithPath("pkg.metadata.version").description("The version of the package"),
-					fieldWithPath("pkg.metadata.packageSourceUrl").description("Location to source code for this package"),
-					fieldWithPath("pkg.metadata.packageHomeUrl").description("The home page of the package"),
-					fieldWithPath("pkg.metadata.tags").description("A comma separated list of tags to use for searching"),
-					fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
-					fieldWithPath("pkg.metadata.description").description("Brief description of the package"),
-					fieldWithPath("pkg.metadata.sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-					fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
-					fieldWithPath("pkg.templates[].name").description("Name is the path-like name of the template"),
-					fieldWithPath("pkg.templates[].data").description("Data is the template as string data"),
-					fieldWithPath("pkg.dependencies").description("The packages that this package depends upon"),
-					fieldWithPath("pkg.configValues.raw").description("The raw YAML string of configuration values"),
-					fieldWithPath("pkg.fileHolders").description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
-					fieldWithPath("configValues.raw").description("The raw YAML string of configuration values"),
-					fieldWithPath("manifest").description("The manifest of the release"),
-					fieldWithPath("platformName").description("Platform name of the release")
-				)
-			));
-		sleep();
+		MvcResult result = this.mockMvc
+				.perform(post("/api/upgrade").accept(MediaType.APPLICATION_JSON).contentType(contentType)
+						.content(convertObjectToJson(upgradeRequest)))
+				.andDo(print())
+				.andExpect(status().isCreated())
+				.andDo(this.documentationHandler.document(
+						responseFields(
+								fieldWithPath("name").description("Name of the release"),
+								fieldWithPath("version").description("Version of the release"),
+								fieldWithPath("info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("pkg.metadata.repositoryId")
+										.description("The repository ID this Package Index file belongs to"),
+								fieldWithPath("pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
+								fieldWithPath("pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("manifest").description("The manifest of the release"),
+								fieldWithPath("platformName").description("Platform name of the release"))))
+				.andReturn();
+		Release release = convertContentToRelease(result.getResponse().getContentAsString());
+		assertReleaseIsDeployedSuccessfully(releaseName, release.getVersion());
 	}
 
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UploadDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UploadDocumentation.java
@@ -42,9 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.platform.local.accounts[test].key=value",
-		"maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot",
-		"spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
+@TestPropertySource(properties = { "spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
 public class UploadDocumentation extends BaseDocumentation {
 
 	@Test
@@ -60,7 +58,8 @@ public class UploadDocumentation extends BaseDocumentation {
 		uploadProperties.setName("log");
 		uploadProperties.setVersion("9.9.9");
 		uploadProperties.setExtension("zip");
-		final Resource resource = new ClassPathResource("/org/springframework/cloud/skipper/server/service/log-9.9.9.zip");
+		final Resource resource = new ClassPathResource(
+				"/org/springframework/cloud/skipper/server/service/log-9.9.9.zip");
 		assertThat(resource.exists()).isTrue();
 		final byte[] originalPackageBytes = StreamUtils.copyToByteArray(resource.getInputStream());
 		assertThat(originalPackageBytes).isNotEmpty();
@@ -72,26 +71,29 @@ public class UploadDocumentation extends BaseDocumentation {
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
 		mockMvc.perform(post("/api/upload").accept(MediaType.APPLICATION_JSON).contentType(contentType)
-			.content(convertObjectToJson(uploadProperties))).andDo(print())
-			.andExpect(status().isCreated())
-			.andDo(
-				this.documentationHandler.document(
-					responseFields(
-						fieldWithPath("apiVersion").description("The Package Index spec version this file is based on"),
-						fieldWithPath("origin").description("Indicates the origin of the repository (free form text)"),
-						fieldWithPath("repositoryId").description("The repository ID this Package Index file belongs to"),
-						fieldWithPath("kind").description("What type of package system is being used"),
-						fieldWithPath("name").description("The name of the package"),
-						fieldWithPath("version").description("The version of the package"),
-						fieldWithPath("packageSourceUrl").description("Location to source code for this package"),
-						fieldWithPath("packageHomeUrl").description("The home page of the package"),
-						fieldWithPath("tags").description("A comma separated list of tags to use for searching"),
-						fieldWithPath("maintainer").description("Who is maintaining this package"),
-						fieldWithPath("description").description("Brief description of the package"),
-						fieldWithPath("sha256").description("Hash of package binary that will be downloaded using SHA256 hash algorithm"),
-						fieldWithPath("iconUrl").description("Url location of a icon")
-					)
-				)
-			);
+				.content(convertObjectToJson(uploadProperties))).andDo(print())
+				.andExpect(status().isCreated())
+				.andDo(
+						this.documentationHandler.document(
+								responseFields(
+										fieldWithPath("apiVersion")
+												.description("The Package Index spec version this file is based on"),
+										fieldWithPath("origin")
+												.description("Indicates the origin of the repository (free form text)"),
+										fieldWithPath("repositoryId")
+												.description("The repository ID this Package Index file belongs to"),
+										fieldWithPath("kind").description("What type of package system is being used"),
+										fieldWithPath("name").description("The name of the package"),
+										fieldWithPath("version").description("The version of the package"),
+										fieldWithPath("packageSourceUrl")
+												.description("Location to source code for this package"),
+										fieldWithPath("packageHomeUrl").description("The home page of the package"),
+										fieldWithPath("tags")
+												.description("A comma separated list of tags to use for searching"),
+										fieldWithPath("maintainer").description("Who is maintaining this package"),
+										fieldWithPath("description").description("Brief description of the package"),
+										fieldWithPath("sha256").description(
+												"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+										fieldWithPath("iconUrl").description("Url location of a icon"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ConfigValueUtilsTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ConfigValueUtilsTests.java
@@ -40,18 +40,19 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import static org.springframework.cloud.skipper.server.service.ConfigValueUtilsTests.TestConfig;
 
 /**
  * @author Mark Pollack
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes  = TestConfig.class)
+@SpringBootTest(classes = TestConfig.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class ConfigValueUtilsTests {
 
 	@Autowired

--- a/spring-cloud-skipper-server-core/src/test/resources/application-repo-test.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/application-repo-test.yml
@@ -2,7 +2,6 @@ spring:
   cloud:
     skipper:
       server:
-        synchonizeIndexOnContextRefresh: true
         packageRepositories:
           -
             name: test

--- a/spring-cloud-skipper-server-core/src/test/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/application.yml
@@ -4,10 +4,6 @@ spring:
   data:
     rest:
       base-path: /api
-  cloud:
-    skipper:
-      server:
-        synchonizeIndexOnContextRefresh: false
   datasource:
     initialize: true
     url: 'jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE'


### PR DESCRIPTION
Fixes #292

Run `$ ./mvnw -pl spring-cloud-skipper-server-core -Dtest=SkipperControllerTests,ReleaseServiceTests test `

And you will see that when ReleaseServiceTests runs, the ReleaseStateUpdateService gets calls many times...

```
oud-dataflow-8829528346040883321/latestPackage-1509080524066/latestPackage.log-v1"},"id":"latestPackage.log-v1-0","state":"deployed"}},"state":"deployed"}]'}
2017-10-27 01:02:14.141  INFO 3476 --- [           main] o.s.c.s.s.service.ReleaseServiceTests    : Deployed! release=latestPackage version=1
2017-10-27 01:02:14.142  INFO 3476 --- [           main] o.s.c.s.s.service.ReleaseServiceTests    : Deleting release latestPackage
2017-10-27 01:02:14.153  INFO 3476 --- [           main] o.s.c.d.spi.local.LocalAppDeployer       : Un-deploying app with deploymentId latestPackage.log-v1 instance 0.
2017-10-27 01:02:16.247  INFO 3476 --- [pool-1-thread-1] o.s.c.s.s.s.ReleaseStateUpdateService    : Scheduled update state method running...
2017-10-27 01:02:18.921  INFO 3476 --- [pool-2-thread-1] o.s.c.s.s.s.ReleaseStateUpdateService    : Scheduled update state method running...
2017-10-27 01:02:19.323  INFO 3476 --- [           main] junit.logTestName                        : Finished Test testInstallByLatestPackage
2017-10-27 01:02:19.324  INFO 3476 --- [           main] junit.logTestName                        : Starting Test testPackageNotFound
2017-10-27 01:02:21.248  INFO 3476 --- [pool-1-thread-1] o.s.c.s.s.s.ReleaseStateUpdateService    : Scheduled update state method running...
2017-10-27 01:02:23.921  INFO 3476 --- [pool-2-thread-1] o.s.c.s.s.s.ReleaseStateUpdateService    : Scheduled update state method running...
```

I had to add @EnableScheduling to see it being invoked.