### PR TITLE
gh-395 Fix sequence-based id generator deprecation warnings

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -17,6 +17,8 @@ spring:
       base-path: /api
   jpa:
     generate-ddl: true
+    properties:
+      hibernate.id.new_generator_mappings: true
   cloud:
     skipper:
       server:


### PR DESCRIPTION
Add `spring.jpa.properties.hibernate.id.new_generator_mappings=true` to `application.yml`

resolves https://github.com/spring-cloud/spring-cloud-skipper/issues/395