### PR TITLE
Fix error handling in statemachine

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.statemachine.persist.StateMachineRuntimePersister;
 import org.springframework.statemachine.service.DefaultStateMachineService;
 import org.springframework.statemachine.service.StateMachineService;
 import org.springframework.statemachine.state.State;
+import org.springframework.statemachine.transition.TransitionConflightPolicy;
 
 /**
  * Statemachine(s) related configurations.
@@ -91,6 +92,7 @@ public class StateMachineConfiguration {
 							log.info("Entering state {}", state);
 						}
 					})
+					.transitionConflightPolicy(TransitionConflightPolicy.PARENT)
 				.and()
 				.withPersistence()
 					.runtimePersister(stateMachineRuntimePersister);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -118,10 +118,8 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 			fail("Expected to throw SkipperException");
 		}
 		catch (SkipperException e) {
-			assertThat(e.getMessage()).isEqualTo("ReleaseAnalysis report is null");
-			//TODO get the right exception thrown from the state machine
-			//assertThat(e.getMessage()).isEqualTo(String.format("Can not find package '%s', version '%s'",
-			//		packageName, packageVersion));
+			assertThat(e.getMessage()).isEqualTo(String.format("Can not find package '%s', version '%s'",
+					packageName, packageVersion));
 		}
 
 		delete(release.getName());


### PR DESCRIPTION
- Now using new TransitionConflightPolicy which allows
  to define if parent or child transition is choses if those
  two conflicts. Root issue is now fixed in statemachine
  snapshots which also caused some random behavioral changes
  when threads were used.
- Changed assert in test to what is now always expected.
- Fixes #378