### PR TITLE
Add metadata properties.

### DIFF
--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -75,6 +75,7 @@ public class DeleteDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.displayName").description("Display name of the release"),
 								fieldWithPath("pkg.metadata.version").description("The version of the package"),
 								fieldWithPath("pkg.metadata.packageSourceUrl")
 										.description("Location to source code for this package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
@@ -60,25 +60,26 @@ public class HistoryDocumentation extends BaseDocumentation {
 										String.format("StatusCode of the release's status (%s)",
 												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
 								fieldWithPath("[].info.status.platformStatus")
-										.description("Status from the underlying platform"),
+								.description("Status from the underlying platform"),
 								fieldWithPath("[].info.firstDeployed").description("Date/Time of first deployment"),
 								fieldWithPath("[].info.lastDeployed").description("Date/Time of last deployment"),
 								fieldWithPath("[].info.deleted")
-										.description("Date/Time of when the release was deleted"),
+								.description("Date/Time of when the release was deleted"),
 								fieldWithPath("[].info.description")
-										.description("Human-friendly 'log entry' about this release"),
+								.description("Human-friendly 'log entry' about this release"),
 								fieldWithPath("[].pkg.metadata.apiVersion")
-										.description("The Package Index spec version this file is based on"),
+								.description("The Package Index spec version this file is based on"),
 								fieldWithPath("[].pkg.metadata.origin")
-										.description("Indicates the origin of the repository (free form text)"),
+								.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("[].pkg.metadata.repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+								.description("The repository ID this Package Index file belongs to"),
 								fieldWithPath("[].pkg.metadata.kind")
-										.description("What type of package system is being used"),
+								.description("What type of package system is being used"),
 								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("[].pkg.metadata.displayName").description("Display name of the release"),
 								fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
 								fieldWithPath("[].pkg.metadata.packageSourceUrl")
-										.description("Location to source code for this package"),
+								.description("Location to source code for this package"),
 								fieldWithPath("[].pkg.metadata.packageHomeUrl")
 										.description("The home page of the package"),
 								fieldWithPath("[].pkg.metadata.tags")

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
@@ -82,6 +82,7 @@ public class InstallDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.displayName").description("Display name of the release"),
 								fieldWithPath("pkg.metadata.version").description("The version of the package"),
 								fieldWithPath("pkg.metadata.packageSourceUrl")
 										.description("Location to source code for this package"),
@@ -158,6 +159,7 @@ public class InstallDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.displayName").description("Display name of the release"),
 								fieldWithPath("pkg.metadata.version").description("The version of the package"),
 								fieldWithPath("pkg.metadata.packageSourceUrl")
 										.description("Location to source code for this package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
@@ -78,6 +78,7 @@ public class ListDocumentation extends BaseDocumentation {
 								fieldWithPath("[].pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("[].pkg.metadata.displayName").description("Display name of the release"),
 								fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
 								fieldWithPath("[].pkg.metadata.packageSourceUrl")
 										.description("Location to source code for this package"),
@@ -148,6 +149,7 @@ public class ListDocumentation extends BaseDocumentation {
 								fieldWithPath("[].pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("[].pkg.metadata.displayName").description("Display name of the release"),
 								fieldWithPath("[].pkg.metadata.version").description("The version of the package"),
 								fieldWithPath("[].pkg.metadata.packageSourceUrl")
 										.description("Location to source code for this package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
@@ -57,6 +57,8 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 										.description("What type of package system is being used"),
 								fieldWithPath("_embedded.packageMetadata[].name")
 										.description("The name of the package"),
+								fieldWithPath("_embedded.packageMetadata[].displayName")
+										.description("Display name of the release"),
 								fieldWithPath("_embedded.packageMetadata[].version")
 										.description("The version of the package"),
 								fieldWithPath("_embedded.packageMetadata[].packageSourceUrl")
@@ -101,6 +103,7 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 										.description("The repository ID this Package Index file belongs to"),
 								fieldWithPath("kind").description("What type of package system is being used"),
 								fieldWithPath("name").description("The name of the package"),
+								fieldWithPath("displayName").description("The display name of the package"),
 								fieldWithPath("version").description("The version of the package"),
 								fieldWithPath("packageSourceUrl")
 										.description("Location to source code for this package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
@@ -78,6 +78,7 @@ public class RollbackDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.displayName").description("Display name of the release"),
 								fieldWithPath("pkg.metadata.version").description("The version of the package"),
 								fieldWithPath("pkg.metadata.packageSourceUrl")
 										.description("Location to source code for this package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
@@ -98,6 +98,7 @@ public class UpgradeDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.displayName").description("Display name of the release"),
 								fieldWithPath("pkg.metadata.version").description("The version of the package"),
 								fieldWithPath("pkg.metadata.packageSourceUrl")
 										.description("Location to source code for this package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UploadDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UploadDocumentation.java
@@ -84,6 +84,7 @@ public class UploadDocumentation extends BaseDocumentation {
 												.description("The repository ID this Package Index file belongs to"),
 										fieldWithPath("kind").description("What type of package system is being used"),
 										fieldWithPath("name").description("The name of the package"),
+										fieldWithPath("displayName").description("The display name of the package"),
 										fieldWithPath("version").description("The version of the package"),
 										fieldWithPath("packageSourceUrl")
 												.description("Location to source code for this package"),

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -62,6 +62,11 @@ public class PackageMetadata extends AbstractEntity {
 	private String name;
 
 	/**
+	 * The display name of the package
+	 */
+	private String displayName;
+
+	/**
 	 * The version of the package
 	 */
 	@NotNull
@@ -143,6 +148,14 @@ public class PackageMetadata extends AbstractEntity {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	public void setDisplayName(String displayName) {
+		this.displayName = displayName;
 	}
 
 	public String getVersion() {

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationSpec.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationSpec.java
@@ -33,6 +33,8 @@ public class SpringCloudDeployerApplicationSpec {
 
 	private String resource;
 
+	private String resourceMetadata;
+
 	private String version;
 
 	private Map<String, String> applicationProperties;
@@ -48,6 +50,14 @@ public class SpringCloudDeployerApplicationSpec {
 
 	public void setResource(String resource) {
 		this.resource = resource;
+	}
+
+	public String getResourceMetadata() {
+		return resourceMetadata;
+	}
+
+	public void setResourceMetadata(String resourceMetadata) {
+		this.resourceMetadata = resourceMetadata;
 	}
 
 	public String getVersion() {


### PR DESCRIPTION
* PackageMetadata#displayName for more readable package name
* SpringCloudDeployerApplicationSpec#resourceMetadata metadata resource for resolving application properties

Related to #389, these additional properties were required in context of this [blog post](https://blog.switchbit.io/spring-cloud-skipper-as-a-service-broker/). Creating this PR for in case it adds value to the core project, feel free to decline if not needed. 

Usage for `displayName` [here](https://github.com/donovanmuller/spring-cloud-skipper/commit/797373ee33ea7f949a9decf972a777ce79984268#diff-c7743b5898f6cede4c672fed9783927aR212) and `resourceMetadata ` [here](https://github.com/donovanmuller/spring-cloud-skipper/commit/797373ee33ea7f949a9decf972a777ce79984268#diff-c7743b5898f6cede4c672fed9783927aR190).

