### PR TITLE
Rename client RestTemplate bean

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientConfiguration.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientConfiguration.java
@@ -37,8 +37,13 @@ import org.springframework.web.client.RestTemplate;
 @EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
 public class SkipperClientConfiguration {
 
-	@Bean
-	public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
+	/**
+	 * Default bean name for {@link RestTemplate} created by {@code SkipperClientConfiguration}.
+	 */
+	public final static String SKIPPERCLIENT_RESTTEMPLATE_BEAN_NAME = "skipperClientRestTemplate";
+
+	@Bean(name = SKIPPERCLIENT_RESTTEMPLATE_BEAN_NAME)
+	public RestTemplate skipperClientRestTemplate(RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
 		RestTemplate restTemplate = restTemplateBuilder
 				.errorHandler(new SkipperClientResponseErrorHandler(objectMapper)).build();
 		return validateRestTemplate(restTemplate);

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/SkipperClientConfigurationTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/SkipperClientConfigurationTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebClientAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.skipper.client.SkipperClientConfigurationTests.TestConfig;
+
+/**
+ * Tests for {@link SkipperClientConfiguration}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfig.class)
+public class SkipperClientConfigurationTests {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Test
+	public void testDefaultRestTemplateBeanName() {
+		assertThat(context.containsBean(SkipperClientConfiguration.SKIPPERCLIENT_RESTTEMPLATE_BEAN_NAME)).isTrue();
+	}
+
+	@Configuration
+	@ImportAutoConfiguration(classes = { WebClientAutoConfiguration.class, SkipperClientConfiguration.class })
+	static class TestConfig {
+	}
+}


### PR DESCRIPTION
- Rename skipper client default RestTemplate from `restTemplate`
  to `skipperClientRestTemplate`. This migitates risks that
  any other config magic accidentally overrides the one
  we expect.
- Fixes #308