### PR TITLE
Fix rollback config settings

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -318,9 +317,7 @@ public class ReleaseService {
 		newRollbackRelease.setManifest(releaseToRollback.getManifest());
 		newRollbackRelease.setVersion(currentRelease.getVersion() + 1);
 		newRollbackRelease.setPlatformName(releaseToRollback.getPlatformName());
-		ConfigValues configValues = new ConfigValues();
-		configValues.setRaw(releaseToRollback.getManifest());
-		newRollbackRelease.setConfigValues(configValues);
+		newRollbackRelease.setConfigValues(releaseToRollback.getConfigValues());
 		newRollbackRelease.setInfo(createNewInfo());
 		if (currentRelease.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
 			// Since the current release is not deployed, we just do a new install.


### PR DESCRIPTION
 - When rolling back, the new rollback release's config was set to the actual release's manifest instead of config values.
  - Set the config values instead of manifest
  - Update test to check this

Resolves #303