### PR TITLE
Support external databases

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -28,11 +28,11 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.skipper.domain.AboutInfo;
 import org.springframework.cloud.skipper.domain.Deployer;
-import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
@@ -118,19 +118,19 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Info status(String releaseName) {
+	public SkipperInfo status(String releaseName) {
 		Map<String, String> uriVariables = new HashMap<String, String>();
 		uriVariables.put("releaseName", releaseName);
-		return this.restTemplate.getForObject(baseUri + "/status/{releaseName}", Info.class, uriVariables);
+		return this.restTemplate.getForObject(baseUri + "/status/{releaseName}", SkipperInfo.class, uriVariables);
 	}
 
 	@Override
-	public Info status(String releaseName, int releaseVersion) {
+	public SkipperInfo status(String releaseName, int releaseVersion) {
 		Map<String, String> uriVariables = new HashMap<String, String>();
 		uriVariables.put("releaseName", releaseName);
 		uriVariables.put("releaseVersion", Integer.toString(releaseVersion));
 		return this.restTemplate.getForObject(baseUri + "/status/{releaseName}/{releaseVersion}",
-				Info.class, uriVariables);
+				SkipperInfo.class, uriVariables);
 	}
 
 	@Override
@@ -150,8 +150,8 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Resources<PackageMetadata> search(String name, boolean details) {
-		ParameterizedTypeReference<Resources<PackageMetadata>> typeReference = new ParameterizedTypeReference<Resources<PackageMetadata>>() {
+	public Resources<SkipperPackageMetadata> search(String name, boolean details) {
+		ParameterizedTypeReference<Resources<SkipperPackageMetadata>> typeReference = new ParameterizedTypeReference<Resources<SkipperPackageMetadata>>() {
 		};
 		Traverson.TraversalBuilder traversalBuilder = this.traverson.follow("packageMetadata");
 		Map<String, Object> parameters = new HashMap<>();
@@ -168,33 +168,33 @@ public class DefaultSkipperClient implements SkipperClient {
 		return traversalBuilder.withTemplateParameters(parameters).toObject(typeReference);
 	}
 
-	public Release install(InstallRequest installRequest) {
+	public SkipperRelease install(InstallRequest installRequest) {
 		String url = String.format("%s/%s", baseUri, "install");
-		return this.restTemplate.postForObject(url, installRequest, Release.class);
+		return this.restTemplate.postForObject(url, installRequest, SkipperRelease.class);
 	}
 
 	@Override
-	public Release upgrade(UpgradeRequest upgradeRequest) {
+	public SkipperRelease upgrade(UpgradeRequest upgradeRequest) {
 		String url = String.format("%s/%s", baseUri, "upgrade");
 		log.debug("Posting UpgradeRequest to " + url + ". UpgradeRequest = " + upgradeRequest);
-		return this.restTemplate.postForObject(url, upgradeRequest, Release.class);
+		return this.restTemplate.postForObject(url, upgradeRequest, SkipperRelease.class);
 	}
 
 	@Override
-	public Release delete(String releaseName) {
+	public SkipperRelease delete(String releaseName) {
 		String url = String.format("%s/%s/%s", baseUri, "delete", releaseName);
-		return this.restTemplate.postForObject(url, null, Release.class);
+		return this.restTemplate.postForObject(url, null, SkipperRelease.class);
 	}
 
 	@Override
-	public Release rollback(String releaseName, int releaseVersion) {
+	public SkipperRelease rollback(String releaseName, int releaseVersion) {
 		String url = String.format("%s/%s/%s/%s", baseUri, "rollback", releaseName, releaseVersion);
-		return this.restTemplate.postForObject(url, null, Release.class);
+		return this.restTemplate.postForObject(url, null, SkipperRelease.class);
 	}
 
 	@Override
-	public List<Release> list(String releaseNameLike) {
-		ParameterizedTypeReference<List<Release>> typeReference = new ParameterizedTypeReference<List<Release>>() {
+	public List<SkipperRelease> list(String releaseNameLike) {
+		ParameterizedTypeReference<List<SkipperRelease>> typeReference = new ParameterizedTypeReference<List<SkipperRelease>>() {
 		};
 		String url;
 		if (StringUtils.hasText(releaseNameLike)) {
@@ -207,8 +207,8 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public List<Release> history(String releaseName, String maxRevisions) {
-		ParameterizedTypeReference<List<Release>> typeReference = new ParameterizedTypeReference<List<Release>>() {
+	public List<SkipperRelease> history(String releaseName, String maxRevisions) {
+		ParameterizedTypeReference<List<SkipperRelease>> typeReference = new ParameterizedTypeReference<List<SkipperRelease>>() {
 		};
 		Map<String, Object> parameters = new HashMap<>();
 		String url = String.format("%s/%s/%s/%s", baseUri, "history", releaseName, maxRevisions);
@@ -216,8 +216,8 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Resources<Release> history(String releaseName) {
-		ParameterizedTypeReference<Resources<Release>> typeReference = new ParameterizedTypeReference<Resources<Release>>() {
+	public Resources<SkipperRelease> history(String releaseName) {
+		ParameterizedTypeReference<Resources<SkipperRelease>> typeReference = new ParameterizedTypeReference<Resources<SkipperRelease>>() {
 		};
 		Map<String, Object> parameters = new HashMap<>();
 		parameters.put("name", releaseName);
@@ -227,23 +227,23 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Repository addRepository(String name, String rootUrl, String sourceUrl) {
+	public SkipperRepository addRepository(String name, String rootUrl, String sourceUrl) {
 		String url = String.format("%s/%s", baseUri, "repositories");
-		Repository repository = new Repository();
+		SkipperRepository repository = new SkipperRepository();
 		repository.setName(name);
 		repository.setUrl(rootUrl);
 		repository.setSourceUrl(sourceUrl);
-		return this.restTemplate.postForObject(url, repository, Repository.class);
+		return this.restTemplate.postForObject(url, repository, SkipperRepository.class);
 	}
 
 	@Override
 	public void deleteRepository(String name) {
-		ParameterizedTypeReference<Resource<Repository>> typeReference = new ParameterizedTypeReference<Resource<Repository>>() {
+		ParameterizedTypeReference<Resource<SkipperRepository>> typeReference = new ParameterizedTypeReference<Resource<SkipperRepository>>() {
 		};
 		Traverson.TraversalBuilder traversalBuilder = this.traverson.follow("repositories", "search", "findByName");
 		Map<String, Object> parameters = new HashMap<>();
 		parameters.put("name", name);
-		Resource<Repository> repositoryResource = traversalBuilder.withTemplateParameters(parameters)
+		Resource<SkipperRepository> repositoryResource = traversalBuilder.withTemplateParameters(parameters)
 				.toObject(typeReference);
 		if (repositoryResource != null) {
 			this.restTemplate.delete(repositoryResource.getId().getHref());
@@ -254,8 +254,8 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Resources<Repository> listRepositories() {
-		ParameterizedTypeReference<Resources<Repository>> typeReference = new ParameterizedTypeReference<Resources<Repository>>() {
+	public Resources<SkipperRepository> listRepositories() {
+		ParameterizedTypeReference<Resources<SkipperRepository>> typeReference = new ParameterizedTypeReference<Resources<SkipperRepository>>() {
 		};
 		Traverson.TraversalBuilder traversalBuilder = this.traverson.follow("repositories");
 		Map<String, Object> parameters = new HashMap<>();
@@ -274,11 +274,11 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public PackageMetadata upload(UploadRequest uploadRequest) {
+	public SkipperPackageMetadata upload(UploadRequest uploadRequest) {
 		String url = String.format("%s/%s", baseUri, "upload");
 		log.debug("Uploading package {}-{} to repository {}.", uploadRequest.getName(), uploadRequest.getVersion(),
 				uploadRequest.getRepoName());
-		return this.restTemplate.postForObject(url, uploadRequest, PackageMetadata.class);
+		return this.restTemplate.postForObject(url, uploadRequest, SkipperPackageMetadata.class);
 	}
 
 	protected Traverson createTraverson(String baseUrl) {

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -19,11 +19,11 @@ import java.util.List;
 
 import org.springframework.cloud.skipper.domain.AboutInfo;
 import org.springframework.cloud.skipper.domain.Deployer;
-import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
@@ -58,21 +58,21 @@ public interface SkipperClient {
 	 * @param details boolean flag to fetch all the metadata
 	 * @return the package metadata with the projection set to summary
 	 */
-	Resources<PackageMetadata> search(String name, boolean details);
+	Resources<SkipperPackageMetadata> search(String name, boolean details);
 
 	/**
 	 * Install the package
 	 * @param installRequest the package install request
-	 * @return the installed {@link Release}
+	 * @return the installed {@link SkipperRelease}
 	 */
-	Release install(InstallRequest installRequest);
+	SkipperRelease install(InstallRequest installRequest);
 
 	/**
 	 * Upgrade a release.
 	 * @param upgradeRequest the request to upgrade the release
-	 * @return the upgraded {@link Release}
+	 * @return the upgraded {@link SkipperRelease}
 	 */
-	Release upgrade(UpgradeRequest upgradeRequest);
+	SkipperRelease upgrade(UpgradeRequest upgradeRequest);
 
 	/*
 	 * Upload the package.
@@ -80,24 +80,24 @@ public interface SkipperClient {
 	 * @param uploadRequest the properties for the package upload
 	 * @return package metadata for the uploaded package
 	 */
-	PackageMetadata upload(UploadRequest uploadRequest);
+	SkipperPackageMetadata upload(UploadRequest uploadRequest);
 
 	/**
 	 * Delete a specific release.
 	 *
 	 * @param releaseName the release name
-	 * @return the deleted {@link Release}
+	 * @return the deleted {@link SkipperRelease}
 	 */
-	Release delete(String releaseName);
+	SkipperRelease delete(String releaseName);
 
 	/**
 	 * Rollback a specific release.
 	 *
 	 * @param releaseName the release name
 	 * @param releaseVersion the release version
-	 * @return the rolled back {@link Release}
+	 * @return the rolled back {@link SkipperRelease}
 	 */
-	Release rollback(String releaseName, int releaseVersion);
+	SkipperRelease rollback(String releaseName, int releaseVersion);
 
 	/**
 	 * List the latest version of releases with status of deployed or failed.
@@ -105,7 +105,7 @@ public interface SkipperClient {
 	 * @param releaseNameLike the wildcard name of releases to search for
 	 * @return the list of all matching releases
 	 */
-	List<Release> list(String releaseNameLike);
+	List<SkipperRelease> list(String releaseNameLike);
 
 	/**
 	 * List the history of versions for a given release.
@@ -114,7 +114,7 @@ public interface SkipperClient {
 	 * @param maxRevisions the maximum number of revisions to get
 	 * @return the list of all releases by the given name and revisions max.
 	 */
-	List<Release> history(String releaseName, String maxRevisions);
+	List<SkipperRelease> history(String releaseName, String maxRevisions);
 
 	/**
 	 * List all releases for the given release name.
@@ -122,7 +122,7 @@ public interface SkipperClient {
 	 * @param releaseName the release name of the release to search for
 	 * @return the list of all releases by the given name
 	 */
-	Resources<Release> history(String releaseName);
+	Resources<SkipperRelease> history(String releaseName);
 
 	/**
 	 * Add a new Package Repository.
@@ -132,7 +132,7 @@ public interface SkipperClient {
 	 * @param sourceUrl the source URL for the packages
 	 * @return the newly added Repository
 	 */
-	Repository addRepository(String name, String rootUrl, String sourceUrl);
+	SkipperRepository addRepository(String name, String rootUrl, String sourceUrl);
 
 	/**
 	 * Delete a Package Repository.
@@ -146,7 +146,7 @@ public interface SkipperClient {
 	 *
 	 * @return the list of package repositories
 	 */
-	Resources<Repository> listRepositories();
+	Resources<SkipperRepository> listRepositories();
 
 	/**
 	 * List Platform Deployers
@@ -161,7 +161,7 @@ public interface SkipperClient {
 	 * @param releaseName the release name
 	 * @return the status info of a release
 	 */
-	Info status(String releaseName);
+	SkipperInfo status(String releaseName);
 
 	/**
 	 * Return a status info of a release version.
@@ -170,7 +170,7 @@ public interface SkipperClient {
 	 * @param releaseVersion the release version
 	 * @return the status info of a release
 	 */
-	Info status(String releaseName, int releaseVersion);
+	SkipperInfo status(String releaseName, int releaseVersion);
 
 	/**
 	 * Return the manifest of the last known release. For packages with dependencies, the

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -66,11 +66,11 @@ public class DefaultSkipperClientTests {
 		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
 		mockServer.expect(requestTo("/status/mylog")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-		Info status = skipperClient.status("mylog");
+		SkipperInfo status = skipperClient.status("mylog");
 		mockServer.verify();
 
 		assertThat(status).isNotNull();
-		assertThat(status).isInstanceOf(Info.class);
+		assertThat(status).isInstanceOf(SkipperInfo.class);
 	}
 
 	@Test(expected = ReleaseNotFoundException.class)

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -59,6 +59,29 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-keyvault</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerProperties.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerProperties.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 
 /**
  * Configurable properties of the server.
@@ -33,7 +33,7 @@ public class SkipperServerProperties {
 	/**
 	 * List of locations for package Repositories
 	 */
-	private List<Repository> packageRepositories = new ArrayList<>();
+	private List<SkipperRepository> packageRepositories = new ArrayList<>();
 
 	/**
 	 * Flag indicating to sync the local contents of the index directory with the database on
@@ -58,11 +58,11 @@ public class SkipperServerProperties {
 	 */
 	private int freeDiskSpacePercentage = 25;
 
-	public List<Repository> getPackageRepositories() {
+	public List<SkipperRepository> getPackageRepositories() {
 		return packageRepositories;
 	}
 
-	public void setPackageRepositories(List<Repository> packageRepositories) {
+	public void setPackageRepositories(List<SkipperRepository> packageRepositories) {
 		this.packageRepositories = packageRepositories;
 	}
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
@@ -21,11 +21,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.domain.AboutInfo;
-import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.cloud.skipper.server.service.PackageService;
@@ -75,31 +75,31 @@ public class SkipperController {
 
 	@RequestMapping(path = "/upload", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public PackageMetadata upload(@RequestBody UploadRequest uploadRequest) {
+	public SkipperPackageMetadata upload(@RequestBody UploadRequest uploadRequest) {
 		return this.packageService.upload(uploadRequest);
 	}
 
 	@RequestMapping(path = "/install", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public Release install(@RequestBody InstallRequest installRequest) {
+	public SkipperRelease install(@RequestBody InstallRequest installRequest) {
 		return this.releaseService.install(installRequest);
 	}
 
 	@RequestMapping(path = "/install/{id}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public Release install(@PathVariable("id") Long id, @RequestBody InstallProperties installProperties) {
+	public SkipperRelease install(@PathVariable("id") Long id, @RequestBody InstallProperties installProperties) {
 		return this.releaseService.install(id, installProperties);
 	}
 
 	@RequestMapping(path = "/status/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public Info status(@PathVariable("name") String name) {
+	public SkipperInfo status(@PathVariable("name") String name) {
 		return this.releaseService.status(name);
 	}
 
 	@RequestMapping(path = "/status/{name}/{version}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public Info status(@PathVariable("name") String name, @PathVariable("version") int version) {
+	public SkipperInfo status(@PathVariable("name") String name, @PathVariable("version") int version) {
 		return this.releaseService.status(name, version);
 	}
 
@@ -115,39 +115,39 @@ public class SkipperController {
 
 	@RequestMapping(path = "/upgrade", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public Release upgrade(@RequestBody UpgradeRequest upgradeRequest) {
+	public SkipperRelease upgrade(@RequestBody UpgradeRequest upgradeRequest) {
 		return this.releaseService.upgrade(upgradeRequest);
 	}
 
 	@RequestMapping(path = "/rollback/{name}/{version}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public Release rollback(@PathVariable("name") String releaseName,
+	public SkipperRelease rollback(@PathVariable("name") String releaseName,
 			@PathVariable("version") int rollbackVersion) {
 		return this.releaseService.rollback(releaseName, rollbackVersion);
 	}
 
 	@RequestMapping(path = "/delete/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public Release delete(@PathVariable("name") String releaseName) {
+	public SkipperRelease delete(@PathVariable("name") String releaseName) {
 		return this.releaseService.delete(releaseName);
 	}
 
 	@RequestMapping(path = "/history/{name}/{max}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public List<Release> history(@PathVariable("name") String releaseName,
+	public List<SkipperRelease> history(@PathVariable("name") String releaseName,
 			@PathVariable("max") int maxRevisions) {
 		return this.releaseService.history(releaseName, maxRevisions);
 	}
 
 	@RequestMapping(path = "/list", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public List<Release> list() {
+	public List<SkipperRelease> list() {
 		return this.releaseService.list();
 	}
 
 	@RequestMapping(path = "/list/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public List<Release> list(@PathVariable("name") String releaseName) {
+	public List<SkipperRelease> list(@PathVariable("name") String releaseName) {
 		return this.releaseService.list(releaseName);
 	}
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/AppDeployerReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/AppDeployerReleaseManager.java
@@ -31,11 +31,11 @@ import org.springframework.cloud.deployer.spi.app.MultiStateAppDeployer;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryDeploymentProperties;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
+import org.springframework.cloud.skipper.domain.SkipperStatus;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
-import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.domain.SkipperAppDeployerData;
 import org.springframework.cloud.skipper.server.domain.SpringCloudDeployerApplicationManifest;
 import org.springframework.cloud.skipper.server.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.cloud.skipper.server.domain.SpringCloudDeployerApplicationSpec;
@@ -88,9 +88,9 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 		this.applicationManifestReader = applicationManifestReader;
 	}
 
-	public Release install(Release releaseInput) {
+	public SkipperRelease install(SkipperRelease releaseInput) {
 		validate(releaseInput);
-		Release release = this.releaseRepository.save(releaseInput);
+		SkipperRelease release = this.releaseRepository.save(releaseInput);
 		logger.debug("Manifest = " + releaseInput.getManifest());
 		// Deploy the application
 		List<? extends SpringCloudDeployerApplicationManifest> applicationSpecList = this.applicationManifestReader
@@ -109,7 +109,7 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 			}
 			catch (Exception e) {
 				// Update Status in DB
-				Status status = new Status();
+				SkipperStatus status = new SkipperStatus();
 				status.setStatusCode(StatusCode.FAILED);
 				release.getInfo().setStatus(status);
 				release.getInfo().setDescription("Install failed");
@@ -121,7 +121,7 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 			}
 		}
 
-		AppDeployerData appDeployerData = new AppDeployerData();
+		SkipperAppDeployerData appDeployerData = new SkipperAppDeployerData();
 		appDeployerData.setReleaseName(release.getName());
 		appDeployerData.setReleaseVersion(release.getVersion());
 		appDeployerData.setDeploymentDataUsingMap(appNameDeploymentIdMap);
@@ -129,7 +129,7 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 		this.appDeployerDataRepository.save(appDeployerData);
 
 		// Update Status in DB
-		Status status = new Status();
+		SkipperStatus status = new SkipperStatus();
 		status.setStatusCode(StatusCode.DEPLOYED);
 		release.getInfo().setStatus(status);
 		release.getInfo().setDescription("Install complete");
@@ -138,7 +138,7 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 		return status(this.releaseRepository.save(release));
 	}
 
-	private void validate(Release releaseInput) {
+	private void validate(SkipperRelease releaseInput) {
 		/**
 		 * Do some AppDeployer specific checks. These should be pushed down into the
 		 * implementations to fail fast.
@@ -170,13 +170,13 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 	}
 
 	@Override
-	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease) {
+	public ReleaseAnalysisReport createReport(SkipperRelease existingRelease, SkipperRelease replacingRelease) {
 		ReleaseAnalysisReport releaseAnalysisReport = this.releaseAnalyzer.analyze(existingRelease, replacingRelease);
 		if (releaseAnalysisReport.getReleaseDifference().areEqual()) {
 			throw new SkipperException(
 					"Package to upgrade has no difference than existing deployed/deleted package. Not upgrading.");
 		}
-		AppDeployerData existingAppDeployerData = this.appDeployerDataRepository
+		SkipperAppDeployerData existingAppDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(
 						existingRelease.getName(), existingRelease.getVersion());
 		Map<String, String> existingAppNamesAndDeploymentIds = existingAppDeployerData.getDeploymentDataAsMap();
@@ -202,7 +202,7 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 				releaseAnalysisReport.getReplacingRelease(), releaseAnalysisReport);
 	}
 
-	private Map<String, Object> calculateAppCountsForRelease(Release replacingRelease,
+	private Map<String, Object> calculateAppCountsForRelease(SkipperRelease replacingRelease,
 			Map<String, String> existingAppNamesAndDeploymentIds, List<String> applicationNamesToUpgrade,
 			List<AppStatus> appStatuses) {
 		Map<String, Object> model = ConfigValueUtils.mergeConfigValues(replacingRelease.getPkg(),
@@ -250,10 +250,10 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 		deploymentPropertiesMap.put(SPRING_CLOUD_DEPLOYER_COUNT, appsCount);
 	}
 
-	public Release status(Release release) {
+	public SkipperRelease status(SkipperRelease release) {
 		AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
 				.getAppDeployer();
-		AppDeployerData appDeployerData = this.appDeployerDataRepository
+		SkipperAppDeployerData appDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersion(release.getName(), release.getVersion());
 		if (appDeployerData == null) {
 			logger.warn(String.format("Could not get status for release %s-v%s.  No app deployer data found.",
@@ -309,18 +309,18 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 		return release;
 	}
 
-	public Release delete(Release release) {
+	public SkipperRelease delete(SkipperRelease release) {
 		AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
 				.getAppDeployer();
 
-		AppDeployerData appDeployerData = this.appDeployerDataRepository
+		SkipperAppDeployerData appDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(release.getName(), release.getVersion());
 		List<String> deploymentIds = appDeployerData.getDeploymentIds();
 		if (!deploymentIds.isEmpty()) {
 			for (String deploymentId : deploymentIds) {
 				appDeployer.undeploy(deploymentId);
 			}
-			Status deletedStatus = new Status();
+			SkipperStatus deletedStatus = new SkipperStatus();
 			deletedStatus.setStatusCode(StatusCode.DELETED);
 			release.getInfo().setStatus(deletedStatus);
 			release.getInfo().setDescription("Delete complete");

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalysisReport.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalysisReport.java
@@ -17,7 +17,7 @@ package org.springframework.cloud.skipper.server.deployer;
 
 import java.util.List;
 
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.util.Assert;
 
 /**
@@ -35,9 +35,9 @@ public class ReleaseAnalysisReport {
 
 	private final ReleaseDifference releaseDifference;
 
-	private final Release existingRelease;
+	private final SkipperRelease existingRelease;
 
-	private final Release replacingRelease;
+	private final SkipperRelease replacingRelease;
 
 	/**
 	 * Create an analysis report.
@@ -48,7 +48,7 @@ public class ReleaseAnalysisReport {
 	 * @param replacingRelease the release to be deployed
 	 */
 	public ReleaseAnalysisReport(List<String> applicationNamesToUpgrade, ReleaseDifference releaseDifference,
-			Release existingRelease, Release replacingRelease) {
+			SkipperRelease existingRelease, SkipperRelease replacingRelease) {
 		Assert.notNull(applicationNamesToUpgrade, "ApplicationNamesToUpgrade can not be null.");
 		Assert.notNull(releaseDifference, "ReleaseDifference can not be null.");
 		this.applicationNamesToUpgrade = applicationNamesToUpgrade;
@@ -65,11 +65,11 @@ public class ReleaseAnalysisReport {
 		return releaseDifference;
 	}
 
-	public Release getExistingRelease() {
+	public SkipperRelease getExistingRelease() {
 		return existingRelease;
 	}
 
-	public Release getReplacingRelease() {
+	public SkipperRelease getReplacingRelease() {
 		return replacingRelease;
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalyzer.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalyzer.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.server.domain.SpringCloudDeployerApplicationManifest;
 import org.springframework.cloud.skipper.server.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.util.StringUtils;
@@ -61,7 +61,7 @@ public class ReleaseAnalyzer {
 	 * existing release.
 	 * @return an analysis report describing the changes to make, if any.
 	 */
-	public ReleaseAnalysisReport analyze(Release existingRelease, Release replacingRelease) {
+	public ReleaseAnalysisReport analyze(SkipperRelease existingRelease, SkipperRelease replacingRelease) {
 
 		// For now, assume single package with no deps or package with same number of deps
 		List<? extends SpringCloudDeployerApplicationManifest> existingApplicationSpecList = this.applicationManifestReader
@@ -100,7 +100,7 @@ public class ReleaseAnalyzer {
 	private ReleaseAnalysisReport analyzeDependentPackagesOnly(
 			List<? extends SpringCloudDeployerApplicationManifest> existingApplicationSpecList,
 			List<? extends SpringCloudDeployerApplicationManifest> replacingApplicationSpecList,
-			Release existingRelease, Release replacingRelease) {
+			SkipperRelease existingRelease, SkipperRelease replacingRelease) {
 		List<String> appsToDelete = new ArrayList<>();
 		StringBuilder diffMessagesBuilder = new StringBuilder();
 		for (SpringCloudDeployerApplicationManifest existingApplicationManifest : existingApplicationSpecList) {
@@ -130,7 +130,7 @@ public class ReleaseAnalyzer {
 	private ReleaseAnalysisReport analyzeTopLevelPackagesOnly(
 			List<? extends SpringCloudDeployerApplicationManifest> existingApplicationSpecList,
 			List<? extends SpringCloudDeployerApplicationManifest> replacingApplicationSpecList,
-			Release existingRelease, Release replacingRelease) {
+			SkipperRelease existingRelease, SkipperRelease replacingRelease) {
 		ReleaseDifference difference = compare(existingApplicationSpecList.get(0),
 				replacingApplicationSpecList.get(0));
 		List<String> appsToDelete = new ArrayList<>();

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.deployer;
 
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 
 /**
  * Manages the lifecycle of a releases.
@@ -34,7 +34,7 @@ public interface ReleaseManager {
 	 * @return the release object after requesting installation
 	 */
 	// TODO return just release name and version
-	Release install(Release release);
+	SkipperRelease install(SkipperRelease release);
 
 	/**
 	 * Create a report of what apps should be updated and deleted upon upgrade. The return
@@ -44,7 +44,7 @@ public interface ReleaseManager {
 	 * release
 	 * @return a report describing the actions to take to update
 	 */
-	ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease);
+	ReleaseAnalysisReport createReport(SkipperRelease existingRelease, SkipperRelease replacingRelease);
 
 	/**
 	 * Given a report of what should be upgraded, perform the upgrade. It is expected this is
@@ -58,7 +58,7 @@ public interface ReleaseManager {
 	 * @param release the release to delete
 	 * @return the updated release object after deltion
 	 */
-	Release delete(Release release);
+	SkipperRelease delete(SkipperRelease release);
 
 	/**
 	 * Get the status of the release, by querying the database. The
@@ -67,6 +67,6 @@ public interface ReleaseManager {
 	 * @param release the release to update state for
 	 * @return the updated release
 	 */
-	Release status(Release release);
+	SkipperRelease status(SkipperRelease release);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeleteStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeleteStep.java
@@ -24,10 +24,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
-import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
+import org.springframework.cloud.skipper.domain.SkipperStatus;
 import org.springframework.cloud.skipper.domain.StatusCode;
-import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.domain.SkipperAppDeployerData;
 import org.springframework.cloud.skipper.server.repository.DeployerRepository;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 
@@ -49,7 +49,7 @@ public class DeleteStep {
 		this.deployerRepository = deployerRepository;
 	}
 
-	public Release delete(Release release, AppDeployerData existingAppDeployerData,
+	public SkipperRelease delete(SkipperRelease release, SkipperAppDeployerData existingAppDeployerData,
 			List<String> applicationNamesToDelete) {
 
 		AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
@@ -70,7 +70,7 @@ public class DeleteStep {
 			}
 		}
 
-		Status deletedStatus = new Status();
+		SkipperStatus deletedStatus = new SkipperStatus();
 		deletedStatus.setStatusCode(StatusCode.DELETED);
 		release.getInfo().setStatus(deletedStatus);
 		release.getInfo().setDescription("Delete complete");

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeployAppStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeployAppStep.java
@@ -22,12 +22,12 @@ import java.util.Map;
 
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
-import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
+import org.springframework.cloud.skipper.domain.SkipperStatus;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
-import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.domain.SkipperAppDeployerData;
 import org.springframework.cloud.skipper.server.domain.SpringCloudDeployerApplicationManifest;
 import org.springframework.cloud.skipper.server.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
@@ -65,7 +65,7 @@ public class DeployAppStep {
 	}
 
 	@Transactional
-	public List<String> deployApps(Release existingRelease, Release replacingRelease,
+	public List<String> deployApps(SkipperRelease existingRelease, SkipperRelease replacingRelease,
 			ReleaseAnalysisReport releaseAnalysisReport) {
 		List<String> applicationNamesToUpgrade = new ArrayList<>();
 		try {
@@ -80,7 +80,7 @@ public class DeployAppStep {
 			// Carry over the applicationDeployment information for apps that were not updated.
 			carryOverAppDeploymentIds(existingRelease, appNameDeploymentIdMap);
 
-			AppDeployerData appDeployerData = new AppDeployerData();
+			SkipperAppDeployerData appDeployerData = new SkipperAppDeployerData();
 			appDeployerData.setReleaseName(replacingRelease.getName());
 			appDeployerData.setReleaseVersion(replacingRelease.getVersion());
 			appDeployerData.setDeploymentDataUsingMap(appNameDeploymentIdMap);
@@ -90,7 +90,7 @@ public class DeployAppStep {
 			throw e;
 		}
 		catch (Exception e) {
-			Status status = new Status();
+			SkipperStatus status = new SkipperStatus();
 			status.setStatusCode(StatusCode.FAILED);
 			replacingRelease.getInfo().setStatus(status);
 			replacingRelease.getInfo().setStatus(status);
@@ -101,8 +101,8 @@ public class DeployAppStep {
 		return applicationNamesToUpgrade;
 	}
 
-	private void carryOverAppDeploymentIds(Release existingRelease, Map<String, String> appNameDeploymentIdMap) {
-		AppDeployerData existingAppDeployerData = this.appDeployerDataRepository
+	private void carryOverAppDeploymentIds(SkipperRelease existingRelease, Map<String, String> appNameDeploymentIdMap) {
+		SkipperAppDeployerData existingAppDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(
 						existingRelease.getName(), existingRelease.getVersion());
 		Map<String, String> existingAppNamesAndDeploymentIds = existingAppDeployerData.getDeploymentDataAsMap();
@@ -115,7 +115,7 @@ public class DeployAppStep {
 		}
 	}
 
-	private Map<String, String> deploy(Release replacingRelease, List<String> applicationNamesToUpgrade,
+	private Map<String, String> deploy(SkipperRelease replacingRelease, List<String> applicationNamesToUpgrade,
 			AppDeployer appDeployer) {
 		List<? extends SpringCloudDeployerApplicationManifest> applicationSpecList = this.applicationManifestReader
 				.read(replacingRelease

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckStep.java
@@ -23,8 +23,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
-import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
+import org.springframework.cloud.skipper.server.domain.SkipperAppDeployerData;
 import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
 import org.springframework.cloud.skipper.server.repository.DeployerRepository;
 
@@ -51,8 +51,8 @@ public class HealthCheckStep {
 		this.healthCheckProperties = healthCheckProperties;
 	}
 
-	public boolean waitForNewAppsToDeploy(Release replacingRelease) {
-		AppDeployerData replacingAppDeployerData = this.appDeployerDataRepository
+	public boolean waitForNewAppsToDeploy(SkipperRelease replacingRelease) {
+		SkipperAppDeployerData replacingAppDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(
 						replacingRelease.getName(), replacingRelease.getVersion());
 
@@ -63,7 +63,7 @@ public class HealthCheckStep {
 		return this.isHealthy(replacingRelease, replacingAppDeployerData);
 	}
 
-	private boolean isHealthy(Release replacingRelease, AppDeployerData replacingAppDeployerData) {
+	private boolean isHealthy(SkipperRelease replacingRelease, SkipperAppDeployerData replacingAppDeployerData) {
 		boolean isHealthy = false;
 		try {
 			long timeout = System.currentTimeMillis() + this.healthCheckProperties.getTimeoutInMillis();

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
@@ -17,7 +17,7 @@ package org.springframework.cloud.skipper.server.deployer.strategies;
 
 import java.util.List;
 
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.scheduling.annotation.Async;
@@ -49,7 +49,7 @@ public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 
 	@Override
 	@Async(SKIPPER_EXECUTOR)
-	public Release upgrade(Release existingRelease, Release replacingRelease,
+	public SkipperRelease upgrade(SkipperRelease existingRelease, SkipperRelease replacingRelease,
 			ReleaseAnalysisReport releaseAnalysisReport) {
 		List<String> applicationNamesToUpgrade = this.deployAppStep.deployApps(existingRelease, replacingRelease,
 				releaseAnalysisReport);

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.deployer.strategies;
 
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 
 /**
@@ -36,6 +36,6 @@ public interface UpgradeStrategy {
 	 * @param releaseAnalysisReport report to guide the strategy on what apps to replace.
 	 * @return the replacingRelease, now deployed.
 	 */
-	Release upgrade(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
+	SkipperRelease upgrade(SkipperRelease existingRelease, SkipperRelease replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/PackageSummary.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/PackageSummary.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.domain;
 
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.data.rest.core.config.Projection;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.data.rest.core.config.Projection;
  * model entity.
  * @author Mark Pollack
  */
-@Projection(name = "summary", types = { PackageMetadata.class })
+@Projection(name = "summary", types = { SkipperPackageMetadata.class })
 public interface PackageSummary {
 
 	String getId();

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/SkipperAppDeployerData.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/SkipperAppDeployerData.java
@@ -42,7 +42,7 @@ import org.springframework.cloud.skipper.domain.AbstractEntity;
  * @author Mark Pollack
  */
 @Entity
-public class AppDeployerData extends AbstractEntity {
+public class SkipperAppDeployerData extends AbstractEntity {
 
 	private String releaseName;
 
@@ -52,7 +52,7 @@ public class AppDeployerData extends AbstractEntity {
 	@Lob
 	private String deploymentData;
 
-	public AppDeployerData() {
+	public SkipperAppDeployerData() {
 	}
 
 	public String getReleaseName() {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/index/PackageMetadataResourceProcessor.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/index/PackageMetadataResourceProcessor.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.index;
 
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.cloud.skipper.server.controller.SkipperController;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Resource;
@@ -30,10 +30,10 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
  * @author Ilayaperumal Gopinathan
  */
 @Component
-public class PackageMetadataResourceProcessor implements ResourceProcessor<Resource<PackageMetadata>> {
+public class PackageMetadataResourceProcessor implements ResourceProcessor<Resource<SkipperPackageMetadata>> {
 
 	@Override
-	public Resource<PackageMetadata> process(Resource<PackageMetadata> packageMetadataResource) {
+	public Resource<SkipperPackageMetadata> process(Resource<SkipperPackageMetadata> packageMetadataResource) {
 		Link installLink = linkTo(
 				methodOn(SkipperController.class).install(packageMetadataResource.getContent().getId(), null))
 						.withRel("install");

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepository.java
@@ -15,15 +15,17 @@
  */
 package org.springframework.cloud.skipper.server.repository;
 
-import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.domain.SkipperAppDeployerData;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 /**
  * @author Mark Pollack
  */
+@RepositoryRestResource(path = "appDeployerDatas", collectionResourceRel = "appDeployerDatas")
 public interface AppDeployerDataRepository
-		extends PagingAndSortingRepository<AppDeployerData, Long>, AppDeployerDataRepositoryCustom {
+		extends PagingAndSortingRepository<SkipperAppDeployerData, Long>, AppDeployerDataRepositoryCustom {
 
-	AppDeployerData findByReleaseNameAndReleaseVersion(String releaseName, Integer releaseVersion);
+	SkipperAppDeployerData findByReleaseNameAndReleaseVersion(String releaseName, Integer releaseVersion);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepositoryCustom.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.cloud.skipper.server.repository;
 
-import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.domain.SkipperAppDeployerData;
 
 /**
  * @author Mark Pollack
  */
 public interface AppDeployerDataRepositoryCustom {
 
-	AppDeployerData findByReleaseNameAndReleaseVersionRequired(String releaseName, Integer releaseVersion);
+	SkipperAppDeployerData findByReleaseNameAndReleaseVersionRequired(String releaseName, Integer releaseVersion);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepositoryImpl.java
@@ -21,7 +21,7 @@ import java.util.stream.StreamSupport;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.domain.SkipperAppDeployerData;
 import org.springframework.util.StringUtils;
 
 /**
@@ -33,11 +33,11 @@ public class AppDeployerDataRepositoryImpl implements AppDeployerDataRepositoryC
 	private AppDeployerDataRepository appDeployerDataRepository;
 
 	@Override
-	public AppDeployerData findByReleaseNameAndReleaseVersionRequired(String releaseName, Integer releaseVersion) {
-		AppDeployerData appDeployerData = appDeployerDataRepository.findByReleaseNameAndReleaseVersion(releaseName,
+	public SkipperAppDeployerData findByReleaseNameAndReleaseVersionRequired(String releaseName, Integer releaseVersion) {
+		SkipperAppDeployerData appDeployerData = appDeployerDataRepository.findByReleaseNameAndReleaseVersion(releaseName,
 				releaseVersion);
 		if (appDeployerData == null) {
-			List<AppDeployerData> appDeployerDataList = StreamSupport
+			List<SkipperAppDeployerData> appDeployerDataList = StreamSupport
 					.stream(appDeployerDataRepository.findAll().spliterator(), false)
 					.collect(Collectors.toList());
 			String existingDeployerData = StringUtils.collectionToCommaDelimitedString(appDeployerDataList);

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepository.java
@@ -17,7 +17,7 @@ package org.springframework.cloud.skipper.server.repository;
 
 import java.util.List;
 
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
@@ -27,17 +27,17 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
  * @author Ilayaperumal Gopinathan
  * @author Janne Valkealahti
  */
-@RepositoryRestResource(path = "packageMetadata", collectionResourceRel = "packageMetadata")
-public interface PackageMetadataRepository extends PagingAndSortingRepository<PackageMetadata, Long>,
+@RepositoryRestResource(path = "packageMetadata", collectionResourceRel = "packageMetadata", itemResourceRel = "packageMetadata")
+public interface PackageMetadataRepository extends PagingAndSortingRepository<SkipperPackageMetadata, Long>,
 		PackageMetadataRepositoryCustom {
 
-	List<PackageMetadata> findByName(@Param("name") String name);
+	List<SkipperPackageMetadata> findByName(@Param("name") String name);
 
-	List<PackageMetadata> findByNameContainingIgnoreCase(@Param("name") String name);
+	List<SkipperPackageMetadata> findByNameContainingIgnoreCase(@Param("name") String name);
 
-	List<PackageMetadata> findByNameAndVersionOrderByApiVersionDesc(@Param("name") String name,
+	List<SkipperPackageMetadata> findByNameAndVersionOrderByApiVersionDesc(@Param("name") String name,
 			@Param("version") String version);
 
-	PackageMetadata findFirstByNameOrderByVersionDesc(@Param("name") String name);
+	SkipperPackageMetadata findFirstByNameOrderByVersionDesc(@Param("name") String name);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryCustom.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.skipper.server.repository;
 import java.util.List;
 
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.data.repository.query.Param;
 
 /**
@@ -27,27 +27,27 @@ import org.springframework.data.repository.query.Param;
 public interface PackageMetadataRepositoryCustom {
 
 	/**
-	 * Find the {@link PackageMetadata} with the given name, version and also from the
+	 * Find the {@link SkipperPackageMetadata} with the given name, version and also from the
 	 * repository that has the highest order set.
 	 *
 	 * @param name the name of the package metadata
 	 * @param version the version of the package metadata
 	 * @return the package metadata
 	 */
-	PackageMetadata findByNameAndVersionByMaxRepoOrder(@Param("name") String name, @Param("version") String version);
+	SkipperPackageMetadata findByNameAndVersionByMaxRepoOrder(@Param("name") String name, @Param("version") String version);
 
 	/**
-	 * Find the list of {@link PackageMetadata} by the given package name.
+	 * Find the list of {@link SkipperPackageMetadata} by the given package name.
 	 *
 	 * @param name the package name
 	 * @return the list of package metadata by the given name
 	 * @throws {@link org.springframework.cloud.skipper.SkipperException} if there is no
 	 * package exists with the given name.
 	 */
-	List<PackageMetadata> findByNameRequired(@Param("name") String name) throws SkipperException;
+	List<SkipperPackageMetadata> findByNameRequired(@Param("name") String name) throws SkipperException;
 
 	/**
-	 * Find the {@link PackageMetadata} given the package name and version. If packageVersion
+	 * Find the {@link SkipperPackageMetadata} given the package name and version. If packageVersion
 	 * is specified, delegate to findByNameAndVersionByMaxRepoOrder, otherwise delegate to
 	 * findFirstByNameOrderByVersionDesc. Throw an e
 	 * @param packageName the name of the package
@@ -56,6 +56,6 @@ public interface PackageMetadataRepositoryCustom {
 	 * @throws {@link org.springframework.cloud.skipper.SkipperException} if there is no
 	 * package exists with the given name.
 	 */
-	PackageMetadata findByNameAndOptionalVersionRequired(String packageName, String packageVersion);
+	SkipperPackageMetadata findByNameAndOptionalVersionRequired(String packageName, String packageVersion);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryImpl.java
@@ -19,8 +19,8 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -38,8 +38,8 @@ public class PackageMetadataRepositoryImpl implements PackageMetadataRepositoryC
 	private RepositoryRepository repositoryRepository;
 
 	@Override
-	public PackageMetadata findByNameAndVersionByMaxRepoOrder(String packageName, String packageVersion) {
-		List<PackageMetadata> packageMetadataList = this.packageMetadataRepository
+	public SkipperPackageMetadata findByNameAndVersionByMaxRepoOrder(String packageName, String packageVersion) {
+		List<SkipperPackageMetadata> packageMetadataList = this.packageMetadataRepository
 				.findByNameAndVersionOrderByApiVersionDesc(packageName,
 						packageVersion);
 		if (packageMetadataList.size() == 0) {
@@ -48,10 +48,10 @@ public class PackageMetadataRepositoryImpl implements PackageMetadataRepositoryC
 		if (packageMetadataList.size() == 1) {
 			return packageMetadataList.get(0);
 		}
-		List<Repository> repositoriesByRepoOrder = this.repositoryRepository.findAllByOrderByRepoOrderDesc();
-		for (Repository repository : repositoriesByRepoOrder) {
+		List<SkipperRepository> repositoriesByRepoOrder = this.repositoryRepository.findAllByOrderByRepoOrderDesc();
+		for (SkipperRepository repository : repositoriesByRepoOrder) {
 			Long repoId = repository.getId();
-			for (PackageMetadata packageMetadata : packageMetadataList) {
+			for (SkipperPackageMetadata packageMetadata : packageMetadataList) {
 				if ((packageMetadata.getRepositoryId() != null) && packageMetadata.getRepositoryId().equals(repoId)) {
 					return packageMetadata;
 				}
@@ -63,8 +63,8 @@ public class PackageMetadataRepositoryImpl implements PackageMetadataRepositoryC
 	}
 
 	@Override
-	public List<PackageMetadata> findByNameRequired(String packageName) {
-		List<PackageMetadata> packageMetadata = this.packageMetadataRepository.findByName(packageName);
+	public List<SkipperPackageMetadata> findByNameRequired(String packageName) {
+		List<SkipperPackageMetadata> packageMetadata = this.packageMetadataRepository.findByName(packageName);
 		if (packageMetadata.isEmpty()) {
 			throw new SkipperException(String.format("Can not find a package named '%s'", packageName));
 		}
@@ -72,9 +72,9 @@ public class PackageMetadataRepositoryImpl implements PackageMetadataRepositoryC
 	}
 
 	@Override
-	public PackageMetadata findByNameAndOptionalVersionRequired(String packageName, String packageVersion) {
+	public SkipperPackageMetadata findByNameAndOptionalVersionRequired(String packageName, String packageVersion) {
 		Assert.isTrue(StringUtils.hasText(packageName), "Package name must not be empty");
-		PackageMetadata packageMetadata;
+		SkipperPackageMetadata packageMetadata;
 		if (StringUtils.hasText(packageVersion)) {
 			packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder(packageName,
 					packageVersion);

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepository.java
@@ -17,11 +17,12 @@ package org.springframework.cloud.skipper.server.repository;
 
 import java.util.List;
 
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Mark Pollack
@@ -29,11 +30,11 @@ import org.springframework.data.rest.core.annotation.RestResource;
  */
 @RepositoryRestResource(path = "releases", collectionResourceRel = "releases")
 @SuppressWarnings("unchecked")
-public interface ReleaseRepository extends PagingAndSortingRepository<Release, Long>, ReleaseRepositoryCustom {
+public interface ReleaseRepository extends PagingAndSortingRepository<SkipperRelease, Long>, ReleaseRepositoryCustom {
 
 	@Override
 	@RestResource(exported = false)
-	Release save(Release release);
+	SkipperRelease save(SkipperRelease release);
 
 	@Override
 	@RestResource(exported = false)
@@ -41,20 +42,25 @@ public interface ReleaseRepository extends PagingAndSortingRepository<Release, L
 
 	@Override
 	@RestResource(exported = false)
-	void delete(Release release);
+	void delete(SkipperRelease release);
 
 	@Override
 	@RestResource(exported = false)
 	void deleteAll();
 
-	List<Release> findByNameOrderByVersionDesc(@Param("name") String name);
+	@Transactional(readOnly = true)
+	List<SkipperRelease> findByNameOrderByVersionDesc(@Param("name") String name);
 
-	List<Release> findByNameIgnoreCaseContainingOrderByNameAscVersionDesc(@Param("name") String name);
+	@Transactional(readOnly = true)
+	List<SkipperRelease> findByNameIgnoreCaseContainingOrderByNameAscVersionDesc(@Param("name") String name);
 
-	List<Release> findByNameAndVersionBetweenOrderByNameAscVersionDesc(@Param("name") String name,
+	@Transactional(readOnly = true)
+	List<SkipperRelease> findByNameAndVersionBetweenOrderByNameAscVersionDesc(@Param("name") String name,
 			@Param("from") int fromVersion, @Param("to") int toVersion);
 
-	Release findTopByNameOrderByVersionDesc(@Param("name") String name);
+	@Transactional(readOnly = true)
+	SkipperRelease findTopByNameOrderByVersionDesc(@Param("name") String name);
 
-	List<Release> findByNameIgnoreCaseContaining(@Param("name") String name);
+	@Transactional(readOnly = true)
+	List<SkipperRelease> findByNameIgnoreCaseContaining(@Param("name") String name);
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryCustom.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 
 /**
  * @author Mark Pollack
@@ -33,7 +33,7 @@ public interface ReleaseRepositoryCustom {
 	 * @return the Release object
 	 * @throws {@link ReleaseNotFoundException} if no Release for the given name can be found.
 	 */
-	Release findLatestRelease(String releaseName);
+	SkipperRelease findLatestRelease(String releaseName);
 
 	/**
 	 * Find the latest in time, release object, by name and with the deployed status.
@@ -41,7 +41,7 @@ public interface ReleaseRepositoryCustom {
 	 * @return the Release object
 	 * @throws {@link ReleaseNotFoundException} if no deployed Release for the given name can be found.
 	 */
-	Release findLatestDeployedRelease(String releaseName);
+	SkipperRelease findLatestDeployedRelease(String releaseName);
 
 	/**
 	 * Find the latest in time, release object, by name whose status is neither unknown nor failed.
@@ -51,7 +51,7 @@ public interface ReleaseRepositoryCustom {
 	 * @throws {@link ReleaseNotFoundException} if no latest Release (with the deployed/deleted status) for the given
 	 * name can be found.
 	 */
-	Release findLatestReleaseForUpdate(String releaseName);
+	SkipperRelease findLatestReleaseForUpdate(String releaseName);
 
 	/**
 	 * Find the release to rollback from the existing version.
@@ -60,7 +60,7 @@ public interface ReleaseRepositoryCustom {
 	 * @return the Release object to rollback to
 	 * @throws {@link ReleaseNotFoundException} if no latest Release found to rollback to.
 	 */
-	Release findReleaseToRollback(String releaseName);
+	SkipperRelease findReleaseToRollback(String releaseName);
 
 	/**
 	 * Find the release for the given release name and version
@@ -69,7 +69,7 @@ public interface ReleaseRepositoryCustom {
 	 * @return {@link ReleaseNotFoundException} if no Release for the given name and version
 	 * can be found.
 	 */
-	Release findByNameAndVersion(String releaseName, int version);
+	SkipperRelease findByNameAndVersion(String releaseName, int version);
 
 	/**
 	 * Find the revisions of the release, by name.
@@ -78,7 +78,7 @@ public interface ReleaseRepositoryCustom {
 	 * @return the list of Releases with their revisions as history
 	 * @throws SkipperException if no Release for the given name can be found.
 	 */
-	List<Release> findReleaseRevisions(String releaseName, int revisions);
+	List<SkipperRelease> findReleaseRevisions(String releaseName, int revisions);
 
 	/**
 	 * Find the latest status (deployed or failed) of the release, by the name.
@@ -86,7 +86,7 @@ public interface ReleaseRepositoryCustom {
 	 * @return list of releases (by the given name) that has the latest revision with the
 	 * state either deployed or failed.
 	 */
-	List<Release> findLatestDeployedOrFailed(String releaseName);
+	List<SkipperRelease> findLatestDeployedOrFailed(String releaseName);
 
 	/**
 	 * Find the latest status (deployed or failed) of all the releases.
@@ -94,7 +94,7 @@ public interface ReleaseRepositoryCustom {
 	 * @return list of releases that has the latest revision with the state either deployed or
 	 * failed.
 	 */
-	List<Release> findLatestDeployedOrFailed();
+	List<SkipperRelease> findLatestDeployedOrFailed();
 
 	/**
 	 * Return the release by the given name if the most recent status of the release is
@@ -104,6 +104,6 @@ public interface ReleaseRepositoryCustom {
 	 * @return if the latest status of the release is deleted then the release is returned,
 	 * otherwise null.
 	 */
-	Release findLatestReleaseIfDeleted(String releaseName);
+	SkipperRelease findLatestReleaseIfDeleted(String releaseName);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryImpl.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 
 /**
@@ -33,8 +33,8 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	private ReleaseRepository releaseRepository;
 
 	@Override
-	public Release findLatestRelease(String releaseName) {
-		Release latestRelease = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
+	public SkipperRelease findLatestRelease(String releaseName) {
+		SkipperRelease latestRelease = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
 		if (latestRelease == null) {
 			throw new ReleaseNotFoundException(releaseName);
 		}
@@ -42,9 +42,9 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
-	public Release findLatestDeployedRelease(String releaseName) {
-		List<Release> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
-		for (Release release : releases) {
+	public SkipperRelease findLatestDeployedRelease(String releaseName) {
+		List<SkipperRelease> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
+		for (SkipperRelease release : releases) {
 			if (release.getInfo().getStatus().getStatusCode().equals(StatusCode.DEPLOYED)) {
 				return release;
 			}
@@ -53,9 +53,9 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
-	public Release findLatestReleaseForUpdate(String releaseName) {
-		List<Release> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
-		for (Release release : releases) {
+	public SkipperRelease findLatestReleaseForUpdate(String releaseName) {
+		List<SkipperRelease> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
+		for (SkipperRelease release : releases) {
 			if (release.getInfo().getStatus().getStatusCode().equals(StatusCode.DEPLOYED) ||
 					release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
 				return release;
@@ -65,10 +65,10 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
-	public Release findReleaseToRollback(String releaseName) {
-		Release latestRelease = this.releaseRepository.findLatestReleaseForUpdate(releaseName);
-		List<Release> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
-		for (Release release : releases) {
+	public SkipperRelease findReleaseToRollback(String releaseName) {
+		SkipperRelease latestRelease = this.releaseRepository.findLatestReleaseForUpdate(releaseName);
+		List<SkipperRelease> releases = this.releaseRepository.findByNameOrderByVersionDesc(releaseName);
+		for (SkipperRelease release : releases) {
 			if ((release.getInfo().getStatus().getStatusCode().equals(StatusCode.DEPLOYED) ||
 					release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) &&
 					release.getVersion() != latestRelease.getVersion()) {
@@ -79,11 +79,11 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
-	public Release findByNameAndVersion(String releaseName, int version) {
-		Iterable<Release> releases = this.releaseRepository.findAll();
+	public SkipperRelease findByNameAndVersion(String releaseName, int version) {
+		Iterable<SkipperRelease> releases = this.releaseRepository.findAll();
 
-		Release matchingRelease = null;
-		for (Release release : releases) {
+		SkipperRelease matchingRelease = null;
+		for (SkipperRelease release : releases) {
 			if (release.getName().equals(releaseName) && release.getVersion() == version) {
 				matchingRelease = release;
 				break;
@@ -96,7 +96,7 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
-	public List<Release> findReleaseRevisions(String releaseName, int revisions) {
+	public List<SkipperRelease> findReleaseRevisions(String releaseName, int revisions) {
 		int latestVersion = findLatestRelease(releaseName).getVersion();
 		int lowerVersion = latestVersion - Integer.valueOf(revisions);
 		return this.releaseRepository.findByNameAndVersionBetweenOrderByNameAscVersionDesc(releaseName,
@@ -104,18 +104,18 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
-	public List<Release> findLatestDeployedOrFailed(String releaseName) {
+	public List<SkipperRelease> findLatestDeployedOrFailed(String releaseName) {
 		return getDeployedOrFailed(this.releaseRepository.findByNameIgnoreCaseContaining(releaseName));
 	}
 
 	@Override
-	public List<Release> findLatestDeployedOrFailed() {
+	public List<SkipperRelease> findLatestDeployedOrFailed() {
 		return getDeployedOrFailed(this.releaseRepository.findAll());
 	}
 
-	private List<Release> getDeployedOrFailed(Iterable<Release> allReleases) {
-		List<Release> releases = new ArrayList<>();
-		for (Release release : allReleases) {
+	private List<SkipperRelease> getDeployedOrFailed(Iterable<SkipperRelease> allReleases) {
+		List<SkipperRelease> releases = new ArrayList<>();
+		for (SkipperRelease release : allReleases) {
 			StatusCode releaseStatusCode = release.getInfo().getStatus().getStatusCode();
 			if (releaseStatusCode.equals(StatusCode.DEPLOYED) || releaseStatusCode.equals(StatusCode.FAILED)) {
 				releases.add(release);
@@ -125,8 +125,8 @@ public class ReleaseRepositoryImpl implements ReleaseRepositoryCustom {
 	}
 
 	@Override
-	public Release findLatestReleaseIfDeleted(String releaseName) {
-		Release latestRelease = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
+	public SkipperRelease findLatestReleaseIfDeleted(String releaseName) {
+		SkipperRelease latestRelease = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
 		return (latestRelease != null &&
 				latestRelease.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) ? latestRelease : null;
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/RepositoryRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/RepositoryRepository.java
@@ -17,7 +17,7 @@ package org.springframework.cloud.skipper.server.repository;
 
 import java.util.List;
 
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
@@ -26,16 +26,16 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  */
-@RepositoryRestResource(path = "repositories", collectionResourceRel = "repositories")
-public interface RepositoryRepository extends PagingAndSortingRepository<Repository, Long> {
+@RepositoryRestResource(path = "repositories", collectionResourceRel = "repositories", itemResourceRel = "repository")
+public interface RepositoryRepository extends PagingAndSortingRepository<SkipperRepository, Long> {
 
-	Repository findByName(@Param("name") String name);
+	SkipperRepository findByName(@Param("name") String name);
 
 	/**
 	 * Get all the repositories with their repository order in descending order.
 	 *
 	 * @return the list of repositories
 	 */
-	List<Repository> findAllByOrderByRepoOrderDesc();
+	List<SkipperRepository> findAllByOrderByRepoOrderDesc();
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageMetadataService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageMetadataService.java
@@ -30,8 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.cloud.skipper.io.TempFileUtils;
 import org.springframework.cloud.skipper.server.repository.RepositoryRepository;
 import org.springframework.context.ResourceLoaderAware;
@@ -60,12 +60,12 @@ public class PackageMetadataService implements ResourceLoaderAware {
 	 * Download package metadata from all repositories.
 	 * @return A list of package metadata, not yet persisted in the PackageMetadataRepository.
 	 */
-	public List<PackageMetadata> downloadPackageMetadata() {
-		List<PackageMetadata> finalMetadataList = new ArrayList<>();
+	public List<SkipperPackageMetadata> downloadPackageMetadata() {
+		List<SkipperPackageMetadata> finalMetadataList = new ArrayList<>();
 		Path targetPath = null;
 		try {
 			targetPath = TempFileUtils.createTempDirectory("skipperIndex");
-			for (Repository packageRepository : this.repositoryRepository.findAll()) {
+			for (SkipperRepository packageRepository : this.repositoryRepository.findAll()) {
 				try {
 					if (!packageRepository.isLocal()) {
 						Resource resource = resourceLoader.getResource(packageRepository.getUrl()
@@ -76,9 +76,9 @@ public class PackageMetadataService implements ResourceLoaderAware {
 							StreamUtils.copy(resource.getInputStream(), new FileOutputStream(downloadedFile));
 							List<File> downloadedFileAsList = new ArrayList<>();
 							downloadedFileAsList.add(downloadedFile);
-							List<PackageMetadata> downloadedPackageMetadata = deserializeFromIndexFiles(
+							List<SkipperPackageMetadata> downloadedPackageMetadata = deserializeFromIndexFiles(
 									downloadedFileAsList);
-							for (PackageMetadata packageMetadata : downloadedPackageMetadata) {
+							for (SkipperPackageMetadata packageMetadata : downloadedPackageMetadata) {
 								packageMetadata.setRepositoryId(packageRepository.getId());
 							}
 							finalMetadataList.addAll(downloadedPackageMetadata);
@@ -102,15 +102,15 @@ public class PackageMetadataService implements ResourceLoaderAware {
 		return finalMetadataList;
 	}
 
-	protected List<PackageMetadata> deserializeFromIndexFiles(List<File> indexFiles) {
-		List<PackageMetadata> packageMetadataList = new ArrayList<>();
+	protected List<SkipperPackageMetadata> deserializeFromIndexFiles(List<File> indexFiles) {
+		List<SkipperPackageMetadata> packageMetadataList = new ArrayList<>();
 		YAMLMapper yamlMapper = new YAMLMapper();
 		yamlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		for (File indexFile : indexFiles) {
 			try {
-				MappingIterator<PackageMetadata> it = yamlMapper.readerFor(PackageMetadata.class).readValues(indexFile);
+				MappingIterator<SkipperPackageMetadata> it = yamlMapper.readerFor(SkipperPackageMetadata.class).readValues(indexFile);
 				while (it.hasNextValue()) {
-					PackageMetadata packageMetadata = it.next();
+					SkipperPackageMetadata packageMetadata = it.next();
 					packageMetadataList.add(packageMetadata);
 				}
 			}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseReportService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseReportService.java
@@ -20,11 +20,11 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
@@ -72,14 +72,14 @@ public class ReleaseReportService {
 		Assert.notNull(upgradeRequest.getUpgradeProperties(), "UpgradeProperties can not be null");
 		Assert.notNull(upgradeRequest.getPackageIdentifier(), "PackageIdentifier can not be null");
 		UpgradeProperties upgradeProperties = upgradeRequest.getUpgradeProperties();
-		Release existingRelease = this.releaseRepository.findLatestReleaseForUpdate(upgradeProperties.getReleaseName());
-		Release latestRelease = this.releaseRepository.findLatestRelease(upgradeProperties.getReleaseName());
+		SkipperRelease existingRelease = this.releaseRepository.findLatestReleaseForUpdate(upgradeProperties.getReleaseName());
+		SkipperRelease latestRelease = this.releaseRepository.findLatestRelease(upgradeProperties.getReleaseName());
 		PackageIdentifier packageIdentifier = upgradeRequest.getPackageIdentifier();
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndOptionalVersionRequired(
+		SkipperPackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndOptionalVersionRequired(
 				packageIdentifier.getPackageName(),
 				packageIdentifier
 						.getPackageVersion());
-		Release replacingRelease = createReleaseForUpgrade(packageMetadata, latestRelease.getVersion() + 1,
+		SkipperRelease replacingRelease = createReleaseForUpgrade(packageMetadata, latestRelease.getVersion() + 1,
 				upgradeProperties,
 				existingRelease.getPlatformName());
 		Map<String, Object> model = ConfigValueUtils.mergeConfigValues(replacingRelease.getPkg(),
@@ -89,17 +89,17 @@ public class ReleaseReportService {
 		return this.releaseManager.createReport(existingRelease, replacingRelease);
 	}
 
-	private Release createReleaseForUpgrade(PackageMetadata packageMetadata, Integer newVersion,
+	private SkipperRelease createReleaseForUpgrade(SkipperPackageMetadata packageMetadata, Integer newVersion,
 			UpgradeProperties upgradeProperties, String platformName) {
 		Assert.notNull(upgradeProperties, "Upgrade Properties can not be null");
 		Package packageToInstall = this.packageService.downloadPackage(packageMetadata);
-		Release release = new Release();
+		SkipperRelease release = new SkipperRelease();
 		release.setName(upgradeProperties.getReleaseName());
 		release.setPlatformName(platformName);
 		release.setConfigValues(upgradeProperties.getConfigValues());
 		release.setPkg(packageToInstall);
 		release.setVersion(newVersion);
-		Info info = Info.createNewInfo("Upgrade install underway");
+		SkipperInfo info = SkipperInfo.createNewInfo("Upgrade install underway");
 		release.setInfo(info);
 		return release;
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseStateUpdateService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseStateUpdateService.java
@@ -20,8 +20,8 @@ import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.cloud.skipper.domain.Info;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -72,9 +72,9 @@ public class ReleaseStateUpdateService {
 			this.nextFullPoll = getNextFullPoll();
 			log.debug("Setup next full poll at {}", new Date(this.nextFullPoll));
 		}
-		Iterable<Release> releases = this.releaseRepository.findLatestDeployedOrFailed();
-		for (Release release : releases) {
-			Info info = release.getInfo();
+		Iterable<SkipperRelease> releases = this.releaseRepository.findLatestDeployedOrFailed();
+		for (SkipperRelease release : releases) {
+			SkipperInfo info = release.getInfo();
 			if (checkInfo(info)) {
 				// poll new apps every time or we do full poll anyway
 				boolean isNewApp = (info.getLastDeployed().getTime() > (now - 120000));
@@ -102,7 +102,7 @@ public class ReleaseStateUpdateService {
 		}
 	}
 
-	private boolean checkInfo(Info info) {
+	private boolean checkInfo(SkipperInfo info) {
 		if (info == null) {
 			throw new IllegalStateException("Info can not be null.");
 		}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/RepositoryInitializationService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/RepositoryInitializationService.java
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.cloud.skipper.server.config.SkipperServerProperties;
 import org.springframework.cloud.skipper.server.repository.PackageMetadataRepository;
 import org.springframework.cloud.skipper.server.repository.RepositoryRepository;
@@ -75,7 +75,7 @@ public class RepositoryInitializationService {
 
 	private void loadAllPackageMetadata() {
 		try {
-			List<PackageMetadata> packageMetadataList = this.packageMetadataService.downloadPackageMetadata();
+			List<SkipperPackageMetadata> packageMetadataList = this.packageMetadataService.downloadPackageMetadata();
 			this.packageMetadataRepository.save(packageMetadataList);
 		}
 		catch (SkipperException e) {
@@ -84,8 +84,8 @@ public class RepositoryInitializationService {
 	}
 
 	private void synchronizeRepositories() {
-		List<Repository> configurationRepositories = skipperServerProperties.getPackageRepositories();
-		for (Repository configurationRepository : configurationRepositories) {
+		List<SkipperRepository> configurationRepositories = skipperServerProperties.getPackageRepositories();
+		for (SkipperRepository configurationRepository : configurationRepositories) {
 			if (repositoryRepository.findByName(configurationRepository.getName()) == null) {
 				logger.info("Initializing repository database with " + configurationRepository);
 				repositoryRepository.save(configurationRepository);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
@@ -33,9 +33,9 @@ import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
@@ -103,7 +103,7 @@ public abstract class AbstractIntegrationTest extends AbstractAssertReleaseDeplo
 		// should go away once we introduce spring state machine.
 		try {
 			Thread.sleep(5000);
-			for (Release release : releaseRepository.findAll()) {
+			for (SkipperRelease release : releaseRepository.findAll()) {
 				if (release.getInfo().getStatus().getStatusCode() != StatusCode.DELETED) {
 					try {
 						logger.info("After test clean up, deleting release " + release.getName());
@@ -129,9 +129,9 @@ public abstract class AbstractIntegrationTest extends AbstractAssertReleaseDeplo
 		try {
 			logger.info("Checking status of release={} version={}", releaseName, releaseVersion);
 			// retrieve status from underlying AppDeployer
-			Release release = this.releaseManager
+			SkipperRelease release = this.releaseManager
 					.status(releaseRepository.findByNameAndVersion(releaseName, releaseVersion));
-			Info info = release.getInfo();
+			SkipperInfo info = release.getInfo();
 
 			logger.info("Status = " + info.getStatus());
 			return info.getStatus().getStatusCode().equals(StatusCode.DEPLOYED) &&
@@ -143,27 +143,27 @@ public abstract class AbstractIntegrationTest extends AbstractAssertReleaseDeplo
 		}
 	}
 
-	protected Release install(InstallRequest installRequest) throws InterruptedException {
-		Release release = releaseService.install(installRequest);
+	protected SkipperRelease install(InstallRequest installRequest) throws InterruptedException {
+		SkipperRelease release = releaseService.install(installRequest);
 		assertReleaseIsDeployedSuccessfully(release.getName(), release.getVersion());
 		return release;
 	}
 
-	protected Release upgrade(UpgradeRequest upgradeRequest) throws InterruptedException {
-		Release release = releaseService.upgrade(upgradeRequest);
+	protected SkipperRelease upgrade(UpgradeRequest upgradeRequest) throws InterruptedException {
+		SkipperRelease release = releaseService.upgrade(upgradeRequest);
 		assertReleaseIsDeployedSuccessfully(release.getName(), release.getVersion());
 		return release;
 	}
 
-	protected Release rollback(String releaseName, int releaseVersion) throws InterruptedException {
-		Release release = releaseService.rollback(releaseName, releaseVersion);
+	protected SkipperRelease rollback(String releaseName, int releaseVersion) throws InterruptedException {
+		SkipperRelease release = releaseService.rollback(releaseName, releaseVersion);
 		// Need to use the value of version passed back from calling rollback,
 		// since 0 implies most recent deleted release
 		assertReleaseIsDeployedSuccessfully(release.getName(), release.getVersion());
 		return release;
 	}
 
-	protected Release delete(String releaseName) {
+	protected SkipperRelease delete(String releaseName) {
 		logger.info("Deleting release {}", releaseName);
 		return releaseService.delete(releaseName);
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractMockMvcTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractMockMvcTests.java
@@ -35,8 +35,8 @@ import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfigurat
 import org.springframework.boot.autoconfigure.web.ErrorMvcAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.skipper.domain.Info;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
@@ -90,7 +90,7 @@ public abstract class AbstractMockMvcTests extends AbstractAssertReleaseDeployed
 			logger.info("Checking status of release={} version={}", releaseName, releaseVersion);
 			MvcResult result = mockMvc.perform(get(String.format("/api/status/%s/%s", releaseName, releaseVersion)))
 					.andReturn();
-			Info info = convertContentToInfo(result.getResponse().getContentAsString());
+			SkipperInfo info = convertContentToInfo(result.getResponse().getContentAsString());
 
 			logger.info("Status = " + info.getStatus());
 			return info.getStatus().getStatusCode().equals(StatusCode.DEPLOYED) &&
@@ -102,10 +102,10 @@ public abstract class AbstractMockMvcTests extends AbstractAssertReleaseDeployed
 		}
 	}
 
-	private Info convertContentToInfo(String json) {
+	private SkipperInfo convertContentToInfo(String json) {
 		ObjectMapper objectMapper = new ObjectMapper();
 		try {
-			return objectMapper.readValue(json, new TypeReference<Info>() {
+			return objectMapper.readValue(json, new TypeReference<SkipperInfo>() {
 			});
 		}
 		catch (IOException e) {
@@ -113,10 +113,10 @@ public abstract class AbstractMockMvcTests extends AbstractAssertReleaseDeployed
 		}
 	}
 
-	protected Release convertContentToRelease(String json) {
+	protected SkipperRelease convertContentToRelease(String json) {
 		ObjectMapper objectMapper = new ObjectMapper();
 		try {
-			return objectMapper.readValue(json, new TypeReference<Release>() {
+			return objectMapper.readValue(json, new TypeReference<SkipperRelease>() {
 			});
 		}
 		catch (IOException e) {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/SkipperControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/SkipperControllerTests.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ActiveProfiles;
@@ -46,7 +46,7 @@ public class SkipperControllerTests extends AbstractControllerTests {
 	@Test
 	public void deployTickTock() throws Exception {
 		String releaseName = "myTicker";
-		Release release = install("ticktock", "1.0.0", "myTicker");
+		SkipperRelease release = install("ticktock", "1.0.0", "myTicker");
 		assertThat(release.getVersion()).isEqualTo(1);
 	}
 
@@ -62,7 +62,7 @@ public class SkipperControllerTests extends AbstractControllerTests {
 		InstallProperties installProperties = createInstallProperties(releaseName);
 		installRequest.setInstallProperties(installProperties);
 
-		Release release = installPackage(installRequest);
+		SkipperRelease release = installPackage(installRequest);
 		assertReleaseIsDeployedSuccessfully(releaseName, 1);
 		assertThat(release.getVersion()).isEqualTo(1);
 	}
@@ -72,13 +72,13 @@ public class SkipperControllerTests extends AbstractControllerTests {
 
 		// Deploy
 		String releaseName = "test1";
-		Release release = install("log", "1.0.0", releaseName);
+		SkipperRelease release = install("log", "1.0.0", releaseName);
 		assertThat(release.getVersion()).isEqualTo(1);
 
 		// Undeploy
 		mockMvc.perform(post("/api/delete/" + releaseName)).andDo(print())
 				.andExpect(status().isCreated()).andReturn();
-		Release deletedRelease = this.releaseRepository.findByNameAndVersion(releaseName, 1);
+		SkipperRelease deletedRelease = this.releaseRepository.findByNameAndVersion(releaseName, 1);
 		assertThat(deletedRelease.getInfo().getStatus().getStatusCode()).isEqualTo(StatusCode.DELETED);
 	}
 
@@ -87,7 +87,7 @@ public class SkipperControllerTests extends AbstractControllerTests {
 
 		// Deploy
 		String releaseName = "test2";
-		Release release = install("log", "1.0.0", releaseName);
+		SkipperRelease release = install("log", "1.0.0", releaseName);
 		assertThat(release.getVersion()).isEqualTo(1);
 
 		// Check manifest
@@ -109,7 +109,7 @@ public class SkipperControllerTests extends AbstractControllerTests {
 		// the 1st.
 		releaseVersion = "3";
 
-		Release rollbackRelease = rollback(releaseName, 1);
+		SkipperRelease rollbackRelease = rollback(releaseName, 1);
 
 		release = this.releaseRepository.findByNameAndVersion(releaseName, Integer.valueOf(releaseVersion));
 		assertReleaseIsDeployedSuccessfully(releaseName, 3);
@@ -121,7 +121,7 @@ public class SkipperControllerTests extends AbstractControllerTests {
 		mockMvc.perform(post("/api/delete/" + releaseName))
 				.andDo(print())
 				.andExpect(status().isCreated()).andReturn();
-		Release deletedRelease = this.releaseRepository.findByNameAndVersion(releaseName,
+		SkipperRelease deletedRelease = this.releaseRepository.findByNameAndVersion(releaseName,
 				Integer.valueOf(releaseVersion));
 		assertThat(deletedRelease.getInfo().getStatus().getStatusCode()).isEqualTo(StatusCode.DELETED);
 	}
@@ -129,7 +129,7 @@ public class SkipperControllerTests extends AbstractControllerTests {
 	@Test
 	public void packageDeployAndUpgrade() throws Exception {
 		String releaseName = "myLog";
-		Release release = install("log", "1.0.0", releaseName);
+		SkipperRelease release = install("log", "1.0.0", releaseName);
 		assertThat(release.getVersion()).isEqualTo(1);
 
 		// Upgrade

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -123,7 +123,7 @@ public class InstallDocumentation extends BaseDocumentation {
 		installRequest.setPackageIdentifier(packageIdentifier);
 		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
-		final Release release = installPackage(installRequest);
+		final SkipperRelease release = installPackage(installRequest);
 
 		final String releaseName2 = "myLogReleaseWithInstallProperties";
 		final InstallProperties installProperties2 = createInstallProperties(releaseName2);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ManifestDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ManifestDocumentation.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -50,7 +50,7 @@ public class ManifestDocumentation extends BaseDocumentation {
 		installRequest.setPackageIdentifier(packageIdentifier);
 		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
-		final Release release = installPackage(installRequest);
+		final SkipperRelease release = installPackage(installRequest);
 
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
@@ -75,7 +75,7 @@ public class ManifestDocumentation extends BaseDocumentation {
 		installRequest.setPackageIdentifier(packageIdentifier);
 		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
-		final Release release = installPackage(installRequest);
+		final SkipperRelease release = installPackage(installRequest);
 
 		this.mockMvc.perform(
 				get("/api/manifest/{releaseName}/{releaseVersion}",

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
@@ -106,7 +106,7 @@ public class RollbackDocumentation extends BaseDocumentation {
 								fieldWithPath("manifest").description("The manifest of the release"),
 								fieldWithPath("platformName").description("Platform name of the release"))))
 				.andReturn();
-		Release release = convertContentToRelease(result.getResponse().getContentAsString());
+		SkipperRelease release = convertContentToRelease(result.getResponse().getContentAsString());
 		assertReleaseIsDeployedSuccessfully(releaseName, release.getVersion());
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -50,7 +50,7 @@ public class StatusDocumentation extends BaseDocumentation {
 		installRequest.setPackageIdentifier(packageIdentifier);
 		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
-		final Release release = installPackage(installRequest);
+		final SkipperRelease release = installPackage(installRequest);
 
 		this.mockMvc.perform(
 				get("/api/status/{releaseName}", release.getName())).andDo(print())
@@ -80,7 +80,7 @@ public class StatusDocumentation extends BaseDocumentation {
 		installRequest.setPackageIdentifier(packageIdentifier);
 		installRequest.setInstallProperties(createInstallProperties(releaseName));
 
-		final Release release = installPackage(installRequest);
+		final SkipperRelease release = installPackage(installRequest);
 
 		this.mockMvc.perform(
 				get("/api/status/{releaseName}/{releaseVersion}",

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
@@ -126,7 +126,7 @@ public class UpgradeDocumentation extends BaseDocumentation {
 								fieldWithPath("manifest").description("The manifest of the release"),
 								fieldWithPath("platformName").description("Platform name of the release"))))
 				.andReturn();
-		Release release = convertContentToRelease(result.getResponse().getContentAsString());
+		SkipperRelease release = convertContentToRelease(result.getResponse().getContentAsString());
 		assertReleaseIsDeployedSuccessfully(releaseName, release.getVersion());
 	}
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UploadDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UploadDocumentation.java
@@ -20,7 +20,7 @@ import java.nio.charset.Charset;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.cloud.skipper.server.repository.RepositoryRepository;
 import org.springframework.core.io.ClassPathResource;
@@ -48,7 +48,7 @@ public class UploadDocumentation extends BaseDocumentation {
 	@Test
 	public void uploadRelease() throws Exception {
 
-		final Repository repository = new Repository();
+		final SkipperRepository repository = new SkipperRepository();
 		repository.setName("database-repo");
 		repository.setUrl("http://example.com/repository/");
 		super.context.getBean(RepositoryRepository.class).save(repository);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataCreator.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataCreator.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.repository;
 
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 
 /**
  * @author Mark Pollack
@@ -23,7 +23,7 @@ import org.springframework.cloud.skipper.domain.PackageMetadata;
 public class PackageMetadataCreator {
 
 	public static void createTwoPackages(PackageMetadataRepository repository) {
-		PackageMetadata packageMetadata = new PackageMetadata();
+		SkipperPackageMetadata packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setOrigin("www.package-repos.com/repo1");
 		packageMetadata.setRepositoryId(1L);
@@ -34,7 +34,7 @@ public class PackageMetadataCreator {
 		packageMetadata.setDescription("A very cool project");
 		packageMetadata.setMaintainer("Alan Hale Jr.");
 		repository.save(packageMetadata);
-		packageMetadata = new PackageMetadata();
+		packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setRepositoryId(1L);
 		packageMetadata.setOrigin("www.package-repos.com/repo2");
@@ -48,7 +48,7 @@ public class PackageMetadataCreator {
 	}
 
 	public static void createPackageWithMultipleVersions(PackageMetadataRepository repository) {
-		PackageMetadata packageMetadata = new PackageMetadata();
+		SkipperPackageMetadata packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setRepositoryId(1L);
 		packageMetadata.setKind("skipper");
@@ -58,7 +58,7 @@ public class PackageMetadataCreator {
 		packageMetadata.setDescription("A very cool project");
 		packageMetadata.setMaintainer("Alan Hale Jr.");
 		repository.save(packageMetadata);
-		packageMetadata = new PackageMetadata();
+		packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setRepositoryId(1L);
 		packageMetadata.setKind("skipper");
@@ -68,7 +68,7 @@ public class PackageMetadataCreator {
 		packageMetadata.setMaintainer("Bob Denver");
 		packageMetadata.setDescription("Another very cool project");
 		repository.save(packageMetadata);
-		packageMetadata = new PackageMetadata();
+		packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setRepositoryId(1L);
 		packageMetadata.setKind("skipper");
@@ -78,7 +78,7 @@ public class PackageMetadataCreator {
 		packageMetadata.setMaintainer("Bob Denver");
 		packageMetadata.setDescription("Another very cool project");
 		repository.save(packageMetadata);
-		packageMetadata = new PackageMetadata();
+		packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setRepositoryId(1L);
 		packageMetadata.setKind("skipper");
@@ -91,7 +91,7 @@ public class PackageMetadataCreator {
 	}
 
 	public static void createTwoPackages(PackageMetadataRepository repository, Long repoId, String apiVersion) {
-		PackageMetadata packageMetadata = new PackageMetadata();
+		SkipperPackageMetadata packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setApiVersion(apiVersion);
 		packageMetadata.setRepositoryId(repoId);
 		packageMetadata.setKind("skipper");
@@ -101,7 +101,7 @@ public class PackageMetadataCreator {
 		packageMetadata.setDescription("A very cool project");
 		packageMetadata.setMaintainer("Alan Hale Jr.");
 		repository.save(packageMetadata);
-		packageMetadata = new PackageMetadata();
+		packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setApiVersion(apiVersion);
 		packageMetadata.setRepositoryId(repoId);
 		packageMetadata.setKind("skipper");

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataMvcTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataMvcTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.skipper.server.repository;
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.cloud.skipper.server.AbstractMockMvcTests;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -47,7 +47,7 @@ public class PackageMetadataMvcTests extends AbstractMockMvcTests {
 	@Test
 	public void testProjection() throws Exception {
 		PackageMetadataCreator.createTwoPackages(packageMetadataRepository);
-		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("package1", "1.0.0");
+		SkipperPackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("package1", "1.0.0");
 		assertThat(packageMetadata.getId()).isNotNull();
 		packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("package2", "2.0.0");
 		assertThat(packageMetadata.getId()).isNotNull();

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryTests.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.cloud.skipper.server.AbstractIntegrationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,15 +40,15 @@ public class PackageMetadataRepositoryTests extends AbstractIntegrationTest {
 	@Test
 	public void basicCrud() {
 		PackageMetadataCreator.createTwoPackages(this.packageMetadataRepository);
-		Iterable<PackageMetadata> packages = this.packageMetadataRepository.findAll();
+		Iterable<SkipperPackageMetadata> packages = this.packageMetadataRepository.findAll();
 		assertThat(packages).isNotEmpty();
 		assertThat(packages).hasSize(2);
-		List<PackageMetadata> packagesNamed1 = this.packageMetadataRepository.findByNameRequired("package1");
+		List<SkipperPackageMetadata> packagesNamed1 = this.packageMetadataRepository.findByNameRequired("package1");
 		assertThat(packagesNamed1).isNotEmpty();
 		assertThat(packagesNamed1).hasSize(1);
 		assertThat(packagesNamed1.get(0).getOrigin()).isEqualTo("www.package-repos.com/repo1");
 		assertThat(packagesNamed1.get(0).getMaintainer()).isEqualTo("Alan Hale Jr.");
-		List<PackageMetadata> packagesNamed2 = this.packageMetadataRepository.findByNameRequired("package2");
+		List<SkipperPackageMetadata> packagesNamed2 = this.packageMetadataRepository.findByNameRequired("package2");
 		assertThat(packagesNamed2).isNotEmpty();
 		assertThat(packagesNamed2).hasSize(1);
 		assertThat(packagesNamed2.get(0).getMaintainer()).isEqualTo("Bob Denver");
@@ -58,25 +58,25 @@ public class PackageMetadataRepositoryTests extends AbstractIntegrationTest {
 	@Test
 	public void verifyMultipleVersions() {
 		PackageMetadataCreator.createPackageWithMultipleVersions(this.packageMetadataRepository);
-		Iterable<PackageMetadata> packages = this.packageMetadataRepository.findAll();
+		Iterable<SkipperPackageMetadata> packages = this.packageMetadataRepository.findAll();
 		assertThat(packages).isNotEmpty();
 		assertThat(packages).hasSize(4);
-		PackageMetadata latestPackage1 = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc("package1");
+		SkipperPackageMetadata latestPackage1 = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc("package1");
 		assertThat(latestPackage1.getVersion()).isEqualTo("2.0.0");
-		PackageMetadata latestPackage2 = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc("package2");
+		SkipperPackageMetadata latestPackage2 = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc("package2");
 		assertThat(latestPackage2.getVersion()).isEqualTo("1.1.0");
 	}
 
 	@Test
 	public void findByNameQueries() {
 		PackageMetadataCreator.createPackageWithMultipleVersions(this.packageMetadataRepository);
-		Iterable<PackageMetadata> packages = this.packageMetadataRepository.findByNameContainingIgnoreCase("PACK");
+		Iterable<SkipperPackageMetadata> packages = this.packageMetadataRepository.findByNameContainingIgnoreCase("PACK");
 		assertThat(packages).isNotEmpty();
 		assertThat(packages).hasSize(4);
-		Iterable<PackageMetadata> packages2 = this.packageMetadataRepository.findByNameContainingIgnoreCase("age");
+		Iterable<SkipperPackageMetadata> packages2 = this.packageMetadataRepository.findByNameContainingIgnoreCase("age");
 		assertThat(packages2).isNotEmpty();
 		assertThat(packages2).hasSize(4);
-		Iterable<PackageMetadata> packages3 = this.packageMetadataRepository.findByNameContainingIgnoreCase("1");
+		Iterable<SkipperPackageMetadata> packages3 = this.packageMetadataRepository.findByNameContainingIgnoreCase("1");
 		assertThat(packages3).isNotEmpty();
 		assertThat(packages3).hasSize(2);
 	}
@@ -95,14 +95,14 @@ public class PackageMetadataRepositoryTests extends AbstractIntegrationTest {
 				this.repositoryRepository.findByName(repoName2).getId(), "2.0.1");
 		PackageMetadataCreator.createTwoPackages(this.packageMetadataRepository,
 				this.repositoryRepository.findByName(repoName3).getId(), "1.0.1");
-		List<PackageMetadata> packageMetadataList = this.packageMetadataRepository
+		List<SkipperPackageMetadata> packageMetadataList = this.packageMetadataRepository
 				.findByNameAndVersionOrderByApiVersionDesc("package1", "1.0.0");
 		assertThat(packageMetadataList.size()).isEqualTo(3);
 		assertThat(packageMetadataList.get(0).getName()).isEqualTo("package1");
 		assertThat(packageMetadataList.get(0).getVersion()).isEqualTo("1.0.0");
 		assertThat(packageMetadataList.get(0).getRepositoryId()).isEqualTo(this.repositoryRepository.findByName(repoName2)
 				.getId());
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("package1",
+		SkipperPackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("package1",
 				"1.0.0");
 		assertThat(packageMetadata.getApiVersion()).isEqualTo("1.0.1");
 		assertThat(packageMetadata.getRepositoryId()).isEqualTo(this.repositoryRepository.findByName(repoName3).getId());

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
@@ -21,11 +21,11 @@ import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
-import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.Package;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Release;
-import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
+import org.springframework.cloud.skipper.domain.SkipperStatus;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.AbstractIntegrationTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -46,43 +46,43 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 
 	@Test
 	public void verifyFindByMethods() {
-		PackageMetadata packageMetadata1 = new PackageMetadata();
+		SkipperPackageMetadata packageMetadata1 = new SkipperPackageMetadata();
 		packageMetadata1.setName("package1");
 		packageMetadata1.setVersion("1.0.0");
 		Package pkg1 = new Package();
 		pkg1.setMetadata(packageMetadata1);
 
-		PackageMetadata packageMetadata2 = new PackageMetadata();
+		SkipperPackageMetadata packageMetadata2 = new SkipperPackageMetadata();
 		packageMetadata2.setName("package2");
 		packageMetadata2.setVersion("1.0.1");
 		Package pkg2 = new Package();
 		pkg2.setMetadata(packageMetadata2);
 
-		Info deletedInfo = new Info();
-		Status deletedStatus = new Status();
+		SkipperInfo deletedInfo = new SkipperInfo();
+		SkipperStatus deletedStatus = new SkipperStatus();
 		deletedStatus.setPlatformStatus("Deleted successfully");
 		deletedStatus.setStatusCode(StatusCode.DELETED);
 		deletedInfo.setStatus(deletedStatus);
 
-		Info deployedInfo = new Info();
-		Status deployedStatus = new Status();
+		SkipperInfo deployedInfo = new SkipperInfo();
+		SkipperStatus deployedStatus = new SkipperStatus();
 		deployedStatus.setPlatformStatus("Deployed successfully");
 		deployedStatus.setStatusCode(StatusCode.DEPLOYED);
 		deployedInfo.setStatus(deployedStatus);
 
-		Info unknownInfo = new Info();
-		Status unknownStatus = new Status();
+		SkipperInfo unknownInfo = new SkipperInfo();
+		SkipperStatus unknownStatus = new SkipperStatus();
 		unknownStatus.setPlatformStatus("Unknown");
 		unknownStatus.setStatusCode(StatusCode.UNKNOWN);
 		unknownInfo.setStatus(unknownStatus);
 
-		Info failedInfo = new Info();
-		Status failedStatus = new Status();
+		SkipperInfo failedInfo = new SkipperInfo();
+		SkipperStatus failedStatus = new SkipperStatus();
 		failedStatus.setPlatformStatus("Deployment failed");
 		failedStatus.setStatusCode(StatusCode.FAILED);
 		failedInfo.setStatus(failedStatus);
 
-		Release release1 = new Release();
+		SkipperRelease release1 = new SkipperRelease();
 		release1.setName("stableA");
 		release1.setVersion(1);
 		release1.setPlatformName("platform1");
@@ -90,7 +90,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release1.setInfo(deletedInfo);
 		this.releaseRepository.save(release1);
 
-		Release release2 = new Release();
+		SkipperRelease release2 = new SkipperRelease();
 		release2.setName(release1.getName());
 		release2.setVersion(2);
 		release2.setPlatformName(release1.getPlatformName());
@@ -98,7 +98,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release2.setInfo(deletedInfo);
 		this.releaseRepository.save(release2);
 
-		Release release3 = new Release();
+		SkipperRelease release3 = new SkipperRelease();
 		release3.setName(release1.getName());
 		release3.setVersion(3);
 		release3.setPlatformName(release1.getPlatformName());
@@ -106,7 +106,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release3.setInfo(deployedInfo);
 		this.releaseRepository.save(release3);
 
-		Release release4 = new Release();
+		SkipperRelease release4 = new SkipperRelease();
 		release4.setName("stableB");
 		release4.setVersion(1);
 		release4.setPlatformName("platform2");
@@ -114,7 +114,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release4.setInfo(deletedInfo);
 		this.releaseRepository.save(release4);
 
-		Release release5 = new Release();
+		SkipperRelease release5 = new SkipperRelease();
 		release5.setName(release4.getName());
 		release5.setVersion(2);
 		release5.setPlatformName(release4.getPlatformName());
@@ -122,7 +122,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release5.setInfo(failedInfo);
 		this.releaseRepository.save(release5);
 
-		Release release6 = new Release();
+		SkipperRelease release6 = new SkipperRelease();
 		release6.setName("multipleDeleted");
 		release6.setVersion(1);
 		release6.setPlatformName("platform2");
@@ -130,7 +130,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release6.setInfo(deployedInfo);
 		this.releaseRepository.save(release6);
 
-		Release release7 = new Release();
+		SkipperRelease release7 = new SkipperRelease();
 		release7.setName(release6.getName());
 		release7.setVersion(2);
 		release7.setPlatformName(release6.getPlatformName());
@@ -138,7 +138,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release7.setInfo(deletedInfo);
 		this.releaseRepository.save(release7);
 
-		Release release8 = new Release();
+		SkipperRelease release8 = new SkipperRelease();
 		release8.setName(release6.getName());
 		release8.setVersion(3);
 		release8.setPlatformName(release6.getPlatformName());
@@ -146,7 +146,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release8.setInfo(failedInfo);
 		this.releaseRepository.save(release8);
 
-		Release release9 = new Release();
+		SkipperRelease release9 = new SkipperRelease();
 		release9.setName(release6.getName());
 		release9.setVersion(4);
 		release9.setPlatformName(release6.getPlatformName());
@@ -154,7 +154,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release9.setInfo(deletedInfo);
 		this.releaseRepository.save(release9);
 
-		Release release10 = new Release();
+		SkipperRelease release10 = new SkipperRelease();
 		release10.setName("multipleRevisions1");
 		release10.setVersion(1);
 		release10.setPlatformName("platform2");
@@ -162,7 +162,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release10.setInfo(deployedInfo);
 		this.releaseRepository.save(release10);
 
-		Release release11 = new Release();
+		SkipperRelease release11 = new SkipperRelease();
 		release11.setName(release10.getName());
 		release11.setVersion(2);
 		release11.setPlatformName(release10.getPlatformName());
@@ -170,7 +170,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release11.setInfo(failedInfo);
 		this.releaseRepository.save(release11);
 
-		Release release12 = new Release();
+		SkipperRelease release12 = new SkipperRelease();
 		release12.setName(release10.getName());
 		release12.setVersion(3);
 		release12.setPlatformName(release10.getPlatformName());
@@ -178,7 +178,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release12.setInfo(failedInfo);
 		this.releaseRepository.save(release12);
 
-		Release release13 = new Release();
+		SkipperRelease release13 = new SkipperRelease();
 		release13.setName("multipleRevisions2");
 		release13.setVersion(1);
 		release13.setPlatformName("platform2");
@@ -186,7 +186,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release13.setInfo(deployedInfo);
 		this.releaseRepository.save(release13);
 
-		Release release14 = new Release();
+		SkipperRelease release14 = new SkipperRelease();
 		release14.setName(release13.getName());
 		release14.setVersion(2);
 		release14.setPlatformName(release13.getPlatformName());
@@ -194,7 +194,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release14.setInfo(deletedInfo);
 		this.releaseRepository.save(release14);
 
-		Release release15 = new Release();
+		SkipperRelease release15 = new SkipperRelease();
 		release15.setName(release13.getName());
 		release15.setVersion(3);
 		release15.setPlatformName(release13.getPlatformName());
@@ -202,7 +202,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release15.setInfo(unknownInfo);
 		this.releaseRepository.save(release15);
 
-		Release release16 = new Release();
+		SkipperRelease release16 = new SkipperRelease();
 		release16.setName("multipleRevisions3");
 		release16.setVersion(1);
 		release16.setPlatformName(release16.getPlatformName());
@@ -210,7 +210,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		release16.setInfo(failedInfo);
 		this.releaseRepository.save(release16);
 
-		Release release17 = new Release();
+		SkipperRelease release17 = new SkipperRelease();
 		release17.setName(release16.getName());
 		release17.setVersion(2);
 		release17.setPlatformName(release16.getPlatformName());
@@ -219,12 +219,12 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		this.releaseRepository.save(release17);
 
 		// findAll
-		Iterable<Release> releases = this.releaseRepository.findAll();
+		Iterable<SkipperRelease> releases = this.releaseRepository.findAll();
 		assertThat(releases).isNotEmpty();
 		assertThat(releases).hasSize(17);
 
 		// findByNameAndVersionOrderByApiVersionDesc
-		Release foundByNameAndVersion = this.releaseRepository.findByNameAndVersion(release1.getName(), 2);
+		SkipperRelease foundByNameAndVersion = this.releaseRepository.findByNameAndVersion(release1.getName(), 2);
 		assertThat(foundByNameAndVersion).isNotNull();
 		assertThat(foundByNameAndVersion.getInfo().getStatus().getStatusCode()).isEqualTo(release2.getInfo().getStatus()
 				.getStatusCode());
@@ -236,7 +236,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 				.getName());
 
 		// findLatestRelease
-		Release latestRelease = this.releaseRepository.findLatestRelease(release1.getName());
+		SkipperRelease latestRelease = this.releaseRepository.findLatestRelease(release1.getName());
 		assertThat(latestRelease).isNotNull();
 		assertThat(latestRelease.getName()).isEqualTo(release3.getName());
 		assertThat(latestRelease.getVersion()).isEqualTo(release3.getVersion());
@@ -244,7 +244,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 				.isEqualTo(release3.getInfo().getStatus().getStatusCode());
 
 		// findReleaseRevisions
-		List<Release> releaseRevisions = this.releaseRepository.findReleaseRevisions(release1.getName(), 2);
+		List<SkipperRelease> releaseRevisions = this.releaseRepository.findReleaseRevisions(release1.getName(), 2);
 		assertThat(releaseRevisions).isNotEmpty();
 		assertThat(releaseRevisions).hasSize(2);
 		assertThat(releaseRevisions.get(0).getName()).isEqualTo(release3.getName());
@@ -257,7 +257,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 				.getStatus().getStatusCode());
 
 		// findByNameIgnoreCaseContainingOrderByNameAscVersionDesc
-		List<Release> orderByVersion = this.releaseRepository
+		List<SkipperRelease> orderByVersion = this.releaseRepository
 				.findByNameIgnoreCaseContainingOrderByNameAscVersionDesc(release4.getName());
 		assertThat(orderByVersion).isNotEmpty();
 		assertThat(orderByVersion).hasSize(2);
@@ -271,34 +271,34 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 				.getStatus().getStatusCode());
 
 		// findByNameIgnoreCaseContaining
-		List<Release> byNameLike = this.releaseRepository.findByNameIgnoreCaseContaining("stable");
+		List<SkipperRelease> byNameLike = this.releaseRepository.findByNameIgnoreCaseContaining("stable");
 		assertThat(byNameLike).isNotEmpty();
 		assertThat(byNameLike).hasSize(5);
 
 		// findLatestDeployedOrFailed
-		List<Release> deployedOrFailed = this.releaseRepository.findLatestDeployedOrFailed("stable");
+		List<SkipperRelease> deployedOrFailed = this.releaseRepository.findLatestDeployedOrFailed("stable");
 		assertThat(deployedOrFailed).isNotEmpty();
 		assertThat(deployedOrFailed).hasSize(2);
 
-		List<Release> deployedOrFailedAll = this.releaseRepository.findLatestDeployedOrFailed("");
+		List<SkipperRelease> deployedOrFailedAll = this.releaseRepository.findLatestDeployedOrFailed("");
 		assertThat(deployedOrFailedAll).isNotEmpty();
 		assertThat(deployedOrFailedAll).hasSize(9);
 
-		Release latestDeletedRelease1 = this.releaseRepository.findLatestReleaseIfDeleted(release1.getName());
+		SkipperRelease latestDeletedRelease1 = this.releaseRepository.findLatestReleaseIfDeleted(release1.getName());
 		assertThat(latestDeletedRelease1).isNull();
 
-		Release latestDeletedRelease2 = this.releaseRepository.findLatestReleaseIfDeleted(release6.getName());
+		SkipperRelease latestDeletedRelease2 = this.releaseRepository.findLatestReleaseIfDeleted(release6.getName());
 		assertThat(latestDeletedRelease2.getVersion()).isEqualTo(4);
 
 		// deployed -> failed -> failed
-		Release latestReleaseForUpdate1 = this.releaseRepository.findLatestReleaseForUpdate(release10.getName());
+		SkipperRelease latestReleaseForUpdate1 = this.releaseRepository.findLatestReleaseForUpdate(release10.getName());
 		assertThat(latestReleaseForUpdate1.getVersion()).isEqualTo(1);
 		// deployed -> deleted -> unknown
-		Release latestReleaseForUpdate2 = this.releaseRepository.findLatestReleaseForUpdate(release13.getName());
+		SkipperRelease latestReleaseForUpdate2 = this.releaseRepository.findLatestReleaseForUpdate(release13.getName());
 		assertThat(latestReleaseForUpdate2.getVersion()).isEqualTo(2);
 
 		// deployed -> deleted -> unknown
-		Release latestDeployedRelease = this.releaseRepository.findLatestDeployedRelease(release13.getName());
+		SkipperRelease latestDeployedRelease = this.releaseRepository.findLatestDeployedRelease(release13.getName());
 		assertThat(latestDeployedRelease.getVersion()).isEqualTo(1);
 
 		try {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryCreator.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryCreator.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.repository;
 
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 
 /**
  * @author Mark Pollack
@@ -24,11 +24,11 @@ import org.springframework.cloud.skipper.domain.Repository;
 public class RepositoryCreator {
 
 	public static void createTwoRepositories(RepositoryRepository repositoryRepository) {
-		Repository repository = new Repository();
+		SkipperRepository repository = new SkipperRepository();
 		repository.setName("stable");
 		repository.setUrl("http://www.example.com/skipper/repository/stable");
 		repositoryRepository.save(repository);
-		repository = new Repository();
+		repository = new SkipperRepository();
 		repository.setName("unstable");
 		repository.setUrl("http://www.example.com/skipper/repository/unstable");
 		repositoryRepository.save(repository);
@@ -36,7 +36,7 @@ public class RepositoryCreator {
 
 	public static void createRepository(RepositoryRepository repositoryRepository, String repoName,
 			Integer repoOrder) {
-		Repository repository = new Repository();
+		SkipperRepository repository = new SkipperRepository();
 		repository.setName(repoName);
 		repository.setUrl("http://www.example.com/skipper/repository/" + repoName);
 		repositoryRepository.save(repository);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryRepositoryTests.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.cloud.skipper.server.AbstractIntegrationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +42,7 @@ public class RepositoryRepositoryTests extends AbstractIntegrationTest {
 	}
 
 	private void deleteRepoIfExists(String repoName) {
-		Repository repo = repositoryRepository.findByName(repoName);
+		SkipperRepository repo = repositoryRepository.findByName(repoName);
 		if (repo != null) {
 			this.repositoryRepository.delete(repo);
 		}
@@ -51,11 +51,11 @@ public class RepositoryRepositoryTests extends AbstractIntegrationTest {
 	@Test
 	public void basicCrud() {
 		RepositoryCreator.createTwoRepositories(repositoryRepository);
-		Iterable<Repository> repositories = repositoryRepository.findAll();
+		Iterable<SkipperRepository> repositories = repositoryRepository.findAll();
 		assertThat(repositories).isNotEmpty();
-		Repository repo1 = repositoryRepository.findByName("stable");
+		SkipperRepository repo1 = repositoryRepository.findByName("stable");
 		assertThat(repo1.getUrl()).isEqualTo("http://www.example.com/skipper/repository/stable");
-		Repository repo2 = repositoryRepository.findByName("unstable");
+		SkipperRepository repo2 = repositoryRepository.findByName("unstable");
 		assertThat(repo2.getUrl()).isEqualTo("http://www.example.com/skipper/repository/unstable");
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageServiceTests.java
@@ -28,8 +28,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Package;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.cloud.skipper.server.AbstractIntegrationTest;
@@ -69,7 +69,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 
 	@Test
 	public void testExceptions() {
-		PackageMetadata packageMetadata = new PackageMetadata();
+		SkipperPackageMetadata packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setName("noname");
 		packageMetadata.setVersion("noversion");
 		assertThat(packageService).isNotNull();
@@ -82,7 +82,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 
 	@Test
 	public void download() {
-		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "1.0.0");
+		SkipperPackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "1.0.0");
 		// Other tests may have caused the file to be loaded into the database, ensure we start
 		// fresh.
 		if (packageMetadata.getPackageFileBytes() != null) {
@@ -95,7 +95,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 		assertThat(packageService).isNotNull();
 		assertThat(packageMetadata.getId()).isNotNull();
 		assertThat(packageMetadata.getRepositoryId()).isNotNull();
-		Repository repository = repositoryRepository.findOne(packageMetadata.getRepositoryId());
+		SkipperRepository repository = repositoryRepository.findOne(packageMetadata.getRepositoryId());
 		assertThat(repository).isNotNull();
 
 		Package downloadedPackage = packageService.downloadPackage(packageMetadata);
@@ -110,13 +110,13 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 	@Test
 	public void upload() throws Exception {
 		// Create throw away repository, treated to be a 'local' database repo by default for now.
-		Repository repository = new Repository();
+		SkipperRepository repository = new SkipperRepository();
 		repository.setName("database-repo");
 		repository.setUrl("http://example.com/repository/");
 		this.repositoryRepository.save(repository);
 
 		// Package log 9.9.9 should not exist, since it hasn't been uploaded yet.
-		PackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "9.9.9");
+		SkipperPackageMetadata packageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log", "9.9.9");
 		assertThat(packageMetadata).isNull();
 
 		UploadRequest uploadProperties = new UploadRequest();
@@ -134,12 +134,12 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 
 		// Upload new package
 		assertThat(packageService).isNotNull();
-		PackageMetadata uploadedPackageMetadata = this.packageService.upload(uploadProperties);
+		SkipperPackageMetadata uploadedPackageMetadata = this.packageService.upload(uploadProperties);
 		assertThat(uploadedPackageMetadata.getName().equals("log")).isTrue();
 		assertThat(uploadedPackageMetadata.getVersion().equals("9.9.9")).isTrue();
 
 		// Retrieve new package
-		PackageMetadata retrievedPackageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log",
+		SkipperPackageMetadata retrievedPackageMetadata = packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log",
 				"9.9.9");
 		assertThat(retrievedPackageMetadata.getName().equals("log")).isTrue();
 		assertThat(retrievedPackageMetadata.getVersion().equals("9.9.9")).isTrue();
@@ -158,7 +158,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 
 	@Test
 	public void deserializePackage() {
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log",
+		SkipperPackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("log",
 				"1.0.0");
 		assertThat(packageService).isNotNull();
 		Package pkg = packageService.downloadPackage(packageMetadata);
@@ -173,7 +173,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 
 	@Test
 	public void deserializeNestedPackage() {
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("ticktock",
+		SkipperPackageMetadata packageMetadata = this.packageMetadataRepository.findByNameAndVersionByMaxRepoOrder("ticktock",
 				"1.0.0");
 		assertThat(packageService).isNotNull();
 		Package pkg = packageService.downloadPackage(packageMetadata);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseAnalyzerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseAnalyzerTests.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.AbstractIntegrationTest;
@@ -74,7 +74,7 @@ public class ReleaseAnalyzerTests extends AbstractIntegrationTest {
 		packageIdentifier.setPackageName(packageName);
 		packageIdentifier.setPackageVersion(packageVersion);
 		installRequest.setPackageIdentifier(packageIdentifier);
-		Release installedRelease = install(installRequest);
+		SkipperRelease installedRelease = install(installRequest);
 
 		assertThat(installedRelease.getName()).isEqualTo(releaseName);
 		logger.info("installed release \n" + installedRelease.getManifest());
@@ -94,7 +94,7 @@ public class ReleaseAnalyzerTests extends AbstractIntegrationTest {
 		packageIdentifier.setPackageVersion(packageVersion);
 		upgradeRequest.setPackageIdentifier(packageIdentifier);
 
-		Release upgradedRelease = upgrade(upgradeRequest);
+		SkipperRelease upgradedRelease = upgrade(upgradeRequest);
 
 		assertThat(upgradedRelease.getName()).isEqualTo(releaseName);
 		logger.info("upgraded release \n" + upgradedRelease.getManifest());

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -25,12 +25,12 @@ import org.springframework.cloud.deployer.resource.support.LRUCleaningResourceLo
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.ConfigValues;
-import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
-import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperInfo;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperRelease;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
@@ -104,11 +104,11 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		packageIdentifier.setPackageName("log");
 		packageIdentifier.setPackageVersion("1.0.0");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		Release release = install(installRequest);
+		SkipperRelease release = install(installRequest);
 		installRequest.setPackageIdentifier(packageIdentifier);
 		assertThat(release).isNotNull();
 		assertThat(release.getPkg().getMetadata().getVersion()).isEqualTo("1.0.0");
-		Info info = this.releaseService.status(releaseName);
+		SkipperInfo info = this.releaseService.status(releaseName);
 		assertThat(info).isNotNull();
 
 		UpgradeProperties upgradeProperties = new UpgradeProperties();
@@ -140,7 +140,7 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		PackageIdentifier packageIdentifier = new PackageIdentifier();
 		packageIdentifier.setPackageName("log");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		Release release = install(installRequest);
+		SkipperRelease release = install(installRequest);
 		assertThat(release).isNotNull();
 		assertThat(release.getPkg().getMetadata().getVersion()).isEqualTo("2.0.0");
 		delete(release.getName());
@@ -184,8 +184,8 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 	@Test
 	public void testLatestPackageByName() {
 		String packageName = "log";
-		PackageMetadata packageMetadata = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc(packageName);
-		PackageMetadata latestPackageMetadata = this.packageMetadataRepository
+		SkipperPackageMetadata packageMetadata = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc(packageName);
+		SkipperPackageMetadata latestPackageMetadata = this.packageMetadataRepository
 				.findByNameAndOptionalVersionRequired(packageName, null);
 		assertThat(packageMetadata).isEqualTo(latestPackageMetadata);
 	}
@@ -199,7 +199,7 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		packageIdentifier.setPackageName("log");
 		packageIdentifier.setPackageVersion("1.0.0");
 		installRequest.setPackageIdentifier(packageIdentifier);
-		Release release = install(installRequest);
+		SkipperRelease release = install(installRequest);
 		assertThat(release).isNotNull();
 
 		// Now let's install it a second time.
@@ -223,12 +223,12 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		packageIdentifier.setPackageVersion("1.0.0");
 		installRequest.setPackageIdentifier(packageIdentifier);
 		// Install
-		Release release = install(installRequest);
+		SkipperRelease release = install(installRequest);
 		assertThat(release).isNotNull();
 		// Delete
 		delete(releaseName);
 		// Install again
-		Release release2 = install(installRequest);
+		SkipperRelease release2 = install(installRequest);
 		assertThat(release2.getVersion()).isEqualTo(2);
 	}
 
@@ -247,7 +247,7 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		installRequest.setPackageIdentifier(packageIdentifier);
 		// Install
 		logger.info("Installing log 1.0.0 package");
-		Release release = install(installRequest);
+		SkipperRelease release = install(installRequest);
 		assertThat(release).isNotNull();
 		assertThat(release.getVersion()).isEqualTo(1);
 		this.appDeployerDataRepository.findByReleaseNameAndReleaseVersionRequired(releaseName, 1);
@@ -267,7 +267,7 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		packageIdentifier.setPackageVersion(packageVersion);
 		upgradeRequest.setPackageIdentifier(packageIdentifier);
 		logger.info("Upgrading to log 2.0.0 package");
-		Release upgradedRelease = upgrade(upgradeRequest);
+		SkipperRelease upgradedRelease = upgrade(upgradeRequest);
 
 		assertThat(upgradedRelease.getVersion()).isEqualTo(2);
 		assertThat(upgradedRelease.getConfigValues()).isEqualTo(upgradeRequest.getUpgradeProperties().getConfigValues());
@@ -276,13 +276,13 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		// Delete
 		delete(releaseName);
 
-		Release deletedRelease = releaseRepository.findByNameAndVersion(releaseName, 2);
+		SkipperRelease deletedRelease = releaseRepository.findByNameAndVersion(releaseName, 2);
 		assertThat(deletedRelease.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED));
 
 		// Rollback
 		logger.info("Rolling back the release " + release);
 
-		Release rolledBackRelease = rollback(releaseName, 0);
+		SkipperRelease rolledBackRelease = rollback(releaseName, 0);
 
 		assertThat(rolledBackRelease.getManifest()).isEqualTo(release.getManifest());
 		assertThat(rolledBackRelease.getConfigValues().getRaw()).isEqualTo(release.getConfigValues().getRaw());

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/RepositoryCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/RepositoryCommands.java
@@ -21,7 +21,7 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.client.SkipperClient;
-import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.SkipperRepository;
 import org.springframework.cloud.skipper.shell.command.support.TableUtils;
 import org.springframework.hateoas.Resources;
 import org.springframework.shell.standard.ShellComponent;
@@ -52,7 +52,7 @@ public class RepositoryCommands extends AbstractSkipperCommand {
 	public String add(@ShellOption(help = "name of the repository") @NotNull String name,
 			@ShellOption(help = "the root URL that points to index.yaml file") @NotNull String url,
 			@ShellOption(help = "the source URL to the package", defaultValue = NULL) String sourceUrl) {
-		Repository repository = this.skipperClient.addRepository(name, url, sourceUrl);
+		SkipperRepository repository = this.skipperClient.addRepository(name, url, sourceUrl);
 		return "Repository '" + name + "' added.";
 	}
 
@@ -64,7 +64,7 @@ public class RepositoryCommands extends AbstractSkipperCommand {
 
 	@ShellMethod(key = "repo list", value = "List package repositories")
 	public Table list() {
-		Resources<Repository> repositoryResources = this.skipperClient.listRepositories();
+		Resources<SkipperRepository> repositoryResources = this.skipperClient.listRepositories();
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("name", "Name");
 		headers.put("url", "URL");

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/SkipperUtils.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/SkipperUtils.java
@@ -17,7 +17,7 @@ package org.springframework.cloud.skipper;
 
 import java.io.File;
 
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 
 /**
  * Utility methods used by Skipper.
@@ -26,7 +26,7 @@ import org.springframework.cloud.skipper.domain.PackageMetadata;
  */
 public class SkipperUtils {
 
-	public static File calculatePackageZipFile(PackageMetadata packageMetadata, File targetPath) {
+	public static File calculatePackageZipFile(SkipperPackageMetadata packageMetadata, File targetPath) {
 		return new File(targetPath, packageMetadata.getName() + "-" + packageMetadata.getVersion() + ".zip");
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Package.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Package.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class Package {
 
 	// Metadata describing the package
-	private PackageMetadata metadata;
+	private SkipperPackageMetadata metadata;
 
 	// The templates for this package
 	private List<Template> templates = new ArrayList<>();
@@ -43,11 +43,11 @@ public class Package {
 	public Package() {
 	}
 
-	public PackageMetadata getMetadata() {
+	public SkipperPackageMetadata getMetadata() {
 		return metadata;
 	}
 
-	public void setMetadata(PackageMetadata metadata) {
+	public void setMetadata(SkipperPackageMetadata metadata) {
 		this.metadata = metadata;
 	}
 

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperInfo.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperInfo.java
@@ -27,10 +27,10 @@ import javax.persistence.OneToOne;
  * @author Mark Pollack
  */
 @Entity
-public class Info extends AbstractEntity {
+public class SkipperInfo extends AbstractEntity {
 
 	@OneToOne(cascade = { CascadeType.ALL })
-	private Status status;
+	private SkipperStatus status;
 
 	private Date firstDeployed;
 
@@ -42,14 +42,14 @@ public class Info extends AbstractEntity {
 	// Description is human-friendly "log entry" about this release.
 	private String description;
 
-	public Info() {
+	public SkipperInfo() {
 	}
 
-	public Status getStatus() {
+	public SkipperStatus getStatus() {
 		return status;
 	}
 
-	public void setStatus(Status status) {
+	public void setStatus(SkipperStatus status) {
 		this.status = status;
 	}
 
@@ -91,11 +91,11 @@ public class Info extends AbstractEntity {
 	 * @param description a string describing the general info status at a level finer than StatusCode
 	 * @return a new Info object
 	 */
-	public static Info createNewInfo(String description) {
-		Info info = new Info();
+	public static SkipperInfo createNewInfo(String description) {
+		SkipperInfo info = new SkipperInfo();
 		info.setFirstDeployed(new Date());
 		info.setLastDeployed(new Date());
-		Status status = new Status();
+		SkipperStatus status = new SkipperStatus();
 		status.setStatusCode(StatusCode.UNKNOWN);
 		info.setStatus(status);
 		info.setDescription(description);

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperPackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperPackageMetadata.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @author Gunnar Hillert
  */
 @Entity
-public class PackageMetadata extends AbstractEntity {
+public class SkipperPackageMetadata extends AbstractEntity {
 
 	/**
 	 * The Package Index spec version this file is based on.
@@ -108,7 +108,7 @@ public class PackageMetadata extends AbstractEntity {
 	 */
 	private String iconUrl;
 
-	public PackageMetadata() {
+	public SkipperPackageMetadata() {
 	}
 
 	public String getApiVersion() {
@@ -234,7 +234,7 @@ public class PackageMetadata extends AbstractEntity {
 			return false;
 		}
 
-		PackageMetadata that = (PackageMetadata) o;
+		SkipperPackageMetadata that = (SkipperPackageMetadata) o;
 
 		if (apiVersion != null ? !apiVersion.equals(that.apiVersion) : that.apiVersion != null) {
 			return false;

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperRelease.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperRelease.java
@@ -37,7 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Pollack
  */
 @Entity
-public class Release extends AbstractEntity {
+public class SkipperRelease extends AbstractEntity {
 
 	/**
 	 * A short name, to associate with the release of this package.
@@ -48,7 +48,7 @@ public class Release extends AbstractEntity {
 	private int version;
 
 	@OneToOne(cascade = { CascadeType.ALL })
-	private Info info;
+	private SkipperInfo info;
 
 	@Transient
 	private Package pkg;
@@ -67,7 +67,7 @@ public class Release extends AbstractEntity {
 
 	private String platformName;
 
-	public Release() {
+	public SkipperRelease() {
 	}
 
 	public String getName() {
@@ -86,11 +86,11 @@ public class Release extends AbstractEntity {
 		this.version = version;
 	}
 
-	public Info getInfo() {
+	public SkipperInfo getInfo() {
 		return info;
 	}
 
-	public void setInfo(Info info) {
+	public void setInfo(SkipperInfo info) {
 		this.info = info;
 	}
 

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperRepository.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperRepository.java
@@ -25,7 +25,7 @@ import javax.validation.constraints.NotNull;
  * @author Mark Pollack
  */
 @Entity
-public class Repository extends AbstractEntity {
+public class SkipperRepository extends AbstractEntity {
 
 	/**
 	 * A short name, e.g. 'stable' to associate with this repository, must be unique.
@@ -65,7 +65,7 @@ public class Repository extends AbstractEntity {
 
 	// TODO security/checksum fields of referenced index file.
 
-	public Repository() {
+	public SkipperRepository() {
 	}
 
 	public String getName() {

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperStatus.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SkipperStatus.java
@@ -45,7 +45,7 @@ import org.springframework.cloud.deployer.spi.app.DeploymentState;
  * @author Mark Pollack
  */
 @Entity
-public class Status extends AbstractEntity {
+public class SkipperStatus extends AbstractEntity {
 
 	// Status from the Release managment platform
 	@Enumerated(EnumType.STRING)
@@ -55,7 +55,7 @@ public class Status extends AbstractEntity {
 	@Lob
 	private String platformStatus;
 
-	public Status() {
+	public SkipperStatus() {
 	}
 
 	public StatusCode getStatusCode() {

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/io/DefaultPackageReader.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/io/DefaultPackageReader.java
@@ -32,7 +32,7 @@ import org.zeroturnaround.zip.commons.FileUtils;
 
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Package;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.util.Assert;
 
@@ -135,12 +135,12 @@ public class DefaultPackageReader implements PackageReader {
 		return configValues;
 	}
 
-	private PackageMetadata loadPackageMetadata(File file) {
+	private SkipperPackageMetadata loadPackageMetadata(File file) {
 		// The Representer will not try to set the value in the YAML on the
 		// Java object if it isn't present on the object
 		Representer representer = new Representer();
 		representer.getPropertyUtils().setSkipMissingProperties(true);
-		Yaml yaml = new Yaml(new Constructor(PackageMetadata.class), representer);
+		Yaml yaml = new Yaml(new Constructor(SkipperPackageMetadata.class), representer);
 		String fileContents = null;
 		try {
 			fileContents = FileUtils.readFileToString(file);
@@ -148,7 +148,7 @@ public class DefaultPackageReader implements PackageReader {
 		catch (IOException e) {
 			e.printStackTrace();
 		}
-		PackageMetadata pkgMetadata = (PackageMetadata) yaml.load(fileContents);
+		SkipperPackageMetadata pkgMetadata = (SkipperPackageMetadata) yaml.load(fileContents);
 		return pkgMetadata;
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/io/DefaultPackageWriter.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/io/DefaultPackageWriter.java
@@ -27,7 +27,7 @@ import org.zeroturnaround.zip.ZipUtil;
 
 import org.springframework.cloud.skipper.SkipperUtils;
 import org.springframework.cloud.skipper.domain.Package;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.FileSystemUtils;
@@ -51,7 +51,7 @@ public class DefaultPackageWriter implements PackageWriter {
 
 	@Override
 	public File write(Package pkg, File targetDirectory) {
-		PackageMetadata packageMetadata = pkg.getMetadata();
+		SkipperPackageMetadata packageMetadata = pkg.getMetadata();
 		File tmpDir = TempFileUtils.createTempDirectory("skipper" + packageMetadata.getName()).toFile();
 		File rootPackageDir = new File(tmpDir,
 				String.format("%s-%s", packageMetadata.getName(), packageMetadata.getVersion()));
@@ -107,7 +107,7 @@ public class DefaultPackageWriter implements PackageWriter {
 		}
 	}
 
-	private String generatePackageMetadata(PackageMetadata packageMetadata) {
+	private String generatePackageMetadata(SkipperPackageMetadata packageMetadata) {
 		return yaml.dump(packageMetadata);
 	}
 

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/io/PackageReaderTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/io/PackageReaderTests.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
 
 import org.springframework.cloud.skipper.domain.Package;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
@@ -48,7 +48,7 @@ public class PackageReaderTests {
 
 	@SuppressWarnings("unchecked")
 	private void assertTickTockPackage(Package pkg) {
-		PackageMetadata metadata = pkg.getMetadata();
+		SkipperPackageMetadata metadata = pkg.getMetadata();
 		assertThat(metadata.getApiVersion()).isEqualTo("v1");
 		assertThat(metadata.getKind()).isEqualTo("skipper");
 		assertThat(metadata.getName()).isEqualTo("ticktock");
@@ -80,7 +80,7 @@ public class PackageReaderTests {
 	}
 
 	private void assertLogPackage(Package pkg) {
-		PackageMetadata metadata = pkg.getMetadata();
+		SkipperPackageMetadata metadata = pkg.getMetadata();
 		assertThat(metadata.getApiVersion()).isEqualTo("v1");
 		assertThat(metadata.getKind()).isEqualTo("skipper");
 		assertThat(metadata.getName()).isEqualTo("log");
@@ -96,7 +96,7 @@ public class PackageReaderTests {
 	}
 
 	private void assertTimePackage(Package pkg) {
-		PackageMetadata metadata = pkg.getMetadata();
+		SkipperPackageMetadata metadata = pkg.getMetadata();
 		assertThat(metadata.getApiVersion()).isEqualTo("v1");
 		assertThat(metadata.getKind()).isEqualTo("skipper");
 		assertThat(metadata.getName()).isEqualTo("time");

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/io/PackageWriterTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/io/PackageWriterTests.java
@@ -36,7 +36,7 @@ import org.zeroturnaround.zip.ZipUtil;
 import org.springframework.cloud.skipper.TestResourceUtils;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Package;
-import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.SkipperPackageMetadata;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -88,7 +88,7 @@ public class PackageWriterTests {
 		Package pkg = new Package();
 
 		// Add package metadata
-		PackageMetadata packageMetadata = new PackageMetadata();
+		SkipperPackageMetadata packageMetadata = new SkipperPackageMetadata();
 		packageMetadata.setName("myapp");
 		packageMetadata.setVersion("1.0.0");
 		packageMetadata.setMaintainer("bob");


### PR DESCRIPTION
- Add build dependencies for hsql/mysql/postgres/mssql following
  what we have in scdf.
- Rename @Entity classes to have `Skipper` prefix which changes
  names of used tables. This pretty much removes a collisions with
  reserved keywords in DB's.
- Change used RepositoryRestResource's to work with changed Entity names
  so that from rest point of view we still get same hal responses. Effectively
  defining those so that `skipper` prefix is not added(as we just want
  to have that prefix in tables, not in json).
- In ReleaseRepository mark additional query methods with @Transactional
  not to get errors i.e. with history command. #338
- Fixes #327
- Fixes #328
- Fixes #338 

I didn't yet update docs as #339 raises some questions how external DB's should be used with different hibernate settings.

Anyway, tested few DB's:
```
# local mysql
java -jar spring-cloud-skipper-server/target/spring-cloud-skipper-server-1.0.0.BUILD-SNAPSHOT.jar --spring.config.location=/home/jvalkealahti/work/skipper/skipper.yml --spring.cloud.skipper.server.synchonizeIndexOnContextRefresh=true --spring.datasource.url=jdbc:mysql://localhost/skipper --spring.datasource.username=spring --spring.datasource.password=spring --spring.datasource.driver-class-name=com.mysql.jdbc.Driver --spring.datasource.initialize=true --spring.jpa.generate-ddl=true --spring.jpa.hibernate.ddl-auto=update

# local postgres
java -jar spring-cloud-skipper-server/target/spring-cloud-skipper-server-1.0.0.BUILD-SNAPSHOT.jar --spring.config.location=/home/jvalkealahti/work/skipper/skipper.yml --spring.cloud.skipper.server.synchonizeIndexOnContextRefresh=true --spring.datasource.url=jdbc:postgresql://localhost:5432/skipper --spring.datasource.username=spring --spring.datasource.password=spring --spring.datasource.driver-class-name=org.postgresql.Driver --spring.datasource.initialize=true --spring.jpa.generate-ddl=true --spring.jpa.hibernate.ddl-auto=update

# mssql in vm
java -jar spring-cloud-skipper-server/target/spring-cloud-skipper-server-1.0.0.BUILD-SNAPSHOT.jar --spring.config.location=/home/jvalkealahti/work/skipper/skipper.yml --spring.cloud.skipper.server.synchonizeIndexOnContextRefresh=true --spring.datasource.url=jdbc:sqlserver://172.16.101.143;databaseName=skipper --spring.datasource.username=spring --spring.datasource.password=Password! --spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver --spring.datasource.initialize=true --spring.jpa.generate-ddl=true --spring.jpa.hibernate.ddl-auto=update

# hsql based on server in xd
java -jar spring-cloud-skipper-server/target/spring-cloud-skipper-server-1.0.0.BUILD-SNAPSHOT.jar --spring.config.location=/home/jvalkealahti/work/skipper/skipper.yml --spring.cloud.skipper.server.synchonizeIndexOnContextRefresh=true --spring.datasource.url=jdbc:hsqldb:hsql://localhost:9101/xdjob --spring.datasource.username=sa --spring.datasource.driver-class-name=org.hsqldb.jdbcDriver --spring.datasource.initialize=true --spring.jpa.generate-ddl=true --spring.jpa.hibernate.ddl-auto=update
```