### PR TITLE
Add support passing shell command args

### DIFF
--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/SkipperShellApplicationRunner.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/SkipperShellApplicationRunner.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.shell.command.support;
 import java.io.File;
 import java.io.FileReader;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -71,9 +72,16 @@ public class SkipperShellApplicationRunner implements ApplicationRunner {
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
 		// if we have args, assume one time run
-		if (args.getSourceArgs().length > 0) {
+		ArrayList<String> argsToShellCommand = new ArrayList<>();
+		for (String arg : args.getSourceArgs()) {
+			// consider client connection options as non command args
+			if (!arg.contains("spring.cloud.skipper.client")) {
+				argsToShellCommand.add(arg);
+			}
+		}
+		if (argsToShellCommand.size() > 0) {
 			CommandInputProvider inputProvider = new CommandInputProvider(
-					StringUtils.arrayToDelimitedString(args.getSourceArgs(), " "));
+					StringUtils.collectionToDelimitedString(argsToShellCommand, " "));
 			shell.run(inputProvider);
 			return;
 		}

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/SkipperShellApplicationRunner.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/SkipperShellApplicationRunner.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.shell.command.support;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jline.reader.LineReader;
+import org.jline.reader.Parser;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.shell.Input;
+import org.springframework.shell.InputProvider;
+import org.springframework.shell.Shell;
+import org.springframework.shell.jline.DefaultShellApplicationRunner;
+import org.springframework.shell.jline.DefaultShellApplicationRunner.JLineInputProvider;
+import org.springframework.shell.jline.FileInputProvider;
+import org.springframework.shell.jline.PromptProvider;
+import org.springframework.util.StringUtils;
+
+/**
+ * Skipper related {@link ApplicationRunner} used in shell to customise
+ * behaviour order to pass in command args, if given, directly to shell
+ * and exit.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Order(DefaultShellApplicationRunner.PRECEDENCE - 5)
+public class SkipperShellApplicationRunner implements ApplicationRunner {
+
+	private final LineReader lineReader;
+	private final PromptProvider promptProvider;
+	private final Parser parser;
+	private final Shell shell;
+
+	/**
+	 * Instantiates a new skipper shell application runner.
+	 *
+	 * @param lineReader the line reader
+	 * @param promptProvider the prompt provider
+	 * @param parser the parser
+	 * @param shell the shell
+	 */
+	public SkipperShellApplicationRunner(LineReader lineReader, PromptProvider promptProvider, Parser parser,
+			Shell shell) {
+		this.lineReader = lineReader;
+		this.promptProvider = promptProvider;
+		this.parser = parser;
+		this.shell = shell;
+	}
+
+	@Override
+	public void run(ApplicationArguments args) throws Exception {
+		// if we have args, assume one time run
+		if (args.getSourceArgs().length > 0) {
+			CommandInputProvider inputProvider = new CommandInputProvider(
+					StringUtils.arrayToDelimitedString(args.getSourceArgs(), " "));
+			shell.run(inputProvider);
+			return;
+		}
+
+		// otherwise, fallback to what DefaultShellApplicationRunner would do
+		List<File> scriptsToRun = args.getNonOptionArgs().stream()
+				.filter(s -> s.startsWith("@"))
+				.map(s -> new File(s.substring(1)))
+				.collect(Collectors.toList());
+		if (scriptsToRun.isEmpty()) {
+			InputProvider inputProvider = new JLineInputProvider(lineReader, promptProvider);
+			shell.run(inputProvider);
+		}
+		else {
+			for (File file : scriptsToRun) {
+				try (Reader reader = new FileReader(file);
+						FileInputProvider inputProvider = new FileInputProvider(reader, parser)) {
+					shell.run(inputProvider);
+				}
+			}
+		}
+	}
+
+	/**
+	 * {@link InputProvider} which gives a single input to shell.
+	 */
+	private static class CommandInputProvider implements InputProvider {
+
+		private String command;
+		private boolean done;
+
+		CommandInputProvider(String command) {
+			this.command = command;
+		}
+
+		@Override
+		public Input readInput() {
+			// we can only give single input as otherwise
+			// shell will start to loop command. thus use a simple
+			// flag to return null next time.
+			if (!done) {
+				done = true;
+				return () -> command;
+			}
+			return null;
+		}
+	}
+}

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/config/ShellConfiguration.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/config/ShellConfiguration.java
@@ -17,8 +17,6 @@ package org.springframework.cloud.skipper.shell.config;
 
 import org.jline.reader.LineReader;
 import org.jline.reader.Parser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -27,6 +25,7 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.cloud.skipper.client.SkipperClientConfiguration;
 import org.springframework.cloud.skipper.client.SkipperClientProperties;
 import org.springframework.cloud.skipper.shell.command.support.ConsoleUserInput;
+import org.springframework.cloud.skipper.shell.command.support.SkipperShellApplicationRunner;
 import org.springframework.cloud.skipper.shell.command.support.Target;
 import org.springframework.cloud.skipper.shell.command.support.TargetHolder;
 import org.springframework.context.annotation.Bean;
@@ -46,25 +45,21 @@ import org.springframework.shell.jline.PromptProvider;
  * @author Mark Pollack
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
 @Configuration
 @Import(SkipperClientConfiguration.class)
 public class ShellConfiguration {
 
-	private static final Logger logger = LoggerFactory.getLogger(ShellConfiguration.class);
-
-	@Bean
-	public ApplicationRunner defaultShellRunner(
-			LineReader lineReader,
-			PromptProvider promptProvider,
-			Parser parser,
-			Shell shell) {
-		return new DefaultShellApplicationRunner(lineReader, promptProvider, parser, shell);
-	}
-
 	@Bean
 	public ApplicationRunner initialConnectionApplicationRunner() {
 		return new InitialConnectionApplicationRunner();
+	}
+
+	@Bean
+	public ApplicationRunner applicationRunner(LineReader lineReader, PromptProvider promptProvider, Parser parser,
+			Shell shell) {
+		return new SkipperShellApplicationRunner(lineReader, promptProvider, parser, shell);
 	}
 
 	@Bean

--- a/spring-cloud-skipper-shell-commands/src/main/resources/application.yml
+++ b/spring-cloud-skipper-shell-commands/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+spring:
+    main:
+        banner-mode: 'off'
 logging:
   level:
     org.springframework.cloud.skipper.shell: 'WARN'


### PR DESCRIPTION
- Add new SkipperShellApplicationRunner handling custom logic
  if args are passed in. Fall back to functionality
  in DefaultShellApplicationRunner.
- Disable banner as it's annoying when running commands.
- Fixes #360 

```
10:24 $ java -jar spring-cloud-skipper-shell/target/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar search
╔═════════════════╤═══════╤═══════════════════════════════════════════════════════════════════════════╗
║      Name       │Version│                                Description                                ║
╠═════════════════╪═══════╪═══════════════════════════════════════════════════════════════════════════╣
║helloworld-docker│1.0.0  │The hello world app says hello.                                            ║
║log              │1.1.0  │The log sink uses the application logger to output the data for inspection.║
║log              │2.0.0  │The log sink uses the application logger to output the data for inspection.║
║log              │1.0.0  │The log sink uses the application logger to output the data for inspection.║
║log-docker       │1.0.0  │Docker version of the log sink application                                 ║
║log-docker       │2.0.0  │Docker version of the log sink application                                 ║
║ticktock         │1.0.0  │The ticktock stream sends a time stamp and logs the value.                 ║
║time             │2.0.0  │The time source periodically emits a timestamp string.                     ║
╚═════════════════╧═══════╧═══════════════════════════════════════════════════════════════════════════╝

$ java -jar spring-cloud-skipper-shell/target/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar install --package-name log --release-name mylog --package-version 1.1.0
Released mylog. Now at version v1.

$ java -jar spring-cloud-skipper-shell/target/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar history --release-name mylog
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
║1      │Wed Nov 22 10:25:10 GMT 2017│DEPLOYED│log         │1.1.0          │Install complete║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════╝

$ java -jar spring-cloud-skipper-shell/target/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar
skipper:>list --release-name mylog
╔═════╤═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤═════════════╤═════════════════════════════════════════════════╗
║Name │Version│        Last updated        │ Status │Package Name│Package Version│Platform Name│                 Platform Status                 ║
╠═════╪═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪═════════════╪═════════════════════════════════════════════════╣
║mylog│1      │Wed Nov 22 10:25:10 GMT 2017│DEPLOYED│log         │1.1.0          │default      │[mylog.log-v1], State = [mylog.log-v1-0=deployed]║
╚═════╧═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧═════════════╧═════════════════════════════════════════════════╝

skipper:>delete --release-name mylog
mylog has been deleted.
skipper:>exit
```