### PR TITLE
Fix upgrade error with postgres

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseReportService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseReportService.java
@@ -67,7 +67,7 @@ public class ReleaseReportService {
 	 * @return A report of what needs to change to bring the current release to the requested
 	 * release
 	 */
-	@Transactional(readOnly = true)
+	@Transactional
 	public ReleaseAnalysisReport createReport(UpgradeRequest upgradeRequest) {
 		Assert.notNull(upgradeRequest.getUpgradeProperties(), "UpgradeProperties can not be null");
 		Assert.notNull(upgradeRequest.getPackageIdentifier(), "PackageIdentifier can not be null");


### PR DESCRIPTION
- Change transaction in ReleaseReportService not to
  be read-only which seem to cause error when
  postgres is in use.
- Fixes #362