### PR TITLE
Tighten up `Package` section of documentation

### DIFF
--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
@@ -68,13 +68,13 @@ Packages contain all the necessary information to install your application or gr
 The approach to decribing the applications is to use a YAML file that provides all the necessary information to help facilitate searching for your application hosted in a Package Registry and to install your application to a platform.
 
 To make it easy to customize a package, the YAML files are templated.  The final version of the YAML file, with all values substituted is known as the release `manifest`.
-Skipper currently understands how to deploy applications based off a YAML file that contains the information needed for a Spring Cloud Deployer implementation to deploy an application.  It describes, where to find the application (either a http, maven or docker location) , application properties (think Spring Boot `@ConfigurationProperties`), an deployment properites (how much memory to use).
+Skipper currently understands how to deploy applications based off a YAML file that contains the information needed for a Spring Cloud Deployer implementation to deploy an application.  It describes, where to find the application (either a http, maven or docker location) , application properties (think Spring Boot `@ConfigurationProperties`), an deployment properites (e.g. how much memory to use).
 
 [[package-format]]
 === Package Format
 
 A package is a collection of YAML files that are zipped up into a file with the naming convention
-`PackageName-PackageVersion.zip` for example: `mypackage-1.0.0.zip`
+`[PackageName]-[PackageVersion].zip` for example: `mypackage-1.0.0.zip`
 
 A package can define a single application or a group of applications.
 
@@ -131,16 +131,19 @@ The file https://github.com/spring-cloud/spring-cloud-skipper/blob/master/spring
 
 
 [[package-metadata]]
-=== Package Metadata
+=== Package Metadata (Package.yml)
 
 The `package.yml` file specifies the package metadata.
 A sample package metadata would look like this:
 
 ----
+# Required Fields
 apiVersion: v1
 kind: skipperPackageMetadata
 name: mypackage
 version: 1.0.0
+
+# Optional Fields
 packageSourceUrl: https://github.com/some-mypackage-project/v1.0.0.RELEASE
 packageHomeUrl: http://some-mypackage-project/
 tags: skipper, mypackage, sample
@@ -148,10 +151,14 @@ maintainer: https://github.com/maintainer
 description: This is a mypackage sample.
 ----
 
-The `apiVersion`, `kind`, `name` and `version` fields of the package metadata are required fields.
-There are many optional fields, described below.
+*Required Fields:*
 
-NOTE: The package search functionality in 1.0 M1 is only a wildcard match against the name of the package.
+* `apiVersion` - 	The Package Index spec version this file is based on
+* `kinds` - What type of package system is being used
+* `name` -  name of the package
+* `version` - version of the package
+
+*Optional Fields:*
 
 * `packageSourceUrl` - 	Location to source code for this package.
 * `packageHomeUrl` - The home page of the package
@@ -162,12 +169,12 @@ NOTE: The package search functionality in 1.0 M1 is only a wildcard match agains
 * `iconUrl` - URL for an icon to show for this package.
 * `origin` - Free form text describing the origin of this package, for example your company name.
 
+NOTE: The package search functionality in 1.0 M1 is only a wildcard match against the name of the package.
+
 A Package Repository exposes an `index.yml` file that contains multiple metadata documents, separated by the standard three dash notation `---` to separate the documents.  For example http://skipper-repository.cfapps.io/repository/experimental/index.yml[index.yml].
 
-See the section
-
 [[package-template-files]]
-=== Package Templates
+=== Package Templates (Template.yml)
 
 The `template.yml` file in a package structure such as
 
@@ -182,6 +189,7 @@ mypackage-1.0.0
 will commonly have the following content:
 
 ----
+# template.yml
 apiVersion: skipper/v1
 kind: SpringCloudDeployerApplication
 metadata:
@@ -204,14 +212,16 @@ The `apiVersion`, `kind` and `spec.resource` are required.
 The `spec.resource` defines where the application executable is located.
 This is either a Spring Boot uberjar hosted under a http endpoint or a maven or docker repository.  There is a template placeholder `{{version}}` so that the version of a specific application can be easily upgraded without having to create a new package .zip file.
 
- The format for the `resource` is an typical `http://` or a `maven://` or `docker:`, whose format is less commonly known.
- Here are some examples:
+The format for the `resource` is an typical `http://` or a `maven://` or `docker:`, whose format is less commonly known.
+Here are some examples:
 
 ----
 spec:
   resource: maven://org.springframework.cloud.samples:spring-cloud-skipper-samples-helloworld:1.0.0.RELEASE
+  resource: maven://{{maven-group-name}}:{{artifact-name}}:{{version}}
 ----
-The first part before the `:` is the Maven group name and the second part after the `:` is the artifact name.  The last part is the version.
+
+This shows the broad structure that maven uses. The first part before the `:` is the Maven group name and the second part after the `:` is the artifact name.  The last part is the version.
 
 ----
 spec:
@@ -219,7 +229,7 @@ spec:
 ----
 This follows typical naming conventions of <user>/<repo>:<tag>.
 
-There is only one setting to specify with maven repositories to search.  This applies across all platform accounts.  By default the configuration
+There is only one setting to specify with maven repositories to search.  This applies across all platform accounts.  By default the configuration:
 
 ----
 maven:
@@ -227,21 +237,34 @@ maven:
     springRepo: https://repo.spring.io/libs-snapshot
 ----
 
-Is used.  You can specify other entries and also specify proxy properties.  This is currently best documented https://docs.spring.io/spring-cloud-dataflow/docs/1.3.0.M2/reference/htmlsingle/#getting-started-maven-configuration[here].
+is used.  You can specify other entries and also specify proxy properties.  This is currently best documented https://docs.spring.io/spring-cloud-dataflow/docs/1.3.0.M2/reference/htmlsingle/#getting-started-maven-configuration[here]. Essentially, this needs to be set a property in your launch properties or `manifest.yml` (when pushing to PCF) like so: 
+
+----
+# manifest.yml
+...
+env: 
+    MAVEN_REMOTE_REPOSITORIES_{{REPOSITORY_NAME}}_URL: https://repo.spring.io
+...
+----
 
 The metadata is used to help search for applications after they have been installed and is not available in Skipper M1.
 
 Currently, only `SpringCloudDeployerApplication` kind is supported which means the applications can be deployed into the target platforms only using their corresponding Spring Cloud Deployer implementations (CF, Kubernetes Deployer etc.).
+
 The `spec` contains the resource specification and the properties for the package.
+
 The `resource` represents the resource URI to download the application from. This would typically be a maven
 co-ordinate or a docker image URL.
+
 The `SpringCloudDeployerApplication` kind of application can have `applicationProperties` and `deploymentProperties` as the
 configuration properties.
+
 The application properties correspond to the properties for the application itself.
+
 The deployment properties correspond to the properties for the deployment operation performed by Spring Cloud Deployer implementations.
 
 [[package-values]]
-=== Package Values
+=== Package Values (Values.yml)
 
 The `values` YAML file contains the default values for any of the keys specified in the template files.
 
@@ -272,6 +295,8 @@ ticktock-1.0.0/
 A top level `values.yml` file
 
 ----
+#values.yml
+
 hello: world
 
 time:


### PR DESCRIPTION
Overall just made some small things clearer/more obvious. Some are style decisions so feel free to remove. 

Also, not as many substantive changes as I thought would be made. This section though, as someone who just had to use it to create a package, is not necessarily as clear or helpful as it could be. But I don't know if it's because of this section (which is pretty clear, though awkward to have to flick to 19 to know what the various fields mean), or because there is a missing section along the lines of "Making your own package" which walks through it more. Maybe that sort of customization section might be useful?