### PR TITLE
Change dependencies leading to shell

### DIFF
--- a/spring-cloud-skipper-client/pom.xml
+++ b/spring-cloud-skipper-client/pom.xml
@@ -15,6 +15,17 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -48,25 +48,9 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-deployer-local</artifactId>
-            <version>${spring-cloud-deployer-local.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-deployer-resource-maven</artifactId>
+            <artifactId>spring-cloud-deployer-spi</artifactId>
             <version>${spring-cloud-deployer.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-deployer-resource-docker</artifactId>
-            <version>${spring-cloud-deployer.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-deployer-resource-support</artifactId>
-            <version>${spring-cloud-deployer.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
- Fix deps so that client/shell doesn't get any deps
  it doesn't need.
- For spring-cloud-skipper, remove all deployer deps and just
  use spring-cloud-deployer-spi.
- For spring-cloud-skipper-client, bring back spring-web and httpclient.
  Previously httpclient were transitive deps via aether and spring-web via
  spring-cloud-deployer-local.
- Fixes #353