### PR TITLE
Add statemachine for release handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <spring-cloud-deployer-local.version>1.3.0.M2</spring-cloud-deployer-local.version>
         <reactor.version>3.0.7.RELEASE</reactor.version>
         <spring-shell.version>2.0.0.M2</spring-shell.version>
+        <spring-statemachine.version>1.2.8.BUILD-SNAPSHOT</spring-statemachine.version>
         <jsonpath.version>2.2.0</jsonpath.version>
 
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
@@ -95,6 +96,21 @@
                 <groupId>org.springframework.shell</groupId>
                 <artifactId>spring-shell-starter</artifactId>
                 <version>${spring-shell.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.statemachine</groupId>
+                <artifactId>spring-statemachine-boot</artifactId>
+                <version>${spring-statemachine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.statemachine</groupId>
+                <artifactId>spring-statemachine-data-jpa</artifactId>
+                <version>${spring-statemachine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.statemachine</groupId>
+                <artifactId>spring-statemachine-test</artifactId>
+                <version>${spring-statemachine.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.zeroturnaround</groupId>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -104,6 +104,19 @@
             <version>3.4</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.statemachine</groupId>
+            <artifactId>spring-statemachine-boot</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.statemachine</groupId>
+            <artifactId>spring-statemachine-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.statemachine</groupId>
+            <artifactId>spring-statemachine-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-deployer-local</artifactId>
             <version>${spring-cloud-deployer-local.version}</version>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -67,8 +67,12 @@ import org.springframework.cloud.skipper.server.service.ReleaseReportService;
 import org.springframework.cloud.skipper.server.service.ReleaseService;
 import org.springframework.cloud.skipper.server.service.ReleaseStateUpdateService;
 import org.springframework.cloud.skipper.server.service.RepositoryInitializationService;
+import org.springframework.cloud.skipper.server.statemachine.StateMachineConfiguration;
+import org.springframework.cloud.skipper.server.statemachine.StateMachineExecutorConfiguration;
+import org.springframework.cloud.skipper.server.statemachine.StateMachinePersistConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
@@ -94,6 +98,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableJpaRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
 @EnableTransactionManagement
 @EnableAsync
+@Import({ StateMachinePersistConfiguration.class, StateMachineExecutorConfiguration.class,
+		StateMachineConfiguration.class })
 public class SkipperServerConfiguration implements AsyncConfigurer {
 
 	public static final String SKIPPER_EXECUTOR = "skipperThreadPoolTaskExecutor";

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.cloud.skipper.server.service.PackageService;
 import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -62,6 +63,9 @@ public class SkipperController {
 	private String appVersion;
 
 	@Autowired
+	private SkipperStateMachineService stateMachineService;
+
+	@Autowired
 	public SkipperController(ReleaseService releaseService, PackageService packageService) {
 		this.releaseService = releaseService;
 		this.packageService = packageService;
@@ -82,13 +86,13 @@ public class SkipperController {
 	@RequestMapping(path = "/install", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public Release install(@RequestBody InstallRequest installRequest) {
-		return this.releaseService.install(installRequest);
+		return this.stateMachineService.installRelease(installRequest);
 	}
 
 	@RequestMapping(path = "/install/{id}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public Release install(@PathVariable("id") Long id, @RequestBody InstallProperties installProperties) {
-		return this.releaseService.install(id, installProperties);
+		return this.stateMachineService.installRelease(id, installProperties);
 	}
 
 	@RequestMapping(path = "/status/{name}", method = RequestMethod.GET)
@@ -116,20 +120,20 @@ public class SkipperController {
 	@RequestMapping(path = "/upgrade", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public Release upgrade(@RequestBody UpgradeRequest upgradeRequest) {
-		return this.releaseService.upgrade(upgradeRequest);
+		return this.stateMachineService.upgradeRelease(upgradeRequest);
 	}
 
 	@RequestMapping(path = "/rollback/{name}/{version}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public Release rollback(@PathVariable("name") String releaseName,
 			@PathVariable("version") int rollbackVersion) {
-		return this.releaseService.rollback(releaseName, rollbackVersion);
+		return this.stateMachineService.rollbackRelease(releaseName, rollbackVersion);
 	}
 
 	@RequestMapping(path = "/delete/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public Release delete(@PathVariable("name") String releaseName) {
-		return this.releaseService.delete(releaseName);
+		return this.stateMachineService.deleteRelease(releaseName);
 	}
 
 	@RequestMapping(path = "/history/{name}/{max}", method = RequestMethod.GET)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
@@ -61,4 +61,27 @@ public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 		return replacingRelease;
 	}
 
+	@Override
+	public void deployApps(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport) {
+		this.deployAppStep.deployApps(existingRelease, replacingRelease, releaseAnalysisReport);
+	}
+
+	@Override
+	public boolean checkStatus(Release replacingRelease) {
+		return this.healthCheckStep.isHealthy(replacingRelease);
+	}
+
+	@Override
+	public void accept(Release existingRelease, Release replacingRelease,
+			ReleaseAnalysisReport releaseAnalysisReport) {
+		this.handleHealthCheckStep.handleHealthCheck(true, existingRelease,
+				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease);
+	}
+
+	@Override
+	public void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport) {
+		this.handleHealthCheckStep.handleHealthCheck(false, existingRelease,
+				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease);
+	}
+
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
  */
 public interface UpgradeStrategy {
 
+	// TODO: remove this method
 	/**
 	 * Given the two releases, the one currently deployed, the 'existingRelease' and to one to
 	 * be deployed, the 'replacingRelease', use the information in the analysis report to
@@ -37,5 +38,13 @@ public interface UpgradeStrategy {
 	 * @return the replacingRelease, now deployed.
 	 */
 	Release upgrade(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
+
+	void deployApps(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
+
+	boolean checkStatus(Release replacingRelease);
+
+	void accept(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
+
+	void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -169,12 +169,13 @@ public class ReleaseService {
 		else {
 			releaseVersion = 1;
 		}
+
 		Release release = createInitialRelease(installProperties, this.packageService.downloadPackage(packageMetadata),
 				releaseVersion);
 		return install(release);
 	}
 
-	protected Release install(Release release) {
+	public Release install(Release release) {
 		Map<String, Object> mergedMap = ConfigValueUtils.mergeConfigValues(release.getPkg(), release.getConfigValues());
 		// Render yaml resources
 		String manifest = ManifestUtils.createManifest(release.getPkg(), mergedMap);
@@ -326,6 +327,10 @@ public class ReleaseService {
 		else {
 			return upgrade(currentRelease, newRollbackRelease);
 		}
+	}
+
+	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease) {
+		return this.releaseManager.createReport(existingRelease, replacingRelease);
 	}
 
 	private Release upgrade(Release existingRelease, Release replacingRelease) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/AbstractAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/AbstractAction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * Base class for {@link Action}s wanting to automatically wrap its execution in
+ * try/catch and add exception into extended state for further processing for
+ * interested parties.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractAction implements Action<SkipperStates, SkipperEvents> {
+
+	private static final Logger log = LoggerFactory.getLogger(AbstractAction.class);
+
+	@Override
+	public final void execute(StateContext<SkipperStates, SkipperEvents> context) {
+		try {
+			executeInternal(context);
+		}
+		catch (Exception e) {
+			// any error here will lead to adding exception into
+			// extended state, thus allowing machine to break up
+			// from executing state.
+			log.error("Action execution failed class=[" + getClass() + "]", e);
+			context.getExtendedState().getVariables().put(SkipperStateMachineService.SkipperVariables.ERROR, e);
+		}
+	}
+
+	/**
+	 * Internal execution similar to {@link Action#execute(StateContext)}. This
+	 * execution is wrapped in try/catch and possible error added to an extended
+	 * state.
+	 *
+	 * @param context the context
+	 */
+	abstract protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context);
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/DeleteDeleteAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/DeleteDeleteAction.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+import org.springframework.util.Assert;
+
+/**
+ * StateMachine {@link Action} handling delete with a {@link ReleaseService}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DeleteDeleteAction extends AbstractAction {
+
+	private static final Logger log = LoggerFactory.getLogger(DeleteDeleteAction.class);
+
+	private final ReleaseService releaseService;
+
+	/**
+	 * Instantiates a new delete delete action.
+	 *
+	 * @param releaseService the release service
+	 */
+	public DeleteDeleteAction(ReleaseService releaseService) {
+		super();
+		Assert.notNull(releaseService, "'releaseService' must be set");
+		this.releaseService = releaseService;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		log.debug("Starting action " + context);
+		String releaseName = context.getMessageHeaders().get(SkipperEventHeaders.RELEASE_NAME, String.class);
+		log.info("About to delete {}", releaseName);
+		Release release = this.releaseService.delete(releaseName);
+		context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, release);
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ErrorAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ErrorAction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action} handling global error. Currently just does
+ * logging of an error.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ErrorAction implements Action<SkipperStates, SkipperEvents> {
+
+	private static final Logger log = LoggerFactory.getLogger(ErrorAction.class);
+
+	@Override
+	public void execute(StateContext<SkipperStates, SkipperEvents> context) {
+		log.error("Going through error state {} {}", context,
+				context.getExtendedState().getVariables().get(SkipperVariables.ERROR));
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/InstallInstallAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/InstallInstallAction.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.InstallProperties;
+import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+import org.springframework.util.Assert;
+
+/**
+ * StateMachine {@link Action} handling calls to {@link ReleaseService} install methods
+ * depending if either {@link InstallRequest} or {@link InstallProperties} exists in
+ * a message header.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class InstallInstallAction extends AbstractAction {
+
+	private static final Logger log = LoggerFactory.getLogger(InstallInstallAction.class);
+	private final ReleaseService releaseService;
+
+	/**
+	 * Instantiates a new install install action.
+	 *
+	 * @param releaseService the release service
+	 */
+	public InstallInstallAction(ReleaseService releaseService) {
+		super();
+		Assert.notNull(releaseService, "'releaseService' must be set");
+		this.releaseService = releaseService;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		log.debug("Starging execution action " + context);
+		InstallRequest installRequest = context.getMessageHeaders().get(SkipperEventHeaders.INSTALL_REQUEST, InstallRequest.class);
+		InstallProperties installProperties = context.getMessageHeaders().get(SkipperEventHeaders.INSTALL_PROPERTIES, InstallProperties.class);
+		if (installRequest != null) {
+			// we have an install request
+			Release release = this.releaseService.install(installRequest);
+			context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, release);
+		}
+		else if (installProperties != null) {
+			// we have install properties
+			Long id = context.getMessageHeaders().get(SkipperEventHeaders.INSTALL_ID, Long.class);
+			Release release = this.releaseService.install(id, installProperties);
+			context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, release);
+		}
+		else {
+			// fall back to assuming target release
+			Release replacingRelease = context.getExtendedState().get(SkipperVariables.TARGET_RELEASE, Release.class);
+			if (replacingRelease == null) {
+				// will end up into machine error handling
+				throw new SkipperException("No InstallRequest or InstallProperties given and replacingRelease is null");
+			}
+			Release release = this.releaseService.install(replacingRelease);
+			context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, release);
+		}
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ResetVariablesAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ResetVariablesAction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action} which simply clears extended state variables.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ResetVariablesAction implements Action<SkipperStates, SkipperEvents> {
+
+	@Override
+	public void execute(StateContext<SkipperStates, SkipperEvents> context) {
+		context.getExtendedState().getVariables().clear();
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/RollbackStartAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/RollbackStartAction.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+import org.springframework.util.Assert;
+
+/**
+ * StateMachine {@link Action} preparing a rollback.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class RollbackStartAction  extends AbstractAction {
+
+	private static final Logger log = LoggerFactory.getLogger(RollbackStartAction.class);
+	private final ReleaseRepository releaseRepository;
+
+	/**
+	 * Instantiates a new rollback start action.
+	 *
+	 * @param releaseRepository the release repository
+	 */
+	public RollbackStartAction(ReleaseRepository releaseRepository) {
+		super();
+		this.releaseRepository = releaseRepository;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		String releaseName = context.getMessageHeaders().get(SkipperEventHeaders.RELEASE_NAME, String.class);
+		Integer rollbackVersion = context.getMessageHeaders().get(SkipperEventHeaders.ROLLBACK_VERSION, Integer.class);
+
+
+		Assert.notNull(releaseName, "Release name must not be null");
+		Assert.isTrue(rollbackVersion >= 0,
+				"Rollback version can not be less than zero.  Value = " + rollbackVersion);
+
+		Release currentRelease = this.releaseRepository.findLatestReleaseForUpdate(releaseName);
+		Assert.notNull(currentRelease, "Could not find release = [" + releaseName + "]");
+
+		// Determine with version to rollback to
+		int rollbackVersionToUse = rollbackVersion;
+		Release releaseToRollback = null;
+		if (rollbackVersion == 0) {
+			releaseToRollback = this.releaseRepository.findReleaseToRollback(releaseName);
+		}
+		else {
+			releaseToRollback = this.releaseRepository.findByNameAndVersion(releaseName, rollbackVersionToUse);
+			StatusCode statusCode = releaseToRollback.getInfo().getStatus().getStatusCode();
+			if (!(statusCode.equals(StatusCode.DEPLOYED) || statusCode.equals(StatusCode.DELETED))) {
+				throw new SkipperException("Rollback version should either be in deployed or deleted status.");
+			}
+		}
+		Assert.notNull(releaseToRollback, "Could not find Release to rollback to [releaseName,releaseVersion] = ["
+				+ releaseName + "," + rollbackVersionToUse + "]");
+
+		log.info("Rolling back releaseName={}.  Current version={}, Target version={}", releaseName,
+				currentRelease.getVersion(), rollbackVersionToUse);
+
+		Release newRollbackRelease = new Release();
+		newRollbackRelease.setName(releaseName);
+		newRollbackRelease.setPkg(releaseToRollback.getPkg());
+		newRollbackRelease.setManifest(releaseToRollback.getManifest());
+		newRollbackRelease.setVersion(currentRelease.getVersion() + 1);
+		newRollbackRelease.setPlatformName(releaseToRollback.getPlatformName());
+		newRollbackRelease.setConfigValues(releaseToRollback.getConfigValues());
+		newRollbackRelease.setInfo(Info.createNewInfo("Initial install underway"));
+
+		context.getExtendedState().getVariables().put(SkipperVariables.TARGET_RELEASE, newRollbackRelease);
+
+		if (!currentRelease.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
+			context.getExtendedState().getVariables().put(SkipperVariables.SOURCE_RELEASE, currentRelease);
+		}
+	}
+
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/SkipperStateMachineService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/SkipperStateMachineService.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.InstallProperties;
+import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.UpgradeRequest;
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.StateContext.Stage;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.listener.StateMachineListener;
+import org.springframework.statemachine.listener.StateMachineListenerAdapter;
+import org.springframework.statemachine.service.StateMachineService;
+import org.springframework.statemachine.transition.Transition;
+import org.springframework.statemachine.transition.TransitionKind;
+import org.springframework.util.Assert;
+import org.springframework.util.concurrent.SettableListenableFuture;
+
+/**
+ * Service class for state machine hiding its operational logic.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class SkipperStateMachineService {
+
+	public final static String STATEMACHINE_FACTORY_BEAN_NAME = "skipperStateMachineFactory";
+	private static final Logger log = LoggerFactory.getLogger(SkipperStateMachineService.class);
+	private final StateMachineService<SkipperStates, SkipperEvents> stateMachineService;
+
+	/**
+	 * Instantiates a new skipper state machine service.
+	 *
+	 * @param stateMachineService the state machine service
+	 */
+	public SkipperStateMachineService(StateMachineService<SkipperStates, SkipperEvents> stateMachineService) {
+		Assert.notNull(stateMachineService, "'stateMachineService' must be set");
+		this.stateMachineService = stateMachineService;
+	}
+
+	/**
+	 * Install release.
+	 *
+	 * @param installRequest the install request
+	 * @return the release
+	 */
+	public Release installRelease(InstallRequest installRequest) {
+		return installReleaseInternal(installRequest, null, null);
+	}
+
+	/**
+	 * Install release.
+	 *
+	 * @param id the id
+	 * @param installProperties the install properties
+	 * @return the release
+	 */
+	public Release installRelease(Long id, InstallProperties installProperties) {
+		return installReleaseInternal(null, id, installProperties);
+	}
+
+	/**
+	 * Upgrade release.
+	 *
+	 * @param upgradeRequest the upgrade request
+	 * @return the release
+	 */
+	public Release upgradeRelease(UpgradeRequest upgradeRequest) {
+		String releaseName = upgradeRequest.getUpgradeProperties().getReleaseName();
+		Message<SkipperEvents> message = MessageBuilder
+				.withPayload(SkipperEvents.UPGRADE)
+				.setHeader(SkipperEventHeaders.UPGRADE_REQUEST, upgradeRequest)
+				.build();
+		return handleMessageAndWait(message, releaseName, SkipperStates.UPGRADE_WAIT_TARGET_APPS);
+	}
+
+	/**
+	 * Delete release.
+	 *
+	 * @param releaseName the release name
+	 * @return the release
+	 */
+	public Release deleteRelease(String releaseName) {
+		Message<SkipperEvents> message = MessageBuilder
+				.withPayload(SkipperEvents.DELETE)
+				.setHeader(SkipperEventHeaders.RELEASE_NAME, releaseName)
+				.build();
+		return handleMessageAndWait(message, releaseName);
+	}
+
+	/**
+	 * Rollback release.
+	 *
+	 * @param releaseName the release name
+	 * @param rollbackVersion the rollback version
+	 * @return the release
+	 */
+	public Release rollbackRelease(final String releaseName, final int rollbackVersion) {
+		Message<SkipperEvents> message = MessageBuilder
+				.withPayload(SkipperEvents.ROLLBACK)
+				.setHeader(SkipperEventHeaders.RELEASE_NAME, releaseName)
+				.setHeader(SkipperEventHeaders.ROLLBACK_VERSION, rollbackVersion)
+				.build();
+		return handleMessageAndWait(message, releaseName, SkipperStates.UPGRADE_WAIT_TARGET_APPS,
+				SkipperStates.INITIAL);
+	}
+
+	private Release installReleaseInternal(InstallRequest installRequest, Long id, InstallProperties installProperties) {
+		String releaseName = installRequest != null ? installRequest.getInstallProperties().getReleaseName()
+				: installProperties.getReleaseName();
+		Message<SkipperEvents> message = MessageBuilder
+				.withPayload(SkipperEvents.INSTALL)
+				.setHeader(SkipperEventHeaders.INSTALL_REQUEST, installRequest)
+				.setHeader(SkipperEventHeaders.INSTALL_ID, id)
+				.setHeader(SkipperEventHeaders.INSTALL_PROPERTIES, installProperties)
+				.build();
+		return handleMessageAndWait(message, releaseName);
+	}
+
+	private boolean isInitialTransition(Transition<?, ?> transition) {
+		return transition != null && transition.getKind() == TransitionKind.INITIAL;
+	}
+
+	private Release handleMessageAndWait(Message<SkipperEvents> message, String machineId) {
+		return handleMessageAndWait(message, machineId, SkipperStates.INITIAL);
+	}
+
+	private Release handleMessageAndWait(Message<SkipperEvents> message, String machineId, SkipperStates... statesToWait) {
+		// machine gets acquired fully started
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = stateMachineService.acquireStateMachine(machineId);
+
+		// setup future handling blocking requirement returning release
+		SettableListenableFuture<Release> future = new SettableListenableFuture<>();
+		StateMachineListener<SkipperStates, SkipperEvents> listener = new StateMachineListenerAdapter<SkipperStates, SkipperEvents>() {
+
+			@Override
+			public void stateContext(StateContext<SkipperStates, SkipperEvents> stateContext) {
+				if (stateContext.getStage() == Stage.STATE_ENTRY) {
+					if (stateContext.getTarget().getId() == SkipperStates.ERROR) {
+						Exception exception = stateContext.getExtendedState().get(SkipperVariables.ERROR, Exception.class);
+						if (exception != null) {
+							// we went through error state, throw if there is an error
+							log.info("setting future exception", exception);
+							future.setException(exception);
+						}
+					}
+					else if (Arrays.asList(statesToWait).contains(stateContext.getTarget().getId())
+							&& !isInitialTransition(stateContext.getTransition())) {
+						Release release = (Release) stateContext.getExtendedState().getVariables().get(SkipperVariables.RELEASE);
+						// at this point we assume machine logic did set release
+						log.info("setting future value {}", release);
+						future.set(release);
+					}
+				}
+			}
+		};
+
+		// add listener which gets removed eventually
+		stateMachine.addStateListener(listener);
+		future.addCallback(result -> {
+			stateMachine.removeStateListener(listener);
+		}, throwable -> {
+			stateMachine.removeStateListener(listener);
+		});
+
+		// if machine doesn't accept an event, we're on state
+		// where a particular message cannot be handled, thus
+		// return exception. this simply happens when we are
+		// i.e. upgrading and delete request comes in.
+		if (stateMachine.sendEvent(message)) {
+			try {
+				return future.get();
+			}
+			catch (ExecutionException e) {
+				if (e.getCause() instanceof SkipperException) {
+					// throw as SkipperException
+					throw (SkipperException) e.getCause();
+				}
+				throw new SkipperException("Error waiting to get Release from a statemachine", e);
+			}
+			catch (Exception e) {
+				throw new SkipperException("Error waiting to get Release from a statemachine", e);
+			}
+		}
+		else {
+			throw new SkipperException("Statemachine is not in state ready to do " + message.getPayload());
+		}
+	}
+
+	/**
+	 * Enumeration of all possible states used by a machine.
+	 */
+	public enum SkipperStates {
+
+		/**
+		 * Initial state of a machine where instantiated machine goes.
+		 */
+		INITIAL,
+
+		/**
+		 * Central error handling state.
+		 */
+		ERROR,
+
+		/**
+		 * Central junction where all transitions from main skipper states terminates.
+		 */
+		ERROR_JUNCTION,
+
+		/**
+		 * Parent state of all install related states.
+		 */
+		INSTALL,
+
+		/**
+		 * State where apps deployment happens.
+		 */
+		INSTALL_INSTALL,
+
+		/**
+		 * Pseudostate used as a controlled exit point from {@link #INSTALL}.
+		 */
+		INSTALL_EXIT,
+
+		/**
+		 * Parent state of all upgrade related states.
+		 */
+		UPGRADE,
+
+		/**
+		 * State where all init logic happens before we can go
+		 * to state where actual new apps will be deployed.
+		 */
+		UPGRADE_START,
+
+		/**
+		 * State where new apps are getting deployed.
+		 */
+		UPGRADE_DEPLOY_TARGET_APPS,
+
+		/**
+		 * Intermediate state where machine pauses to either doing
+		 * a loop via {@link #UPGRADE_CHECK_TARGET_APPS} back to itself
+		 * or hopping into {@link #UPGRADE_CANCEL}.
+		 */
+		UPGRADE_WAIT_TARGET_APPS,
+
+		/**
+		 * State where status of a target release is checked.
+		 */
+		UPGRADE_CHECK_TARGET_APPS,
+
+		/**
+		 * State where machine ends up if target release is considered failed.
+		 */
+		UPGRADE_DEPLOY_TARGET_APPS_FAILED,
+
+		/**
+		 * State where machine ends up if target release is considered successful.
+		 */
+		UPGRADE_DEPLOY_TARGET_APPS_SUCCEED,
+
+		/**
+		 * State where machine goes if it is possible to cancel current
+		 * upgrade operation.
+		 */
+		UPGRADE_CANCEL,
+
+		/**
+		 * State where source apps are getting deleted.
+		 */
+		UPGRADE_DELETE_SOURCE_APPS,
+
+		/**
+		 * Pseudostate used to chooce between {@link #UPGRADE_DELETE_SOURCE_APPS}
+		 * and {@link #UPGRADE_CHECK_TARGET_APPS}
+		 */
+		UPGRADE_CHECK_CHOICE,
+
+		/**
+		 * Pseudostate used as a controlled exit point from {@link #UPGRADE}.
+		 */
+		UPGRADE_EXIT,
+
+		/**
+		 * Parent state of all delete related states.
+		 */
+		DELETE,
+
+		/**
+		 * State where release delete happens.
+		 */
+		DELETE_DELETE,
+
+		/**
+		 * Pseudostate used as a controlled exit point from {@link #DELETE}.
+		 */
+		DELETE_EXIT,
+
+		/**
+		 * Parent state of all rollback related states.
+		 */
+		ROLLBACK,
+
+		/**
+		 * Initialisation state where future branch from {@link #ROLLBACK_CHOICE}
+		 * is desided.
+		 */
+		ROLLBACK_START,
+
+		/**
+		 * Pseudostate makind decision between exit points {@link #ROLLBACK_EXIT},
+		 * {@link #ROLLBACK_EXIT_INSTALL} and {@link #ROLLBACK_EXIT_UPGRADE}.
+		 */
+		ROLLBACK_CHOICE,
+
+		/**
+		 * Controlled exit into {@link #INSTALL}.
+		 */
+		ROLLBACK_EXIT_INSTALL,
+
+		/**
+		 * Controlled exit into {@link #UPGRADE}.
+		 */
+		ROLLBACK_EXIT_UPGRADE,
+
+		/**
+		 * Controlled exit which acts as a fallback in case either {@link #ROLLBACK_EXIT_INSTALL}
+		 * or {@link #ROLLBACK_EXIT_UPGRADE} cannot be chosen for some reason.
+		 */
+		ROLLBACK_EXIT;
+	}
+
+	/**
+	 * Enumeration of all possible events used by a machine.
+	 */
+	public enum SkipperEvents {
+
+		/**
+		 * Main level event instructing an install request.
+		 */
+		INSTALL,
+
+		/**
+		 * Main level event instructing a delete request.
+		 */
+		DELETE,
+
+		/**
+		 * Main level event instructing an upgrade request.
+		 */
+		UPGRADE,
+
+		/**
+		 * While being on {@link SkipperStates#UPGRADE}, this event can be used
+		 * to try upgrade cancel operation. Cancellation happens if machine
+		 * is in a state where it is possible to go into cancel procedure.
+		 */
+		UPGRADE_CANCEL,
+
+		/**
+		 * While being on {@link SkipperStates#UPGRADE}, this event can be used
+		 * to try upgrade accept procedure.
+		 */
+		UPGRADE_ACCEPT,
+
+		/**
+		 * Main level event instructing a rollback request.
+		 */
+		ROLLBACK;
+	}
+
+	/**
+	 * Definitions of possible event headers used by a machine. Defined as
+	 * string constants instead of enums because spring message headers
+	 * don't work with enums.
+	 */
+	public final class SkipperEventHeaders {
+
+		/**
+		 * Header for {@link PackageMetadata}.
+		 */
+		public static final String PACKAGE_METADATA = "PACKAGE_METADATA";
+
+		/**
+		 * Header for version integer used in api's.
+		 */
+		public static final String VERSION = "VERSION";
+
+		/**
+		 * Header for id used in install api's.
+		 */
+		public static final String INSTALL_ID = "INSTALL_ID";
+
+		/**
+		 * Header for {@link InstallProperties}.
+		 */
+		public static final String INSTALL_PROPERTIES = "INSTALL_PROPERTIES";
+
+		/**
+		 * Header for {@link InstallRequest}.
+		 */
+		public static final String INSTALL_REQUEST = "INSTALL_REQUEST";
+
+		/**
+		 * Header for {@link UpgradeRequest}.
+		 */
+		public static final String UPGRADE_REQUEST = "UPGRADE_REQUEST";
+
+		/**
+		 * Header for internal timeout value for upgrade.
+		 */
+		public static final String UPGRADE_TIMEOUT = "UPGRADE_TIMEOUT";
+
+		/**
+		 * Header for generic {@code release name} identifier.
+		 */
+		public static final String RELEASE_NAME = "RELEASE_NAME";
+
+		/**
+		 * Header for rollback version.
+		 */
+		public static final String ROLLBACK_VERSION = "ROLLBACK_VERSION";
+	}
+
+	/**
+	 * Extended state variable names for skipper statemachine.
+	 */
+	public enum SkipperVariables {
+
+		/**
+		 * Global error variable which any component can set to
+		 * indicate unprocessed exception.
+		 */
+		ERROR,
+
+		/**
+		 * Variable for release which is returned to a caller
+		 * when machine goes back to initial state.
+		 */
+		RELEASE,
+
+		/**
+		 * Variable keeping {@link ReleaseAnalysisReport} in a context.
+		 */
+		RELEASE_ANALYSIS_REPORT,
+
+		/**
+		 * Variable for a {@link Release} where skipper is coming from.
+		 */
+		SOURCE_RELEASE,
+
+		/**
+		 * Variable for a {@link Release} where skipper is going to.
+		 */
+		TARGET_RELEASE,
+
+		/**
+		 * Variable keeping a cutoff time.
+		 */
+		UPGRADE_CUTOFF_TIME,
+
+		/**
+		 * Variable internally used in a an upgrade state for current status.
+		 */
+		UPGRADE_STATUS;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineConfiguration.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.cloud.skipper.server.service.ReleaseReportService;
+import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.statemachine.StateMachinePersist;
+import org.springframework.statemachine.config.EnableStateMachineFactory;
+import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.statemachine.config.builders.StateMachineConfigurationConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+import org.springframework.statemachine.guard.Guard;
+import org.springframework.statemachine.listener.StateMachineListenerAdapter;
+import org.springframework.statemachine.persist.StateMachineRuntimePersister;
+import org.springframework.statemachine.service.DefaultStateMachineService;
+import org.springframework.statemachine.service.StateMachineService;
+import org.springframework.statemachine.state.State;
+
+/**
+ * Statemachine(s) related configurations.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+public class StateMachineConfiguration {
+
+	private static final Logger log = LoggerFactory.getLogger(StateMachineConfiguration.class);
+
+	/**
+	 * Configuration defining {@link StateMachineFactory} for skipper release handling.
+	 */
+	@EnableStateMachineFactory(name = SkipperStateMachineService.STATEMACHINE_FACTORY_BEAN_NAME)
+	@Configuration
+	public static class SkipperStateMachineFactoryConfig extends StateMachineConfigurerAdapter<SkipperStates, SkipperEvents> {
+
+		@Autowired
+		private TaskExecutor skipperStateMachineTaskExecutor;
+
+		@Autowired
+		private ReleaseService releaseService;
+
+		@Autowired
+		private ReleaseReportService releaseReportService;
+
+		@Autowired
+		private ReleaseRepository releaseRepository;
+
+		@Autowired
+		private UpgradeStrategy upgradeStrategy;
+
+		@Autowired
+		private StateMachineRuntimePersister<SkipperStates, SkipperEvents, String> stateMachineRuntimePersister;
+
+		@Override
+		public void configure(StateMachineConfigurationConfigurer<SkipperStates, SkipperEvents> config)	throws Exception {
+			config
+				.withConfiguration()
+					.taskExecutor(skipperStateMachineTaskExecutor)
+					// this is to simply add logging for state enters
+					.listener(new StateMachineListenerAdapter<SkipperStates, SkipperEvents>() {
+						@Override
+						public void stateEntered(State<SkipperStates, SkipperEvents> state) {
+							log.info("Entering state {}", state);
+						}
+					})
+				.and()
+				.withPersistence()
+					.runtimePersister(stateMachineRuntimePersister);
+		}
+
+		@Override
+		public void configure(StateMachineStateConfigurer<SkipperStates, SkipperEvents> states) throws Exception {
+			states
+				// there's no need to explicitly define supported states
+				// as every state id used in below config, adds it as supported state
+				.withStates()
+					// define main states
+					.initial(SkipperStates.INITIAL)
+					.stateEntry(SkipperStates.ERROR, errorAction())
+					// clear memory for stored variables
+					.stateExit(SkipperStates.INITIAL, resetVariablesAction())
+					.state(SkipperStates.INSTALL)
+					.state(SkipperStates.DELETE)
+					.state(SkipperStates.UPGRADE)
+					.state(SkipperStates.ROLLBACK)
+					.junction(SkipperStates.ERROR_JUNCTION)
+					.and()
+					.withStates()
+						// substates for install
+						.parent(SkipperStates.INSTALL)
+						.initial(SkipperStates.INSTALL_INSTALL)
+						.stateEntry(SkipperStates.INSTALL_INSTALL, installInstallAction())
+						.exit(SkipperStates.INSTALL_EXIT)
+						.and()
+					.withStates()
+						// substates for upgrade
+						.parent(SkipperStates.UPGRADE)
+						.initial(SkipperStates.UPGRADE_START)
+						.stateEntry(SkipperStates.UPGRADE_START, upgradeStartAction())
+						.stateEntry(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS, upgradeDeployTargetAppsAction())
+						.state(SkipperStates.UPGRADE_WAIT_TARGET_APPS)
+						.state(SkipperStates.UPGRADE_CHECK_TARGET_APPS, SkipperEvents.UPGRADE_CANCEL)
+						.stateEntry(SkipperStates.UPGRADE_CHECK_TARGET_APPS, upgradeCheckTargetAppsAction())
+						.stateEntry(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS_SUCCEED, upgradeDeployTargetAppsSucceedAction())
+						.stateEntry(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS_FAILED, upgradeDeployTargetAppsFailedAction())
+						.stateEntry(SkipperStates.UPGRADE_CANCEL, upgradeCancelAction())
+						.stateEntry(SkipperStates.UPGRADE_DELETE_SOURCE_APPS, upgradeDeleteSourceAppsAction())
+						.choice(SkipperStates.UPGRADE_CHECK_CHOICE)
+						.exit(SkipperStates.UPGRADE_EXIT)
+						.and()
+					.withStates()
+						// substates for delete
+						.parent(SkipperStates.DELETE)
+						.initial(SkipperStates.DELETE_DELETE)
+						.stateEntry(SkipperStates.DELETE_DELETE, deleteDeleteAction())
+						.exit(SkipperStates.DELETE_EXIT)
+						.and()
+					.withStates()
+						// substates for rollback
+						.parent(SkipperStates.ROLLBACK)
+						.initial(SkipperStates.ROLLBACK_START)
+						.stateEntry(SkipperStates.ROLLBACK_START, rollbackStartAction())
+						.choice(SkipperStates.ROLLBACK_CHOICE)
+						.exit(SkipperStates.ROLLBACK_EXIT_UPGRADE)
+						.exit(SkipperStates.ROLLBACK_EXIT_INSTALL)
+						.exit(SkipperStates.ROLLBACK_EXIT);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<SkipperStates, SkipperEvents> transitions) throws Exception {
+			transitions
+
+				// transitions around error handling outside of main skipper states
+				// all controlled exit points go via error junction as well
+				// anonymous transitions from all main states go to error junction
+				// having error guard. error state leads back to initial state and
+				// we're back to for processing next command.
+				.withJunction()
+					.source(SkipperStates.ERROR_JUNCTION)
+					.first(SkipperStates.ERROR, errorGuard())
+					.last(SkipperStates.INITIAL)
+					.and()
+				.withExternal()
+					.source(SkipperStates.ERROR).target(SkipperStates.INITIAL)
+					.and()
+				.withExternal()
+					.source(SkipperStates.INSTALL).target(SkipperStates.ERROR_JUNCTION)
+					.guard(errorGuard())
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE).target(SkipperStates.ERROR_JUNCTION)
+					.guard(errorGuard())
+					.and()
+				.withExternal()
+					.source(SkipperStates.DELETE).target(SkipperStates.ERROR_JUNCTION)
+					.guard(errorGuard())
+					.and()
+				.withExternal()
+					.source(SkipperStates.ROLLBACK).target(SkipperStates.ERROR_JUNCTION)
+					.guard(errorGuard())
+					.and()
+
+				// install transitions
+				.withExternal()
+					.source(SkipperStates.INITIAL).target(SkipperStates.INSTALL)
+					.event(SkipperEvents.INSTALL)
+					.and()
+				.withExternal()
+					.source(SkipperStates.INSTALL_INSTALL).target(SkipperStates.INSTALL_EXIT)
+					.and()
+				.withExit()
+					.source(SkipperStates.INSTALL_EXIT).target(SkipperStates.ERROR_JUNCTION)
+					.and()
+
+				// upgrade transitions
+				.withExternal()
+					.source(SkipperStates.INITIAL).target(SkipperStates.UPGRADE)
+					.event(SkipperEvents.UPGRADE)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_START).target(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS).target(SkipperStates.UPGRADE_WAIT_TARGET_APPS)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_WAIT_TARGET_APPS).target(SkipperStates.UPGRADE_CHECK_CHOICE)
+					.timer(1000)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_CHECK_TARGET_APPS).target(SkipperStates.UPGRADE_WAIT_TARGET_APPS)
+					.and()
+				.withExternal()
+					// define transition which allows to break out from wait/check loop
+					// if machine is in state where this can happen
+					.source(SkipperStates.UPGRADE_WAIT_TARGET_APPS).target(SkipperStates.UPGRADE_CANCEL)
+					.event(SkipperEvents.UPGRADE_CANCEL)
+					.and()
+				.withChoice()
+					.source(SkipperStates.UPGRADE_CHECK_CHOICE)
+					.first(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS_SUCCEED, upgradeOkGuard())
+					.then(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS_FAILED, upgradeFailedGuard())
+					.last(SkipperStates.UPGRADE_CHECK_TARGET_APPS)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS_SUCCEED).target(SkipperStates.UPGRADE_DELETE_SOURCE_APPS)
+					.event(SkipperEvents.UPGRADE_ACCEPT)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS_SUCCEED).target(SkipperStates.UPGRADE_CANCEL)
+					.event(SkipperEvents.UPGRADE_CANCEL)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_DEPLOY_TARGET_APPS_FAILED).target(SkipperStates.UPGRADE_CANCEL)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_CANCEL).target(SkipperStates.UPGRADE_EXIT)
+					.and()
+				.withExternal()
+					.source(SkipperStates.UPGRADE_DELETE_SOURCE_APPS).target(SkipperStates.UPGRADE_EXIT)
+					.and()
+				.withExit()
+					.source(SkipperStates.UPGRADE_EXIT).target(SkipperStates.ERROR_JUNCTION)
+					.and()
+
+				// delete transitions
+				.withExternal()
+					.source(SkipperStates.INITIAL).target(SkipperStates.DELETE)
+					.event(SkipperEvents.DELETE)
+					.and()
+				.withExternal()
+					.source(SkipperStates.DELETE_DELETE).target(SkipperStates.DELETE_EXIT)
+					.and()
+				.withExit()
+					.source(SkipperStates.DELETE_EXIT).target(SkipperStates.ERROR_JUNCTION)
+					.and()
+
+				// rollback transitions
+				.withExternal()
+					.source(SkipperStates.INITIAL).target(SkipperStates.ROLLBACK)
+					.event(SkipperEvents.ROLLBACK)
+					.and()
+				.withExternal()
+					.source(SkipperStates.ROLLBACK_START).target(SkipperStates.ROLLBACK_CHOICE)
+					.and()
+				.withChoice()
+					.source(SkipperStates.ROLLBACK_CHOICE)
+					.first(SkipperStates.ROLLBACK_EXIT_UPGRADE, rollbackUpgradeGuard())
+					.then(SkipperStates.ROLLBACK_EXIT_INSTALL, rollbackInstallGuard())
+					.last(SkipperStates.ROLLBACK_EXIT)
+					.and()
+				.withExit()
+					.source(SkipperStates.ROLLBACK_EXIT).target(SkipperStates.ERROR_JUNCTION)
+					.and()
+				.withExit()
+					.source(SkipperStates.ROLLBACK_EXIT_UPGRADE).target(SkipperStates.UPGRADE)
+					.and()
+				.withExit()
+					.source(SkipperStates.ROLLBACK_EXIT_INSTALL).target(SkipperStates.INSTALL);
+		}
+
+		@Bean
+		public ResetVariablesAction resetVariablesAction() {
+			return new ResetVariablesAction();
+		}
+
+		@Bean
+		public Guard<SkipperStates, SkipperEvents> errorGuard() {
+			return context -> context.getExtendedState().getVariables().containsKey(SkipperVariables.ERROR);
+		}
+
+		@Bean
+		public ErrorAction errorAction() {
+			return new ErrorAction();
+		}
+
+		@Bean
+		public InstallInstallAction installInstallAction() {
+			return new InstallInstallAction(releaseService);
+		}
+
+		@Bean
+		public UpgradeStartAction upgradeStartAction() {
+			return new UpgradeStartAction(releaseReportService, releaseService);
+		}
+
+		@Bean
+		public UpgradeDeployTargetAppsAction upgradeDeployTargetAppsAction() {
+			return new UpgradeDeployTargetAppsAction(upgradeStrategy);
+		}
+
+		@Bean
+		public UpgradeCheckTargetAppsAction upgradeCheckTargetAppsAction() {
+			return new UpgradeCheckTargetAppsAction(upgradeStrategy);
+		}
+
+		@Bean
+		public UpgradeCheckNewAppsGuard upgradeOkGuard() {
+			return new UpgradeCheckNewAppsGuard(true);
+		}
+
+		@Bean
+		public UpgradeCheckNewAppsGuard upgradeFailedGuard() {
+			return new UpgradeCheckNewAppsGuard(false);
+		}
+
+		@Bean
+		public UpgradeDeployTargetAppsSucceedAction upgradeDeployTargetAppsSucceedAction() {
+			return new UpgradeDeployTargetAppsSucceedAction();
+		}
+
+		@Bean
+		public UpgradeDeployTargetAppsFailedAction upgradeDeployTargetAppsFailedAction() {
+			return new UpgradeDeployTargetAppsFailedAction();
+		}
+
+		@Bean
+		public UpgradeCancelAction upgradeCancelAction() {
+			return new UpgradeCancelAction(upgradeStrategy);
+		}
+
+		@Bean
+		public UpgradeDeleteSourceAppsAction upgradeDeleteSourceAppsAction() {
+			return new UpgradeDeleteSourceAppsAction(upgradeStrategy);
+		}
+
+		@Bean
+		public DeleteDeleteAction deleteDeleteAction() {
+			return new DeleteDeleteAction(releaseService);
+		}
+
+		@Bean
+		public RollbackStartAction rollbackStartAction() {
+			return new RollbackStartAction(releaseRepository);
+		}
+
+		@Bean
+		public Guard<SkipperStates, SkipperEvents> rollbackInstallGuard() {
+			return context -> {
+				return context.getExtendedState().getVariables().containsKey(SkipperVariables.TARGET_RELEASE)
+						&& !context.getExtendedState().getVariables().containsKey(SkipperVariables.SOURCE_RELEASE);
+			};
+		}
+
+		@Bean
+		public Guard<SkipperStates, SkipperEvents> rollbackUpgradeGuard() {
+			return context -> {
+				return context.getExtendedState().getVariables().containsKey(SkipperVariables.TARGET_RELEASE)
+						&& context.getExtendedState().getVariables().containsKey(SkipperVariables.SOURCE_RELEASE);
+			};
+		}
+	}
+
+	/**
+	 * Configuration related to {@link SkipperStateMachineService}.
+	 */
+	@Configuration
+	public static class StateMachineServiceConfig {
+
+		@Bean
+		public StateMachineService<SkipperStates, SkipperEvents> stateMachineService(
+				StateMachineFactory<SkipperStates, SkipperEvents> stateMachineFactory,
+				StateMachinePersist<SkipperStates, SkipperEvents, String> stateMachinePersist) {
+			return new DefaultStateMachineService<>(stateMachineFactory, stateMachinePersist);
+		}
+
+		@Bean
+		public SkipperStateMachineService skipperStateMachineService(StateMachineService<SkipperStates, SkipperEvents> stateMachineService) {
+			return new SkipperStateMachineService(stateMachineService);
+		}
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineExecutorConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineExecutorConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Executor configuration for statemachine. Keeping all these separate from main machine
+ * config allows to run tests tests in isolation without adding persistence layer.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+public class StateMachineExecutorConfiguration {
+
+	@Bean
+	public TaskExecutor skipperStateMachineTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(4);
+		return executor;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachinePersistConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachinePersistConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.data.jpa.JpaPersistingStateMachineInterceptor;
+import org.springframework.statemachine.data.jpa.JpaStateMachineRepository;
+import org.springframework.statemachine.persist.StateMachineRuntimePersister;
+
+/**
+ * Persistence config for statemachine. Keeping all these separate from main machine
+ * config allows to run tests tests in isolation without adding persistence layer.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+public class StateMachinePersistConfiguration {
+
+	@Bean
+	public StateMachineRuntimePersister<SkipperStates, SkipperEvents, String> stateMachineRuntimePersister(
+			JpaStateMachineRepository jpaStateMachineRepository) {
+		// repository created in statemachine boot integration
+		return new JpaPersistingStateMachineInterceptor<>(jpaStateMachineRepository);
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCancelAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCancelAction.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action}
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class UpgradeCancelAction extends AbstractAction {
+
+	private final UpgradeStrategy upgradeStrategy;
+
+	/**
+	 * Instantiates a new upgrade cancel action.
+	 *
+	 * @param upgradeStrategy the upgrade strategy
+	 */
+	public UpgradeCancelAction(UpgradeStrategy upgradeStrategy) {
+		super();
+		this.upgradeStrategy = upgradeStrategy;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		ReleaseAnalysisReport releaseAnalysisReport = context.getExtendedState().get(SkipperVariables.RELEASE_ANALYSIS_REPORT,
+				ReleaseAnalysisReport.class);
+		upgradeStrategy.cancel(releaseAnalysisReport.getExistingRelease(), releaseAnalysisReport.getReplacingRelease(),
+				releaseAnalysisReport);
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCheckNewAppsGuard.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCheckNewAppsGuard.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.guard.Guard;
+
+/**
+ * A {@link Guard} using extended state variable {@link SkipperVariables#UPGRADE_STATUS}
+ * to determine condition based on initialised {@code upgradeStatus} flag. Value of a
+ * {@link SkipperVariables#UPGRADE_STATUS} is set in {@link UpgradeCheckTargetAppsAction}
+ * and as this same guard is used to protect 'succeed' and 'failure' transitions,
+ * {@code upgradeStatus} is simply used to differentiate between the two.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class UpgradeCheckNewAppsGuard implements Guard<SkipperStates, SkipperEvents> {
+
+	private static final Logger log = LoggerFactory.getLogger(UpgradeCheckNewAppsGuard.class);
+	private final boolean upgradeStatus;
+
+	/**
+	 * Instantiates a new upgrade check new apps guard.
+	 *
+	 * @param upgradeStatus the upgrade status flag
+	 */
+	public UpgradeCheckNewAppsGuard(boolean upgradeStatus) {
+		this.upgradeStatus = upgradeStatus;
+	}
+
+	@Override
+	public boolean evaluate(StateContext<SkipperStates, SkipperEvents> context) {
+		Integer status = context.getExtendedState().get(SkipperVariables.UPGRADE_STATUS, Integer.class);
+		log.debug("Checking condition {} with upgradeStatus {}", status, upgradeStatus);
+		if (status == null || status == 0) {
+			return false;
+		}
+		else if (upgradeStatus && status > 0) {
+			return true;
+		}
+		else if (!upgradeStatus && status < 0) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCheckTargetAppsAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCheckTargetAppsAction.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action} checking upgrade status with an {@link UpgradeStrategy}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class UpgradeCheckTargetAppsAction extends AbstractAction {
+
+	private static final Logger log = LoggerFactory.getLogger(UpgradeCheckTargetAppsAction.class);
+	private final UpgradeStrategy upgradeStrategy;
+
+	/**
+	 * Instantiates a new upgrade check target apps action.
+	 *
+	 * @param upgradeStrategy the upgrade strategy
+	 */
+	public UpgradeCheckTargetAppsAction(UpgradeStrategy upgradeStrategy) {
+		super();
+		this.upgradeStrategy = upgradeStrategy;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		ReleaseAnalysisReport releaseAnalysisReport = context.getExtendedState().get(SkipperVariables.RELEASE_ANALYSIS_REPORT,
+				ReleaseAnalysisReport.class);
+		int upgradeStatus = 0;
+		boolean ok = upgradeStrategy.checkStatus(releaseAnalysisReport.getReplacingRelease());
+		log.debug("upgradeStrategy checkStatus {}", ok);
+		if (ok) {
+			upgradeStatus = 1;
+		}
+		else if (!ok && cutOffTimeExceed(context)) {
+			upgradeStatus = -1;
+		}
+		log.debug("Setting upgradeStatus {}", upgradeStatus);
+		context.getExtendedState().getVariables().put(SkipperVariables.UPGRADE_STATUS, upgradeStatus);
+	}
+
+	private boolean cutOffTimeExceed(StateContext<SkipperStates, SkipperEvents> context) {
+		long now = System.currentTimeMillis();
+		Long cutOffTime = context.getExtendedState().get(SkipperVariables.UPGRADE_CUTOFF_TIME, Long.class);
+		log.debug("Testing cutOffTime {} to now {}", cutOffTime, now);
+		return now > cutOffTime;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeleteSourceAppsAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeleteSourceAppsAction.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action} accepting app with an {@link UpgradeStrategy}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class UpgradeDeleteSourceAppsAction extends AbstractAction {
+
+	private final UpgradeStrategy upgradeStrategy;
+
+	/**
+	 * Instantiates a new upgrade delete source apps action.
+	 *
+	 * @param upgradeStrategy the upgrade strategy
+	 */
+	public UpgradeDeleteSourceAppsAction(UpgradeStrategy upgradeStrategy) {
+		super();
+		this.upgradeStrategy = upgradeStrategy;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		ReleaseAnalysisReport releaseAnalysisReport = context.getExtendedState().get(SkipperVariables.RELEASE_ANALYSIS_REPORT,
+				ReleaseAnalysisReport.class);
+		upgradeStrategy.accept(releaseAnalysisReport.getExistingRelease(), releaseAnalysisReport.getReplacingRelease(),
+				releaseAnalysisReport);
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeployTargetAppsAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeployTargetAppsAction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action} deploying app with an {@link UpgradeStrategy}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class UpgradeDeployTargetAppsAction extends AbstractAction {
+
+	private static final Logger log = LoggerFactory.getLogger(UpgradeDeployTargetAppsAction.class);
+	private final UpgradeStrategy upgradeStrategy;
+
+	/**
+	 * Instantiates a new upgrade deploy target apps action.
+	 *
+	 * @param upgradeStrategy the upgrade strategy
+	 */
+	public UpgradeDeployTargetAppsAction(UpgradeStrategy upgradeStrategy) {
+		super();
+		this.upgradeStrategy = upgradeStrategy;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		log.info("Using UpgradeStrategy {}", upgradeStrategy);
+		ReleaseAnalysisReport releaseAnalysisReport = context.getExtendedState().get(SkipperVariables.RELEASE_ANALYSIS_REPORT,
+				ReleaseAnalysisReport.class);
+		log.info("releaseAnalysisReport {}", releaseAnalysisReport);
+		this.upgradeStrategy.deployApps(releaseAnalysisReport.getExistingRelease(),
+				releaseAnalysisReport.getReplacingRelease(), releaseAnalysisReport);
+		context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, releaseAnalysisReport.getReplacingRelease());
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeployTargetAppsFailedAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeployTargetAppsFailedAction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action} which simple sends an event to machine to cancel an upgrade.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class UpgradeDeployTargetAppsFailedAction extends AbstractAction {
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		// doesn't currently do anything
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeployTargetAppsSucceedAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeployTargetAppsSucceedAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action} which simple sends an event to machine to accept an upgrade.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class UpgradeDeployTargetAppsSucceedAction extends AbstractAction {
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		// TODO: when we support other type of strategies, we would not need to just
+		//       blindly send accept as we can also cancel upgrade in this stage.
+		context.getStateMachine().sendEvent(SkipperEvents.UPGRADE_ACCEPT);
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeStartAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeStartAction.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.UpgradeRequest;
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.service.ReleaseReportService;
+import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+/**
+ * StateMachine {@link Action} preparing upgrage logic and adds {@link ReleaseAnalysisReport}
+ * and cutoff time to a context.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class UpgradeStartAction extends AbstractAction {
+
+	private static final Logger log = LoggerFactory.getLogger(UpgradeStartAction.class);
+	private static final long DEFAULT_UPGRADE_TIMEOUT = 60000L;
+	private final ReleaseReportService releaseReportService;
+	private final ReleaseService releaseService;
+
+	/**
+	 * Instantiates a new upgrade start action.
+	 *
+	 * @param releaseReportService the release report service
+	 * @param releaseService the release service
+	 */
+	public UpgradeStartAction(ReleaseReportService releaseReportService, ReleaseService releaseService) {
+		super();
+		this.releaseReportService = releaseReportService;
+		this.releaseService = releaseService;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		setUpgradeCutOffTime(context);
+
+		UpgradeRequest upgradeRequest = context.getMessageHeaders().get(SkipperEventHeaders.UPGRADE_REQUEST, UpgradeRequest.class);
+		log.info("upgradeRequest {}", upgradeRequest);
+		if (upgradeRequest != null) {
+			ReleaseAnalysisReport releaseAnalysisReport = this.releaseReportService.createReport(upgradeRequest);
+			log.info("releaseAnalysisReport {}", releaseAnalysisReport);
+			context.getExtendedState().getVariables().put(SkipperVariables.RELEASE_ANALYSIS_REPORT, releaseAnalysisReport);
+		}
+		else {
+			Release existingRelease = context.getExtendedState().get(SkipperVariables.SOURCE_RELEASE, Release.class);
+			Release replacingRelease = context.getExtendedState().get(SkipperVariables.TARGET_RELEASE, Release.class);
+			ReleaseAnalysisReport releaseAnalysisReport = releaseService.createReport(existingRelease, replacingRelease);
+			context.getExtendedState().getVariables().put(SkipperVariables.RELEASE_ANALYSIS_REPORT, releaseAnalysisReport);
+		}
+	}
+
+	private void setUpgradeCutOffTime(StateContext<SkipperStates, SkipperEvents> context) {
+		Long upgradeTimeout = context.getMessageHeaders().get(SkipperEventHeaders.UPGRADE_TIMEOUT, Long.class);
+		if (upgradeTimeout == null) {
+			upgradeTimeout = DEFAULT_UPGRADE_TIMEOUT;
+		}
+		long cutOffTime = System.currentTimeMillis() + upgradeTimeout;
+		context.getExtendedState().getVariables().put(SkipperVariables.UPGRADE_CUTOFF_TIME,
+				cutOffTime);
+		log.debug("Set cutoff time as {}", cutOffTime);
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeStartAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeStartAction.java
@@ -40,7 +40,7 @@ import org.springframework.statemachine.action.Action;
 public class UpgradeStartAction extends AbstractAction {
 
 	private static final Logger log = LoggerFactory.getLogger(UpgradeStartAction.class);
-	private static final long DEFAULT_UPGRADE_TIMEOUT = 60000L;
+	private static final long DEFAULT_UPGRADE_TIMEOUT = 300000L;
 	private final ReleaseReportService releaseReportService;
 	private final ReleaseService releaseService;
 

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -53,4 +53,5 @@ logging:
     org.hibernate: 'WARN'
     # The following INFO is to log the generated password when using basic security
     org.springframework.boot.autoconfigure.security: 'INFO'
-    org.springframework.skipper: 'INFO'
+    org.springframework.cloud.skipper: 'INFO'
+    org.springframework.statemachine: 'INFO'    

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
@@ -45,6 +45,7 @@ import org.springframework.cloud.skipper.server.service.ReleaseService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.statemachine.boot.autoconfigure.StateMachineJpaRepositoriesAutoConfiguration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -169,8 +170,8 @@ public abstract class AbstractIntegrationTest extends AbstractAssertReleaseDeplo
 	}
 
 	@Configuration
-	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class,
-			EmbeddedDataSourceConfiguration.class, HibernateJpaAutoConfiguration.class })
+	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
+			HibernateJpaAutoConfiguration.class, StateMachineJpaRepositoriesAutoConfiguration.class })
 	@Import(SkipperServerConfiguration.class)
 	@EnableWebMvc
 	static class TestConfig {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractMockMvcTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractMockMvcTests.java
@@ -43,6 +43,7 @@ import org.springframework.cloud.skipper.server.config.SkipperServerConfiguratio
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.statemachine.boot.autoconfigure.StateMachineJpaRepositoriesAutoConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -133,7 +134,7 @@ public abstract class AbstractMockMvcTests extends AbstractAssertReleaseDeployed
 	@Configuration
 	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
 			HibernateJpaAutoConfiguration.class, RepositoryRestMvcAutoConfiguration.class,
-			ErrorMvcAutoConfiguration.class })
+			ErrorMvcAutoConfiguration.class, StateMachineJpaRepositoriesAutoConfiguration.class })
 	@Import(SkipperServerConfiguration.class)
 	@EnableWebMvc
 	static class TestConfig {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/PlatformPropertiesTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/PlatformPropertiesTests.java
@@ -32,6 +32,7 @@ import org.springframework.cloud.deployer.spi.kubernetes.KubernetesDeployerPrope
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.statemachine.boot.autoconfigure.StateMachineJpaRepositoriesAutoConfiguration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -93,7 +94,8 @@ public class PlatformPropertiesTests {
 	}
 
 	@Configuration
-	@ImportAutoConfiguration(classes = { EmbeddedDataSourceConfiguration.class, HibernateJpaAutoConfiguration.class })
+	@ImportAutoConfiguration(classes = { EmbeddedDataSourceConfiguration.class, HibernateJpaAutoConfiguration.class,
+			StateMachineJpaRepositoriesAutoConfiguration.class })
 	@Import(SkipperServerConfiguration.class)
 	static class TestConfig {
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
@@ -77,6 +77,11 @@ public class ApiDocumentation extends BaseDocumentation {
 				linkWithRel("deployers").description("Exposes deployer"),
 				linkWithRel("releases").description("Exposes release information"),
 				linkWithRel("packageMetadata").description("Provides details for Package Metadata"),
+				linkWithRel("jpaRepositoryStates").description(""),
+				linkWithRel("jpaRepositoryGuards").description(""),
+				linkWithRel("jpaRepositoryTransitions").description(""),
+				linkWithRel("jpaRepositoryStateMachines").description(""),
+				linkWithRel("jpaRepositoryActions").description(""),
 				linkWithRel("profile").description(
 						"Entrypoint to provide ALPS metadata defining simple descriptions of application-level semantics"),
 				linkWithRel("status/name")

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ConfigValueUtilsTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ConfigValueUtilsTests.java
@@ -40,6 +40,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.statemachine.boot.autoconfigure.StateMachineJpaRepositoriesAutoConfiguration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
@@ -88,7 +89,7 @@ public class ConfigValueUtilsTests {
 
 	@Configuration
 	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
-			HibernateJpaAutoConfiguration.class })
+			HibernateJpaAutoConfiguration.class, StateMachineJpaRepositoriesAutoConfiguration.class })
 	@Import(SkipperServerConfiguration.class)
 	static class TestConfig {
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageMetadataServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageMetadataServiceTests.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.skipper.server.config.SkipperServerConfiguratio
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.UrlResource;
+import org.springframework.statemachine.boot.autoconfigure.StateMachineJpaRepositoriesAutoConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,7 +68,7 @@ public class PackageMetadataServiceTests {
 
 	@Configuration
 	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
-			HibernateJpaAutoConfiguration.class })
+			HibernateJpaAutoConfiguration.class, StateMachineJpaRepositoriesAutoConfiguration.class })
 	@Import(SkipperServerConfiguration.class)
 	static class TestConfig {
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.InstallProperties;
+import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.domain.UpgradeRequest;
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.deployer.ReleaseDifference;
+import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
+import org.springframework.cloud.skipper.server.deployer.strategies.DeployAppStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.HandleHealthCheckStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.cloud.skipper.server.service.PackageService;
+import org.springframework.cloud.skipper.server.service.ReleaseReportService;
+import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.StateMachineTests.TestConfig;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.statemachine.persist.StateMachineRuntimePersister;
+import org.springframework.statemachine.test.StateMachineTestPlan;
+import org.springframework.statemachine.test.StateMachineTestPlanBuilder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+
+/**
+ * Generic tests for skipper statemachine logic. In these tests we simply
+ * want to test machine logic meaning we control actions by using
+ * mocks for classes actions are using.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("unchecked")
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestConfig.class)
+@DirtiesContext
+public class StateMachineTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@MockBean
+	private StateMachineRuntimePersister<SkipperStates, SkipperEvents, String> stateMachineRuntimePersister;
+
+	@MockBean
+	private ReleaseManager releaseManager;
+
+	@MockBean
+	private PackageService packageService;
+
+	@MockBean
+	private ReleaseReportService releaseReportService;
+
+	@MockBean
+	private UpgradeStrategy upgradeStrategy;
+
+	@MockBean
+	private DeployAppStep deployAppStep;
+
+	@MockBean
+	private HealthCheckStep healthCheckStep;
+
+	@MockBean
+	private HandleHealthCheckStep handleHealthCheckStep;
+
+	@MockBean
+	private ReleaseService releaseService;
+
+	@MockBean
+	private ReleaseRepository releaseRepository;
+
+	@SpyBean
+	private UpgradeCancelAction upgradeCancelAction;
+
+	@SpyBean
+	private ErrorAction errorAction;
+
+	@Test
+	public void testFactory() {
+		StateMachineFactory<SkipperStates, SkipperEvents> factory = context.getBean(StateMachineFactory.class);
+		assertThat(factory).isNotNull();
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = factory.getStateMachine("testFactory");
+		assertThat(stateMachine).isNotNull();
+	}
+
+	@Test
+	public void testSimpleInstallShouldNotError() throws Exception {
+		Mockito.when(packageService.downloadPackage(any()))
+				.thenReturn(new org.springframework.cloud.skipper.domain.Package());
+		Mockito.when(releaseService.install(any(), any())).thenReturn(new Release());
+
+		Message<SkipperEvents> message = MessageBuilder
+			.withPayload(SkipperEvents.INSTALL)
+			.setHeader(SkipperEventHeaders.PACKAGE_METADATA, new PackageMetadata())
+			.setHeader(SkipperEventHeaders.INSTALL_PROPERTIES, new InstallProperties())
+			.setHeader(SkipperEventHeaders.VERSION, 1)
+			.build();
+
+		StateMachineFactory<SkipperStates, SkipperEvents> factory = context.getBean(StateMachineFactory.class);
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = factory.getStateMachine("testInstall");
+
+		StateMachineTestPlan<SkipperStates, SkipperEvents> plan =
+				StateMachineTestPlanBuilder.<SkipperStates, SkipperEvents>builder()
+					.defaultAwaitTime(10)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(SkipperStates.INITIAL)
+						.and()
+					.step()
+						.sendEvent(message)
+						.expectStates(SkipperStates.INITIAL)
+						.expectStateChanged(3)
+						.expectStateEntered(SkipperStates.INSTALL,
+								SkipperStates.INSTALL_INSTALL,
+								SkipperStates.INITIAL)
+						.and()
+					.build();
+		plan.test();
+
+		Mockito.verify(errorAction, never()).execute(any());
+	}
+
+	@Test
+	public void testSimpleUpgradeShouldNotError() throws Exception {
+		Mockito.when(releaseReportService.createReport(any())).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+				new ReleaseDifference(true), new Release(), new Release()));
+		Mockito.when(upgradeStrategy.checkStatus(any()))
+				.thenReturn(true);
+
+		UpgradeRequest upgradeRequest = new UpgradeRequest();
+
+		Message<SkipperEvents> message1 = MessageBuilder
+				.withPayload(SkipperEvents.UPGRADE)
+				.setHeader(SkipperEventHeaders.UPGRADE_REQUEST, upgradeRequest)
+				.build();
+
+		StateMachineFactory<SkipperStates, SkipperEvents> factory = context.getBean(StateMachineFactory.class);
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = factory.getStateMachine("testSimpleUpgradeShouldNotError");
+
+		StateMachineTestPlan<SkipperStates, SkipperEvents> plan =
+				StateMachineTestPlanBuilder.<SkipperStates, SkipperEvents>builder()
+					.defaultAwaitTime(10)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(SkipperStates.INITIAL)
+						.and()
+					.step()
+						.sendEvent(message1)
+						.expectStates(SkipperStates.INITIAL)
+						.expectStateChanged(9)
+						.and()
+					.build();
+		plan.test();
+		Mockito.verify(upgradeCancelAction, never()).execute(any());
+		Mockito.verify(errorAction, never()).execute(any());
+	}
+
+	@Test
+	public void testUpgradeFailsNewAppFailToDeploy() throws Exception {
+		Mockito.when(releaseReportService.createReport(any())).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+				new ReleaseDifference(true), new Release(), new Release()));
+		Mockito.when(upgradeStrategy.checkStatus(any()))
+				.thenReturn(false);
+
+		UpgradeRequest upgradeRequest = new UpgradeRequest();
+
+		// timeout 0 for things to fail immediately
+		Message<SkipperEvents> message1 = MessageBuilder
+				.withPayload(SkipperEvents.UPGRADE)
+				.setHeader(SkipperEventHeaders.UPGRADE_REQUEST, upgradeRequest)
+				.setHeader(SkipperEventHeaders.UPGRADE_TIMEOUT, 0L)
+				.build();
+
+		StateMachineFactory<SkipperStates, SkipperEvents> factory = context.getBean(StateMachineFactory.class);
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = factory.getStateMachine("testUpgradeFailsNewAppFailToDeploy");
+
+		StateMachineTestPlan<SkipperStates, SkipperEvents> plan =
+				StateMachineTestPlanBuilder.<SkipperStates, SkipperEvents>builder()
+					.defaultAwaitTime(10)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(SkipperStates.INITIAL)
+						.and()
+					.step()
+						.sendEvent(message1)
+						.expectStates(SkipperStates.INITIAL)
+						.expectStateChanged(9)
+						.expectStateEntered(SkipperStates.UPGRADE,
+								SkipperStates.UPGRADE_START,
+								SkipperStates.UPGRADE_DEPLOY_TARGET_APPS,
+								SkipperStates.UPGRADE_WAIT_TARGET_APPS,
+								SkipperStates.UPGRADE_CHECK_TARGET_APPS,
+								SkipperStates.UPGRADE_WAIT_TARGET_APPS,
+								SkipperStates.UPGRADE_DEPLOY_TARGET_APPS_FAILED,
+								SkipperStates.UPGRADE_CANCEL,
+								SkipperStates.INITIAL)
+						.and()
+					.build();
+		plan.test();
+
+		Mockito.verify(upgradeCancelAction).execute(any());
+		Mockito.verify(errorAction, never()).execute(any());
+	}
+
+	@Test
+	public void testUpgradeCancelWhileCheckingApps() throws Exception {
+		Mockito.when(releaseReportService.createReport(any())).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+				new ReleaseDifference(true), new Release(), new Release()));
+		Mockito.when(upgradeStrategy.checkStatus(any()))
+				.thenReturn(false);
+
+		UpgradeRequest upgradeRequest = new UpgradeRequest();
+
+		// timeout 60s giving time to try cancel
+		Message<SkipperEvents> message1 = MessageBuilder
+				.withPayload(SkipperEvents.UPGRADE)
+				.setHeader(SkipperEventHeaders.UPGRADE_REQUEST, upgradeRequest)
+				.setHeader(SkipperEventHeaders.UPGRADE_TIMEOUT, 60000L)
+				.build();
+
+		Message<SkipperEvents> message2 = MessageBuilder
+				.withPayload(SkipperEvents.UPGRADE_CANCEL)
+				.build();
+
+		StateMachineFactory<SkipperStates, SkipperEvents> factory = context.getBean(StateMachineFactory.class);
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = factory.getStateMachine("testUpgradeCancelWhileCheckingApps");
+
+		StateMachineTestPlan<SkipperStates, SkipperEvents> plan =
+				StateMachineTestPlanBuilder.<SkipperStates, SkipperEvents>builder()
+					.defaultAwaitTime(10)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(SkipperStates.INITIAL)
+						.and()
+					.step()
+						.sendEvent(message1)
+						.expectStateChanged(4)
+						.expectStateEntered(SkipperStates.UPGRADE,
+								SkipperStates.UPGRADE_START,
+								SkipperStates.UPGRADE_DEPLOY_TARGET_APPS,
+								SkipperStates.UPGRADE_WAIT_TARGET_APPS)
+						.and()
+					.step()
+						.sendEvent(message2)
+						.expectStateChanged(2)
+						.expectStateEntered(SkipperStates.UPGRADE_CANCEL,
+								SkipperStates.INITIAL)
+						.and()
+					.build();
+		plan.test();
+
+		Mockito.verify(upgradeCancelAction).execute(any());
+		Mockito.verify(errorAction, never()).execute(any());
+	}
+
+	@Test
+	public void testRollbackInstall() throws Exception {
+		Release release = new Release();
+		Status status = new Status();
+		status.setStatusCode(StatusCode.DELETED);
+		Info info = Info.createNewInfo("xxx");
+		info.setStatus(status);
+		release.setInfo(info);
+		Mockito.when(releaseRepository.findLatestReleaseForUpdate(any())).thenReturn(release);
+		Mockito.when(releaseRepository.findReleaseToRollback(any())).thenReturn(release);
+		Mockito.when(releaseService.install(any(Release.class))).thenReturn(release);
+
+
+		Message<SkipperEvents> message1 = MessageBuilder
+				.withPayload(SkipperEvents.ROLLBACK)
+				.setHeader(SkipperEventHeaders.RELEASE_NAME, "testRollbackInstall")
+				.setHeader(SkipperEventHeaders.ROLLBACK_VERSION, 0)
+				.build();
+
+		StateMachineFactory<SkipperStates, SkipperEvents> factory = context.getBean(StateMachineFactory.class);
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = factory.getStateMachine("testRollbackInstall");
+
+		StateMachineTestPlan<SkipperStates, SkipperEvents> plan =
+				StateMachineTestPlanBuilder.<SkipperStates, SkipperEvents>builder()
+					.defaultAwaitTime(10)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(SkipperStates.INITIAL)
+						.and()
+					.step()
+						.sendEvent(message1)
+						.expectStates(SkipperStates.INITIAL)
+						.expectStateChanged(5)
+						.expectStateEntered(SkipperStates.ROLLBACK,
+								SkipperStates.ROLLBACK_START,
+								SkipperStates.INSTALL,
+								SkipperStates.INSTALL_INSTALL,
+								SkipperStates.INITIAL)
+						.and()
+					.build();
+		plan.test();
+
+		Mockito.verify(errorAction, never()).execute(any());
+	}
+
+	@Test
+	public void testInstallDeniedWhileUpgrading() throws Exception {
+		Mockito.when(releaseReportService.createReport(any())).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+				new ReleaseDifference(true), new Release(), new Release()));
+		Mockito.when(upgradeStrategy.checkStatus(any()))
+				.thenReturn(false);
+
+		UpgradeRequest upgradeRequest = new UpgradeRequest();
+
+		Message<SkipperEvents> message1 = MessageBuilder
+				.withPayload(SkipperEvents.UPGRADE)
+				.setHeader(SkipperEventHeaders.UPGRADE_REQUEST, upgradeRequest)
+				.build();
+
+		Message<SkipperEvents> message2 = MessageBuilder
+				.withPayload(SkipperEvents.INSTALL)
+				.setHeader(SkipperEventHeaders.PACKAGE_METADATA, new PackageMetadata())
+				.setHeader(SkipperEventHeaders.INSTALL_PROPERTIES, new InstallProperties())
+				.setHeader(SkipperEventHeaders.VERSION, 1)
+				.build();
+
+		StateMachineFactory<SkipperStates, SkipperEvents> factory = context.getBean(StateMachineFactory.class);
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = factory.getStateMachine("testInstallDeniedWhileUpgrading");
+
+		StateMachineTestPlan<SkipperStates, SkipperEvents> plan =
+				StateMachineTestPlanBuilder.<SkipperStates, SkipperEvents>builder()
+					.defaultAwaitTime(10)
+					.stateMachine(stateMachine)
+					.step()
+						.expectStateMachineStarted(1)
+						.expectStates(SkipperStates.INITIAL)
+						.and()
+					.step()
+						.sendEvent(message1)
+						.expectStateChanged(6)
+						.and()
+					.build();
+		plan.test();
+
+		// install event is not accepted
+		boolean accepted = stateMachine.sendEvent(message2);
+		assertThat(accepted).isFalse();
+	}
+
+	@Import(StateMachineConfiguration.class)
+	static class TestConfig {
+
+		@Bean
+		public TaskExecutor skipperStateMachineTaskExecutor() {
+			ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+			executor.setCorePoolSize(1);
+			return executor;
+		}
+
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/templates/PackageTemplateTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/templates/PackageTemplateTests.java
@@ -38,6 +38,7 @@ import org.springframework.cloud.skipper.server.templates.PackageTemplateTests.T
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
+import org.springframework.statemachine.boot.autoconfigure.StateMachineJpaRepositoriesAutoConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StreamUtils;
 
@@ -85,7 +86,7 @@ public class PackageTemplateTests {
 
 	@Configuration
 	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
-			HibernateJpaAutoConfiguration.class })
+			HibernateJpaAutoConfiguration.class, StateMachineJpaRepositoriesAutoConfiguration.class })
 	@Import(SkipperServerConfiguration.class)
 	static class TestConfig {
 	}


### PR DESCRIPTION
- Uses 1.2.8 snapshot as some enhacement were required
  around persistense and utility classes.
- Machine design as presented in a ticket #234
- Minimal changes outside of new machine classes.
- Machine is only called from SkipperController which
  delegates to SkipperStateMachineService hiding low level
  logic.
- UpgradeStrategy still has its old method `upgrade` which
  has been split to four doing same upgrade, but in steps
  order for machine have better control over upgrade logic.
  Old `upgrade` method and its use(might still be used in tests)
  is removed later and it causes quite a bit of changes.
- Machine is executed in its own thread pool, thus machine logic
  is asynchronous. Blocking happens in SkipperController as
  `Release` is returned to caller.
- Fixes #234