### PR TITLE
Implement better help command feature

### DIFF
--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/InitializeConnectionApplicationRunner.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/InitializeConnectionApplicationRunner.java
@@ -53,6 +53,13 @@ public class InitializeConnectionApplicationRunner implements ApplicationRunner 
 
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
+		// user just wants to print help, do not try
+		// to init connection. HelpAwareShellApplicationRunner simply output
+		// usage and InteractiveModeApplicationRunner forces to run help.
+		if (ShellUtils.hasHelpOption(args)) {
+			return;
+		}
+
 		Target target = new Target(skipperClientProperties.getUri(), skipperClientProperties.getUsername(),
 				skipperClientProperties.getPassword(), skipperClientProperties.isSkipSslValidation());
 

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/InteractiveModeApplicationRunner.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/InteractiveModeApplicationRunner.java
@@ -90,6 +90,12 @@ public class InteractiveModeApplicationRunner implements ApplicationRunner {
 			}
 		}
 		if (argsToShellCommand.size() > 0) {
+			if (ShellUtils.hasHelpOption(args)) {
+				// going into 'help' mode. HelpAwareShellApplicationRunner already
+				// printed usage, we just force running just help.
+				argsToShellCommand.clear();
+				argsToShellCommand.add("help");
+			}
 			CommandInputProvider inputProvider = new CommandInputProvider(
 					StringUtils.collectionToDelimitedString(argsToShellCommand, " "));
 			shell.run(inputProvider);

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/ShellUtils.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/ShellUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.shell.command.support;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.boot.ApplicationArguments;
+
+/**
+ * Various utility functions for a skipper shell.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class ShellUtils {
+
+	private final static List<String> helpArgs = Arrays.asList("-h", "-help", "--help", "help");
+
+	/**
+	 * Checks if given application arguments contains any usual help option.
+	 *
+	 * @param args the application arguments
+	 * @return true if arguments contain common help option
+	 */
+	public static boolean hasHelpOption(ApplicationArguments args) {
+		return !Collections.disjoint(helpArgs, args.getNonOptionArgs()) || !Collections.disjoint(helpArgs, args.getOptionNames());
+	}
+}

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/config/HelpAwareShellApplicationRunner.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/config/HelpAwareShellApplicationRunner.java
@@ -22,6 +22,7 @@ import java.io.Reader;
 
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.cloud.skipper.shell.command.support.ShellUtils;
 import org.springframework.core.annotation.Order;
 import org.springframework.shell.jline.DefaultShellApplicationRunner;
 import org.springframework.util.Assert;
@@ -41,7 +42,7 @@ public class HelpAwareShellApplicationRunner implements ApplicationRunner {
 
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
-		if (args.containsOption("help")) {
+		if (ShellUtils.hasHelpOption(args)) {
 			String usageInstructions;
 
 			final Reader reader = new InputStreamReader(getInputStream(HelpAwareShellApplicationRunner.class, "/usage.txt"));
@@ -54,7 +55,6 @@ public class HelpAwareShellApplicationRunner implements ApplicationRunner {
 				throw new IllegalStateException("Cannot read stream", ex);
 			}
 			System.out.println(usageInstructions);
-			System.exit(0);
 		}
 	}
 


### PR DESCRIPTION
- Tweak all ApplicationRunner's to understand that when user wants
  to print help, we get same output with various options like
  -h, -help, --help, help.
- Also change connection init so that if help is requests, we
  don't try to connect to a server by changing target. This
  removes error if shell is just about to print help.
- We print static usage text and actual shell help command.
- All these happen if commands are run within OS shell,
  there's no changes when actual shell instance is launched.
- Didn't add tests as we're still figuring out how proper
  e2e tests should get handled.
- Fixes #369 

With these:
```
java -jar spring-cloud-skipper-shell/target/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar help
java -jar spring-cloud-skipper-shell/target/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar -h
java -jar spring-cloud-skipper-shell/target/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar -help
java -jar spring-cloud-skipper-shell/target/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar --help
```
You'd always get usage and help.

```
Skipper Options:

  --spring.cloud.skipper.client.uri=<uri>                        Address of the Skipper Server [default: http://localhost:7577].
  --spring.cloud.skipper.client.username=<USER>                        Username of the Skipper Server [no default].
  --spring.cloud.skipper.client.password=<PASSWORD>                    Password of the Skipper Server [no default].
  --spring.cloud.skipper.client.credentials-provider-command=<COMMAND> Executes an external command which must return an OAuth Access Token [no default].
  --spring.cloud.skipper.client.skip-ssl-validation=<true|false>       Accept any SSL certificate (even self-signed) [default: no].

  --spring.shell.historySize=<SIZE>                 Default size of the shell log file [default: 3000].
  --spring.shell.commandFile=<FILE>                 Skipper Shell executes commands read from the file(s) and then exits.

  --help                                            This message.

AVAILABLE COMMANDS

Built-In Commands
        clear: Clear the shell screen.
        exit, quit: Exit the shell.
        help: Display help about available commands.
        script: Read and execute commands from a file.
        stacktrace: Display the full stacktrace of the last error.

Config Commands
        config: Configure the Spring Cloud Skipper REST server to use.
        info: Show the Skipper server being used.

Manifest Commands
        manifest get: Get the manifest for a release

Platform Commands
        platform list: List platforms

Repository Commands
        repo add: Add package repository
        repo delete: Delete a package repository
        repo list: List package repositories

Skipper Commands
        delete: Delete the release.
        history: List the history of versions for a given release.
        install: Install a package.
        list: List the latest version of releases with status of deployed or failed.
        rollback: Rollback the release to a previous or a specific release.
        search: Search for the packages.
        status: Status for a last known release version.
        upgrade: Upgrade a release.
        upload: Upload a package.
```
