### PR TITLE
Support external databases

### DIFF
--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -59,6 +59,29 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-keyvault</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/AppDeployerData.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/AppDeployerData.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import javax.persistence.Entity;
 import javax.persistence.Lob;
+import javax.persistence.Table;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -42,6 +43,7 @@ import org.springframework.cloud.skipper.domain.AbstractEntity;
  * @author Mark Pollack
  */
 @Entity
+@Table(name = "SkipperAppDeployerData")
 public class AppDeployerData extends AbstractEntity {
 
 	private String releaseName;

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/AppDeployerDataRepository.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.skipper.server.repository;
 
 import org.springframework.cloud.skipper.server.domain.AppDeployerData;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Mark Pollack
@@ -24,6 +25,7 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 public interface AppDeployerDataRepository
 		extends PagingAndSortingRepository<AppDeployerData, Long>, AppDeployerDataRepositoryCustom {
 
+	@Transactional(readOnly = true)
 	AppDeployerData findByReleaseNameAndReleaseVersion(String releaseName, Integer releaseVersion);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/ReleaseRepository.java
@@ -22,6 +22,7 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Mark Pollack
@@ -47,14 +48,19 @@ public interface ReleaseRepository extends PagingAndSortingRepository<Release, L
 	@RestResource(exported = false)
 	void deleteAll();
 
+	@Transactional(readOnly = true)
 	List<Release> findByNameOrderByVersionDesc(@Param("name") String name);
 
+	@Transactional(readOnly = true)
 	List<Release> findByNameIgnoreCaseContainingOrderByNameAscVersionDesc(@Param("name") String name);
 
+	@Transactional(readOnly = true)
 	List<Release> findByNameAndVersionBetweenOrderByNameAscVersionDesc(@Param("name") String name,
 			@Param("from") int fromVersion, @Param("to") int toVersion);
 
+	@Transactional(readOnly = true)
 	Release findTopByNameOrderByVersionDesc(@Param("name") String name);
 
+	@Transactional(readOnly = true)
 	List<Release> findByNameIgnoreCaseContaining(@Param("name") String name);
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Info.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Info.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 /**
  * Basic information about the package deployment operation.
@@ -27,6 +28,7 @@ import javax.persistence.OneToOne;
  * @author Mark Pollack
  */
 @Entity
+@Table(name = "SkipperInfo")
 public class Info extends AbstractEntity {
 
 	@OneToOne(cascade = { CascadeType.ALL })

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.skipper.domain;
 
 import javax.persistence.Entity;
 import javax.persistence.Lob;
+import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @author Gunnar Hillert
  */
 @Entity
+@Table(name = "SkipperPackageMetadata")
 public class PackageMetadata extends AbstractEntity {
 
 	/**

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
@@ -22,6 +22,7 @@ import javax.persistence.Entity;
 import javax.persistence.Lob;
 import javax.persistence.OneToOne;
 import javax.persistence.PostLoad;
+import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 
@@ -37,6 +38,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Pollack
  */
 @Entity
+@Table(name = "SkipperRelease")
 public class Release extends AbstractEntity {
 
 	/**

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Repository.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.skipper.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
 /**
@@ -25,6 +26,7 @@ import javax.validation.constraints.NotNull;
  * @author Mark Pollack
  */
 @Entity
+@Table(name = "SkipperRepository")
 public class Repository extends AbstractEntity {
 
 	/**

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
@@ -23,6 +23,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Lob;
+import javax.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -45,6 +46,7 @@ import org.springframework.cloud.deployer.spi.app.DeploymentState;
  * @author Mark Pollack
  */
 @Entity
+@Table(name = "SkipperStatus")
 public class Status extends AbstractEntity {
 
 	// Status from the Release managment platform


### PR DESCRIPTION
- Add build dependencies for hsql/mysql/postgres/mssql following
  what we have in scdf.
- Add @Table annotation to entity classes instructing
  tables to have `SkipperXxx` naming. This should remove
  a collisions with reserved keywords in DB's.
- In ReleaseRepository and AppDeployerDataRepository mark additional
  query methods with @Transactional not to get errors i.e. with
  history command #338 and upgrade command.
- Fixes #327
- Fixes #328
- Fixes #338