### PR TITLE
Add new properties to yaml converter

### DIFF
--- a/spring-cloud-skipper-client/pom.xml
+++ b/spring-cloud-skipper-client/pom.xml
@@ -47,11 +47,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.codearte.props2yaml</groupId>
-            <artifactId>props2yaml</artifactId>
-            <version>0.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>

--- a/spring-cloud-skipper-shell-commands/pom.xml
+++ b/spring-cloud-skipper-shell-commands/pom.xml
@@ -43,11 +43,6 @@
             <version>2.5</version>
         </dependency>
         <dependency>
-            <groupId>io.codearte.props2yaml</groupId>
-            <artifactId>props2yaml</artifactId>
-            <version>0.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.18</version>

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/YmlUtils.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/support/YmlUtils.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.skipper.shell.command.support;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 
 import org.yaml.snakeyaml.Yaml;
 
@@ -37,12 +36,7 @@ import org.springframework.util.StringUtils;
  */
 public abstract class YmlUtils {
 
-	public static String convertFromCsvToYaml(String propertiesAsString) {
-		return YamlConverter.builder().mode(Mode.FLATTEN).map(DeploymentPropertiesUtils.parse(propertiesAsString))
-				.build().convert().getYaml();
-	}
-
-	public static String getYamlConfigValues(File yamlFile, String propertiesAsCsvString) throws IOException {
+	public static String getYamlConfigValues(File yamlFile, String properties) {
 		String configValuesYML = null;
 		if (yamlFile != null) {
 			Yaml yaml = new Yaml();
@@ -54,18 +48,20 @@ public abstract class YmlUtils {
 				throw new SkipperException("Could not find file " + yamlFile.toString());
 			}
 		}
-		else if (StringUtils.hasText(propertiesAsCsvString)) {
-			configValuesYML = convertToYaml(propertiesAsCsvString);
+		else if (StringUtils.hasText(properties)) {
+			configValuesYML = convertToYaml(properties);
 		}
 		return configValuesYML;
 	}
 
-	private static String convertToYaml(String propertiesAsCsvString) {
+	private static String convertToYaml(String properties) {
 		return YamlConverter.builder()
 				.mode(Mode.FLATTEN)
 				.flat("spec.applicationProperties")
 				.flat("spec.deploymentProperties")
-				.map(DeploymentPropertiesUtils.parse(propertiesAsCsvString)).build()
+				.flat("\\w+\\.spec\\.applicationProperties")
+				.flat("\\w+\\.spec\\.deploymentProperties")
+				.map(DeploymentPropertiesUtils.parse(properties)).build()
 				.convert().getYaml();
 	}
 }

--- a/spring-cloud-skipper-shell-commands/src/test/java/org/springframework/cloud/skipper/shell/command/support/YmlUtilsTests.java
+++ b/spring-cloud-skipper-shell-commands/src/test/java/org/springframework/cloud/skipper/shell/command/support/YmlUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,8 @@
 package org.springframework.cloud.skipper.shell.command.support;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 
 import org.junit.Test;
-
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.util.StreamUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,29 +35,27 @@ public class YmlUtilsTests {
 	}
 
 	@Test
-	public void testBasicContent() throws IOException {
-		Resource resource = new ClassPathResource(
-				"/org/springframework/cloud/skipper/shell/command/support/log4j.properties");
-		String stringToConvert = StreamUtils.copyToString(resource.getInputStream(), Charset.defaultCharset());
-		String yml = YmlUtils.convertFromCsvToYaml(stringToConvert);
-		Resource convertedYmlResource = new ClassPathResource(
-				"/org/springframework/cloud/skipper/shell/command/support/log4j.yml");
-		assertThat(yml).isEqualTo(StreamUtils.copyToString(convertedYmlResource.getInputStream(),
-				Charset.defaultCharset()));
-	}
-
-	@Test
 	public void testPropertiesParsingWithPackageDeps() throws IOException {
 		String properties = "log.spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=mlp3-helloworld.cfapps.io,"
 				+ "time.spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=mlp1-helloworld.cfapps.io";
-		String propertiesYml = YmlUtils.getYamlConfigValues(null, properties);
+		String propertiesYml = YmlUtils.convertFromCsvToYaml(properties);
 		assertThat(propertiesYml).isEqualTo(
 				"log:\n"
 						+ "  spec:\n"
-						+ "    deploymentProperties: {spring.cloud.deployer.cloudfoundry.route: mlp3-helloworld.cfapps.io}\n"
+						+ "    deploymentProperties:\n"
+						+ "      spring:\n"
+						+ "        cloud:\n"
+						+ "          deployer:\n"
+						+ "            cloudfoundry:\n"
+						+ "              route: mlp3-helloworld.cfapps.io\n"
 						+ "time:\n"
 						+ "  spec:\n"
-						+ "    deploymentProperties: {spring.cloud.deployer.cloudfoundry.route: mlp1-helloworld.cfapps.io}\n");
+						+ "    deploymentProperties:\n"
+						+ "      spring:\n"
+						+ "        cloud:\n"
+						+ "          deployer:\n"
+						+ "            cloudfoundry:\n"
+						+ "              route: mlp1-helloworld.cfapps.io\n");
 	}
 
 	@Test
@@ -70,14 +63,15 @@ public class YmlUtilsTests {
 		String properties = "spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=mlp3-helloworld.cfapps.io";
 		String propertiesYml = YmlUtils.getYamlConfigValues(null, properties);
 		assertThat(propertiesYml).isEqualTo("spec:\n"
-				+ "  deploymentProperties: {spring.cloud.deployer.cloudfoundry.route: mlp3-helloworld.cfapps.io}\n");
+				+ "  deploymentProperties:\n"
+				+ "    spring.cloud.deployer.cloudfoundry.route: mlp3-helloworld.cfapps.io\n");
 	}
 
 	@Test
 	public void testLogVersion() throws IOException {
 		String properties = "log.version=1.1.1.RELEASE";
 		String propertiesYml = YmlUtils.getYamlConfigValues(null, properties);
-		assertThat(propertiesYml).isEqualTo("log: {version: 1.1.1.RELEASE}\n");
+		assertThat(propertiesYml).isEqualTo("log:\n  version: 1.1.1.RELEASE\n");
 	}
 
 }

--- a/spring-cloud-skipper-shell-commands/src/test/java/org/springframework/cloud/skipper/shell/command/support/YmlUtilsTests.java
+++ b/spring-cloud-skipper-shell-commands/src/test/java/org/springframework/cloud/skipper/shell/command/support/YmlUtilsTests.java
@@ -30,7 +30,7 @@ public class YmlUtilsTests {
 	@Test
 	public void testSimpleConversion() {
 		String stringToConvert = "hello=oi,world=mundo";
-		String yml = YmlUtils.convertFromCsvToYaml(stringToConvert);
+		String yml = YmlUtils.getYamlConfigValues(null, stringToConvert);
 		assertThat(yml).isEqualTo("hello: oi\nworld: mundo\n");
 	}
 
@@ -38,24 +38,16 @@ public class YmlUtilsTests {
 	public void testPropertiesParsingWithPackageDeps() throws IOException {
 		String properties = "log.spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=mlp3-helloworld.cfapps.io,"
 				+ "time.spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=mlp1-helloworld.cfapps.io";
-		String propertiesYml = YmlUtils.convertFromCsvToYaml(properties);
+		String propertiesYml = YmlUtils.getYamlConfigValues(null, properties);
 		assertThat(propertiesYml).isEqualTo(
 				"log:\n"
 						+ "  spec:\n"
 						+ "    deploymentProperties:\n"
-						+ "      spring:\n"
-						+ "        cloud:\n"
-						+ "          deployer:\n"
-						+ "            cloudfoundry:\n"
-						+ "              route: mlp3-helloworld.cfapps.io\n"
+						+ "      spring.cloud.deployer.cloudfoundry.route: mlp3-helloworld.cfapps.io\n"
 						+ "time:\n"
 						+ "  spec:\n"
 						+ "    deploymentProperties:\n"
-						+ "      spring:\n"
-						+ "        cloud:\n"
-						+ "          deployer:\n"
-						+ "            cloudfoundry:\n"
-						+ "              route: mlp1-helloworld.cfapps.io\n");
+						+ "      spring.cloud.deployer.cloudfoundry.route: mlp1-helloworld.cfapps.io\n");
 	}
 
 	@Test

--- a/spring-cloud-skipper-shell-commands/src/test/resources/org/springframework/cloud/skipper/shell/command/support/log4j.yml
+++ b/spring-cloud-skipper-shell-commands/src/test/resources/org/springframework/cloud/skipper/shell/command/support/log4j.yml
@@ -8,5 +8,4 @@ log4j:
         org:
             hibernate: DEBUG
             hibernate.type: ALL
-    rootLogger: INFO
-stdout: ''
+    rootLogger: INFO, stdout

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/DeploymentPropertiesUtils.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/DeploymentPropertiesUtils.java
@@ -48,9 +48,8 @@ public final class DeploymentPropertiesUtils {
 
 	/**
 	 * Parses a String comprised of 0 or more comma-delimited key=value pairs where each key
-	 * has the format: {@code app.[appname].[key]} or {@code deployer.[appname].[key]}. Values
-	 * may themselves contain commas, since the split points will be based upon the key
-	 * pattern.
+	 * has the properties format(strings and dots). Values may themselves contain commas, since
+	 * the split points will be based upon the key pattern.
 	 * <p>
 	 * Logic of parsing key/value pairs from a string is based on few rules and assumptions 1.
 	 * keys will not have commas or equals. 2. First raw split is done by commas which will

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/DeploymentPropertiesUtils.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/DeploymentPropertiesUtils.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Provides utility methods for formatting and parsing deployment properties.
+ *
+ * @author Eric Bottard
+ * @author Mark Fisher
+ * @author Janne Valkealahti
+ */
+public final class DeploymentPropertiesUtils {
+
+	/**
+	 * Pattern used for parsing a String of command-line arguments.
+	 */
+	private static final Pattern DEPLOYMENT_PARAMS_PATTERN = Pattern
+			.compile("(\\s(?=" + "([^\\\"']*[\\\"'][^\\\"']*[\\\"'])*[^\\\"']*$))");
+
+	private DeploymentPropertiesUtils() {
+		// prevent instantiation
+	}
+
+	/**
+	 * Parses a String comprised of 0 or more comma-delimited key=value pairs where each key
+	 * has the format: {@code app.[appname].[key]} or {@code deployer.[appname].[key]}. Values
+	 * may themselves contain commas, since the split points will be based upon the key
+	 * pattern.
+	 * <p>
+	 * Logic of parsing key/value pairs from a string is based on few rules and assumptions 1.
+	 * keys will not have commas or equals. 2. First raw split is done by commas which will
+	 * need to be fixed later if value is a comma-delimited list.
+	 *
+	 * @param s the string to parse
+	 * @return the Map of parsed key value pairs
+	 */
+	public static Map<String, String> parse(String s) {
+		Map<String, String> deploymentProperties = new HashMap<String, String>();
+		ArrayList<String> pairs = new ArrayList<>();
+
+		// get raw candidates as simple comma split
+		String[] candidates = StringUtils.commaDelimitedListToStringArray(s);
+		for (int i = 0; i < candidates.length; i++) {
+			if (i > 0 && !candidates[i].contains("=")) {
+				// we don't have '=' so this has to be latter parts of
+				// a comma delimited value, append it to previously added
+				// key/value pair.
+				// we skip first as we would not have anything to append to. this
+				// would happen if dep prop string is malformed and first given
+				// key/value pair is not actually a key/value.
+				pairs.set(pairs.size() - 1, pairs.get(pairs.size() - 1) + "," + candidates[i]);
+			}
+			else {
+				// we have a key/value pair having '=', or malformed first pair
+				pairs.add(candidates[i]);
+			}
+		}
+
+		// add what we got, addKeyValuePairAsProperty
+		// handles rest as trimming, etc
+		for (String pair : pairs) {
+			addKeyValuePairAsProperty(pair, deploymentProperties);
+		}
+		return deploymentProperties;
+	}
+
+	/**
+	 * Returns a String representation of deployment properties as a comma separated list of
+	 * key=value pairs.
+	 *
+	 * @param properties the properties to format
+	 * @return the properties formatted as a String
+	 */
+	public static String format(Map<String, String> properties) {
+		StringBuilder sb = new StringBuilder(15 * properties.size());
+		for (Map.Entry<String, String> pair : properties.entrySet()) {
+			if (sb.length() > 0) {
+				sb.append(",");
+			}
+			sb.append(pair.getKey()).append("=").append(pair.getValue());
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Convert Properties to a Map with String keys and String values.
+	 *
+	 * @param properties the properties object
+	 * @return the equivalent {@code Map<String,String>}
+	 */
+	public static Map<String, String> convert(Properties properties) {
+		Map<String, String> result = new HashMap<>(properties.size());
+		for (Enumeration<?> e = properties.propertyNames(); e.hasMoreElements();) {
+			String key = (String) e.nextElement();
+			result.put(key, properties.getProperty(key));
+		}
+		return result;
+	}
+
+	/**
+	 * Adds a String of format key=value to the provided Map as a key/value pair.
+	 *
+	 * @param pair the String representation
+	 * @param properties the Map to which the key/value pair should be added
+	 */
+	private static void addKeyValuePairAsProperty(String pair, Map<String, String> properties) {
+		int firstEquals = pair.indexOf('=');
+		if (firstEquals != -1) {
+			// todo: should key only be a "flag" as in: put(key, true)?
+			properties.put(pair.substring(0, firstEquals).trim(), pair.substring(firstEquals + 1).trim());
+		}
+	}
+
+	/**
+	 * Parses a list of command line parameters and returns a list of parameters which doesn't
+	 * contain any special quoting either for values or whole parameter.
+	 *
+	 * @param params the params
+	 * @return the list
+	 */
+	public static List<String> parseParams(List<String> params) {
+		List<String> paramsToUse = new ArrayList<>();
+		if (params != null) {
+			for (String param : params) {
+				Matcher regexMatcher = DEPLOYMENT_PARAMS_PATTERN.matcher(param);
+				int start = 0;
+				while (regexMatcher.find()) {
+					String p = removeQuoting(param.substring(start, regexMatcher.start()).trim());
+					if (StringUtils.hasText(p)) {
+						paramsToUse.add(p);
+					}
+					start = regexMatcher.start();
+				}
+				if (param != null && param.length() > 0) {
+					String p = removeQuoting(param.substring(start, param.length()).trim());
+					if (StringUtils.hasText(p)) {
+						paramsToUse.add(p);
+					}
+				}
+			}
+		}
+		return paramsToUse;
+	}
+
+	private static String removeQuoting(String param) {
+		param = removeQuote(param, '\'');
+		param = removeQuote(param, '"');
+		if (StringUtils.hasText(param)) {
+			String[] split = param.split("=", 2);
+			if (split.length == 2) {
+				String value = removeQuote(split[1], '\'');
+				value = removeQuote(value, '"');
+				param = split[0] + "=" + value;
+			}
+		}
+		return param;
+	}
+
+	private static String removeQuote(String param, char c) {
+		if (param != null && param.length() > 1) {
+			if (param.charAt(0) == c && param.charAt(param.length() - 1) == c) {
+				param = param.substring(1, param.length() - 1);
+			}
+		}
+		return param;
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/DefaultYamlConverter.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/DefaultYamlConverter.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support.yaml;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Default implementation of a {@link YamlConverter}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultYamlConverter implements YamlConverter {
+
+	private static final Pattern COMMENT = Pattern.compile("(?m)^\\s*(\\#|\\!)");
+	private final YamlConversionStatus status = new YamlConversionStatus();
+	private final Mode mode;
+	private final ArrayList<Map<String, String>> mapList;
+	private final ArrayList<Properties> propertiesList;
+	private final ArrayList<File> fileList;
+	private final ArrayList<String> keyspaceList;
+
+	/**
+	 * Instantiates a new default yaml converter.
+	 *
+	 * @param mapList the map list
+	 * @param propertiesList the properties list
+	 * @param fileList the file list
+	 * @param keyspaceList the keyspace list
+	 */
+	public DefaultYamlConverter(Mode mode, ArrayList<Map<String, String>> mapList, ArrayList<Properties> propertiesList,
+			ArrayList<File> fileList, ArrayList<String> keyspaceList) {
+		this.mode = mode != null ? mode : Mode.DEFAULT;
+		this.propertiesList = propertiesList;
+		this.mapList = mapList;
+		this.fileList = fileList;
+		this.keyspaceList = keyspaceList;
+	}
+
+	@Override
+	public YamlConversionResult convert() {
+		Map<String, Collection<String>> propertiesMap = new HashMap<>();
+		mapList.forEach(m -> addMap(propertiesMap, m));
+		propertiesList.forEach(p -> addProperties(propertiesMap, p));
+		fileList.forEach(f -> addFile(propertiesMap, f));
+		return convert(propertiesMap);
+	}
+
+	private Map<String, Collection<String>> addFile(Map<String, Collection<String>> propertiesMap, File file) {
+		Properties p = new Properties();
+		try {
+			String content = new String(Files.readAllBytes(Paths.get(file.toURI())));
+			if (hasComments(content)) {
+				status.addWarning("The properties file has comments, which will be lost in the refactoring!");
+			}
+			p.load(new StringReader(content));
+		}
+		catch (IOException e) {
+			status.addError("Problem loading file " + file + ": " + e.getMessage());
+		}
+		return addProperties(propertiesMap, p);
+	}
+
+	private Map<String, Collection<String>> addProperties(Map<String, Collection<String>> propertiesMap, Properties properties) {
+		for (Entry<Object, Object> e : properties.entrySet()) {
+			Set<String> s = new LinkedHashSet<>();
+			s.add((String) e.getValue());
+			propertiesMap.put((String) e.getKey(), s);
+		}
+		return propertiesMap;
+	}
+
+	private Map<String, Collection<String>> addMap(Map<String, Collection<String>> propertiesMap, Map<String, String> properties) {
+		for (Entry<String, String> e : properties.entrySet()) {
+			Set<String> s = new LinkedHashSet<>();
+			s.add((String) e.getValue());
+			propertiesMap.put((String) e.getKey(), s);
+		}
+		return propertiesMap;
+	}
+
+	private YamlConversionResult convert(Map<String, Collection<String>> properties) {
+		if (properties.isEmpty()) {
+			return YamlConversionResult.EMPTY;
+		}
+
+		YamlBuilder root = new YamlBuilder(mode, keyspaceList, status, YamlPath.EMPTY);
+		for (Entry<String, Collection<String>> e : properties.entrySet()) {
+			for (String v : e.getValue()) {
+				root.addProperty(YamlPath.fromProperty(e.getKey()), v);
+			}
+		}
+
+		Object object = root.build();
+
+		DumperOptions options = new DumperOptions();
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		options.setPrettyFlow(true);
+
+		Yaml yaml = new Yaml(options);
+		String output = yaml.dump(object);
+		return new YamlConversionResult(status, output);
+	}
+
+	private boolean hasComments(String line) {
+		return COMMENT.matcher(line).find();
+	}
+
+	/**
+	 * Default implementation of a {@link Builder} building a {@link DefaultYamlConverter}.
+	 */
+	public static class DefaultBuilder implements Builder {
+
+		private Mode mode;
+		private ArrayList<Properties> propertiesList = new ArrayList<>();
+		private ArrayList<Map<String, String>> mapList = new ArrayList<>();
+		private ArrayList<File> fileList = new ArrayList<>();
+		private ArrayList<String> keyspaceList = new ArrayList<>();
+
+		@Override
+		public Builder mode(Mode mode) {
+			this.mode = mode;
+			return this;
+		}
+
+		@Override
+		public Builder flat(String keyspace) {
+			this.keyspaceList.add(keyspace);
+			return this;
+		}
+
+		@Override
+		public Builder file(File file) {
+			this.fileList.add(file);
+			return this;
+		}
+
+		@Override
+		public Builder properties(Properties properties) {
+			this.propertiesList.add(properties);
+			return this;
+		}
+
+		@Override
+		public Builder map(Map<String, String> properties) {
+			this.mapList.add(properties);
+			return this;
+		}
+
+		@Override
+		public YamlConverter build() {
+			return new DefaultYamlConverter(mode, mapList, propertiesList, fileList, keyspaceList);
+		}
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlBuilder.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlBuilder.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support.yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.springframework.cloud.skipper.support.yaml.YamlConverter.Mode;
+import org.springframework.cloud.skipper.support.yaml.YamlPathSegment.AtIndex;
+
+/**
+ * {@code YamlBuilder} acts as a recursive builder handler for properties.
+ *
+ * @author Kris De Volder
+ * @author Janne Valkealahti
+ *
+ */
+class YamlBuilder {
+
+	private final Mode mode;
+	private final ArrayList<String> keyspaceList;
+	private final YamlConversionStatus status;
+	private final YamlPath path;
+	private final List<String> scalars = new ArrayList<>();
+	private final TreeMap<Integer, YamlBuilder> listItems = new TreeMap<>();
+	private final TreeMap<String, YamlBuilder> mapEntries = new TreeMap<>();
+
+	/**
+	 * Instantiates a new yaml builder.
+	 *
+	 * @param mode the mode
+	 * @param keyspaceList the keyspaces
+	 * @param status the status
+	 * @param path the path
+	 */
+	YamlBuilder(Mode mode, ArrayList<String> keyspaceList, YamlConversionStatus status, YamlPath path) {
+		this.mode = mode;
+		this.keyspaceList = keyspaceList;
+		this.status = status;
+		this.path = path;
+	}
+
+	/**
+	 * Adds a property to this builder identified by its path and value.
+	 *
+	 * @param path the path
+	 * @param value the value
+	 */
+	public void addProperty(YamlPath path, String value) {
+		if (path.isEmpty()) {
+			scalars.add(value);
+		}
+		else {
+			YamlPathSegment segment = path.getSegment(0);
+			YamlBuilder subBuilder;
+			if (segment instanceof AtIndex) {
+				subBuilder = getSubBuilder(listItems, segment, segment.toIndex());
+			}
+			else {
+				subBuilder = getSubBuilder(mapEntries, segment, segment.toPropString());
+			}
+			subBuilder.addProperty(path.dropFirst(1), value);
+		}
+	}
+
+	/**
+	 * Builds the object from this builder.
+	 *
+	 * @return the object
+	 */
+	public Object build() {
+		String propString = this.path.toPropString();
+		boolean force = keyspaceList.stream().anyMatch((s) -> propString.startsWith(s) && !propString.equals(s));
+
+		Flatten flatten = null;
+		if (!scalars.isEmpty()) {
+			if (listItems.isEmpty() && mapEntries.isEmpty()) {
+				if (scalars.size() > 1) {
+					status.addWarning("Multiple values " + scalars + " assigned to '" + path.toPropString()
+							+ "'. Values will be merged into a yaml sequence node.");
+					return scalars;
+				}
+				else {
+					return scalars.get(0);
+				}
+			}
+			else {
+				if (mode == Mode.FLATTEN) {
+					flatten = new Flatten();
+					flatten.list = scalars;
+				}
+				else {
+					if (!mapEntries.isEmpty()) {
+						status.addError("Direct assignment '" + path.toPropString() + "=" + scalars.get(0)
+								+ "' can not be combined " + "with sub-property assignment '" + path.toPropString()
+								+ "." + mapEntries.keySet().iterator().next() + "...'. "
+								+ "Direct assignment will be dropped!");
+					}
+					else {
+						status.addError("Direct assignment '" + path.toPropString() + "=" + scalars.get(0)
+								+ "' can not be combined " + "with sequence assignment '" + path.toPropString() + "["
+								+ listItems.keySet().iterator().next() + "]...' "
+								+ "Direct assignments will be dropped!");
+					}
+					scalars.clear();
+				}
+			}
+		}
+		if (!listItems.isEmpty() && !mapEntries.isEmpty()) {
+			status.addWarning("'" + path.toPropString()
+					+ "' has some entries that look like list items and others that look like map entries. "
+					+ "All these entries will be treated as map entries");
+			for (Entry<Integer, YamlBuilder> listItem : listItems.entrySet()) {
+				mapEntries.put(listItem.getKey().toString(), listItem.getValue());
+			}
+			listItems.clear();
+		}
+		if (!listItems.isEmpty()) {
+			return listItems.values().stream().map(childBuilder -> childBuilder.build())
+					.collect(Collectors.toList());
+		}
+		else {
+			TreeMap<String, Object> map = new TreeMap<>();
+			if (force) {
+				flatten = new Flatten();
+			}
+			for (Entry<String, YamlBuilder> entry : mapEntries.entrySet()) {
+				String key = entry.getKey();
+				Object value = entry.getValue().build();
+
+				if (mode == Mode.FLATTEN && value instanceof Flatten) {
+					Flatten f = (Flatten) value;
+					if (f.list != null && f.list.size() == 1) {
+						map.put(key, f.list.get(0));
+					}
+					else {
+						if (f.list != null) {
+							map.put(key, f.list);
+						}
+					}
+					for (Entry<String, Object> e : f.map.entrySet()) {
+						if (e.getValue() != null) {
+							map.put(key + "." + e.getKey(), e.getValue());
+						}
+					}
+				}
+				else {
+					map.put(key, value);
+				}
+			}
+			if (flatten != null) {
+				flatten.map = map;
+				return flatten;
+			}
+			else {
+				return map;
+			}
+		}
+	}
+
+	private <T> YamlBuilder getSubBuilder(TreeMap<T, YamlBuilder> subBuilders, YamlPathSegment segment, T key) {
+		YamlBuilder existing = subBuilders.get(key);
+		if (existing == null) {
+			existing = new YamlBuilder(mode, keyspaceList, status, path.append(segment));
+			subBuilders.put(key, existing);
+		}
+		return existing;
+	}
+
+	private static class Flatten {
+		List<String> list;
+		Map<String, Object> map;
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlBuilder.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlBuilder.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.springframework.cloud.skipper.support.yaml.YamlConverter.Mode;
@@ -88,7 +90,12 @@ class YamlBuilder {
 	 */
 	public Object build() {
 		String propString = this.path.toPropString();
-		boolean force = keyspaceList.stream().anyMatch((s) -> propString.startsWith(s) && !propString.equals(s));
+		boolean force = keyspaceList.stream().anyMatch((s) -> {
+			// check that prop starts with regex pattern and
+			// need to skip full match
+			Matcher m = Pattern.compile(s).matcher(propString);
+			return m.lookingAt() && !m.matches();
+		});
 
 		Flatten flatten = null;
 		if (!scalars.isEmpty()) {

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlConversionResult.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlConversionResult.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support.yaml;
+
+/**
+ * {@code YamlConversionResult} is a result returned by {@link YamlConverter}
+ * and contains actual {@code YAML} and conversion status.
+ *
+ * @author Kris De Volder
+ * @author Janne Valkealahti
+ *
+ */
+public class YamlConversionResult {
+
+	static YamlConversionResult EMPTY = new YamlConversionResult(YamlConversionStatus.EMPTY, "");
+	private YamlConversionStatus status;
+	private String yaml;
+
+	/**
+	 * Instantiates a new yaml conversion result.
+	 *
+	 * @param status the status
+	 * @param output the output
+	 */
+	YamlConversionResult(YamlConversionStatus status, String output) {
+		this.status = status;
+		this.yaml = output;
+	}
+
+	/**
+	 * Gets the yaml.
+	 *
+	 * @return the yaml
+	 */
+	public String getYaml() {
+		return yaml;
+	}
+
+	/**
+	 * Gets the status.
+	 *
+	 * @return the status
+	 */
+	public YamlConversionStatus getStatus() {
+		return status;
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlConversionStatus.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlConversionStatus.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support.yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@code YamlConversionStatus} keeps more information around
+ * for status of a conversion. For example warnings if something
+ * is removed or errors if something cannot be converted.
+ *
+ * @author Kris De Volder
+ * @author Janne Valkealahti
+ *
+ */
+public class YamlConversionStatus {
+
+	public static final YamlConversionStatus EMPTY = new YamlConversionStatus();
+	public static final int OK = 0;
+	public static final int WARNING = 1;
+	public static final int ERROR = 2;
+	private int severity;
+	private List<ConversionMessage> entries = new ArrayList<>();
+
+	void addError(String message) {
+		entries.add(new ConversionMessage(ERROR, message));
+		if (severity < ERROR) {
+			severity = ERROR;
+		}
+	}
+
+	void addWarning(String message) {
+		entries.add(new ConversionMessage(WARNING, message));
+		if (severity < WARNING) {
+			severity = WARNING;
+		}
+	}
+
+	/**
+	 * Gets the status entries.
+	 *
+	 * @return the status entries
+	 */
+	public List<ConversionMessage> getEntries() {
+		return entries;
+	}
+
+	/**
+	 * Gets the severity.
+	 *
+	 * @return the severity
+	 */
+	public int getSeverity() {
+		return severity;
+	}
+
+	static class ConversionMessage {
+
+		private int severity;
+		private String message;
+
+		ConversionMessage(int severity, String message) {
+			this.severity = severity;
+			this.message = message;
+		}
+
+		public int getSeverity() {
+			return severity;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlConverter.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlConverter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support.yaml;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Interface able to convert a various sources into {@code YAML}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface YamlConverter {
+
+	/**
+	 * Gets a default {@link Builder} building a configured {@link YamlConverter}.
+	 *
+	 * @return the builder
+	 */
+	static Builder builder() {
+		return new DefaultYamlConverter.DefaultBuilder();
+	}
+
+	/**
+	 * Convert configured sources as a {@link YamlConversionResult}.
+	 *
+	 * @return the yaml conversion result
+	 */
+	YamlConversionResult convert();
+
+	/**
+	 * Enumeration of a converter mode.
+	 */
+	enum Mode {
+
+		/** Default strict mode using normal yaml format without any compatibility tricks */
+		DEFAULT,
+
+		/** Flatten properties if parent has a scalar and sub-keys */
+		FLATTEN;
+	}
+
+	/**
+	 * Interface for building a {@code YamlConverter}.
+	 */
+	interface Builder {
+
+		/**
+		 * Sets the used {@link Mode} for a converter. Defaults
+		 * to {@link Mode#DEFAULT}.
+		 *
+		 * @param mode the mode
+		 * @return the builder
+		 */
+		Builder mode(Mode mode);
+
+		/**
+		 * Adds a keyspace which forces flattening.
+		 *
+		 * @param keyspace the keyspace
+		 * @return the builder for chaining
+		 */
+		Builder flat(String keyspace);
+
+		/**
+		 * Adds a {@link File} containing properties.
+		 *
+		 * @param file the file
+		 * @return the builder for chaining
+		 */
+		Builder file(File file);
+
+		/**
+		 * Adds a plain {@link Properties}.
+		 *
+		 * @param properties the properties
+		 * @return the builder for chaining
+		 */
+		Builder properties(Properties properties);
+
+		/**
+		 * Adds a {@link Map} of properties.
+		 *
+		 * @param properties the properties
+		 * @return the builder for chaining
+		 */
+		Builder map(Map<String, String> properties);
+
+		/**
+		 * Builds the configured {@code YamlConverter}.
+		 *
+		 * @return the built yaml converter
+		 */
+		YamlConverter build();
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlConverter.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlConverter.java
@@ -71,7 +71,8 @@ public interface YamlConverter {
 		Builder mode(Mode mode);
 
 		/**
-		 * Adds a keyspace which forces flattening.
+		 * Adds a keyspace regex pattern which forces flattening.
+		 * This pattern needs to fully match target keyspace.
 		 *
 		 * @param keyspace the keyspace
 		 * @return the builder for chaining

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlPath.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlPath.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support.yaml;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
+
+/**
+ * Property path representation in {@link YamlBuilder}.
+ *
+ * @author Kris De Volder
+ * @author Janne Valkealahti
+ *
+ */
+class YamlPath {
+
+	public static final YamlPath EMPTY = new YamlPath();
+	private final YamlPathSegment[] segments;
+
+	/**
+	 * Instantiates a new yaml path.
+	 */
+	YamlPath() {
+		this.segments = new YamlPathSegment[0];
+	}
+
+	/**
+	 * Instantiates a new yaml path.
+	 *
+	 * @param segments the segments
+	 */
+	YamlPath(List<YamlPathSegment> segments) {
+		this.segments = segments.toArray(new YamlPathSegment[segments.size()]);
+	}
+
+	/**
+	 * Instantiates a new yaml path.
+	 *
+	 * @param segments the segments
+	 */
+	YamlPath(YamlPathSegment... segments) {
+		this.segments = segments;
+	}
+
+	/**
+	 * Gets a property format of path.
+	 *
+	 * @return the string
+	 */
+	public String toPropString() {
+		StringBuilder buf = new StringBuilder();
+		boolean first = true;
+		for (YamlPathSegment s : segments) {
+			if (first) {
+				buf.append(s.toPropString());
+			}
+			else {
+				buf.append(s.toNavString());
+			}
+			first = false;
+		}
+		return buf.toString();
+	}
+
+	/**
+	 * Gets a navigation format of path. This is similar to
+	 * property format but will have leading dot.
+	 *
+	 * @return the string
+	 */
+	public String toNavString() {
+		StringBuilder buf = new StringBuilder();
+		for (YamlPathSegment s : segments) {
+			buf.append(s.toNavString());
+		}
+		return buf.toString();
+	}
+
+	/**
+	 * Gets the segments.
+	 *
+	 * @return the segments
+	 */
+	public YamlPathSegment[] getSegments() {
+		return segments;
+	}
+
+
+	/**
+	 * Parse a YamlPath from a dotted property name. The segments are obtained
+	 * by spliting the name at each dot.
+	 *
+	 * @param propName the prop name
+	 * @return the yaml path
+	 */
+	public static YamlPath fromProperty(String propName) {
+		List<YamlPathSegment> segments = new ArrayList<>();
+		String delim = ".[]";
+		StringTokenizer tokens = new StringTokenizer(propName, delim, true);
+		try {
+			while (tokens.hasMoreTokens()) {
+				String token = tokens.nextToken(delim);
+				if (token.equals(".") || token.equals("]")) {
+					// Skip it silently
+				}
+				else if (token.equals("[")) {
+					String bracketed = tokens.nextToken("]");
+					if (bracketed.equals("]")) {
+						// empty string between []? Makes no sense, so ignore
+						// that.
+					}
+					else {
+						try {
+							int index = Integer.parseInt(bracketed);
+							segments.add(YamlPathSegment.valueAt(index));
+						}
+						catch (NumberFormatException e) {
+							segments.add(YamlPathSegment.valueAt(bracketed));
+						}
+					}
+				}
+				else {
+					segments.add(YamlPathSegment.valueAt(token));
+				}
+			}
+		}
+		catch (NoSuchElementException e) {
+			// Ran out of tokens.
+		}
+		return new YamlPath(segments);
+	}
+
+	/**
+	 * Create a YamlPath with a single segment (i.e. like 'fromProperty', but
+	 * does not parse '.' as segment separators.
+	 *
+	 * @param name the name
+	 * @return the yaml path
+	 */
+	public static YamlPath fromSimpleProperty(String name) {
+		return new YamlPath(YamlPathSegment.valueAt(name));
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder buf = new StringBuilder();
+		buf.append("YamlPath(");
+		boolean first = true;
+		for (YamlPathSegment s : segments) {
+			if (!first) {
+				buf.append(", ");
+			}
+			buf.append(s);
+			first = false;
+		}
+		buf.append(")");
+		return buf.toString();
+	}
+
+	/**
+	 * Gets the number of segments.
+	 *
+	 * @return the number of segments
+	 */
+	public int size() {
+		return segments.length;
+	}
+
+	/**
+	 * Gets the segment.
+	 *
+	 * @param segment the segment
+	 * @return the segment
+	 */
+	public YamlPathSegment getSegment(int segment) {
+		if (segment >= 0 && segment < segments.length) {
+			return segments[segment];
+		}
+		return null;
+	}
+
+	/**
+	 * Prepend a segment.
+	 *
+	 * @param s the s
+	 * @return the yaml path
+	 */
+	public YamlPath prepend(YamlPathSegment s) {
+		YamlPathSegment[] newPath = new YamlPathSegment[segments.length + 1];
+		newPath[0] = s;
+		System.arraycopy(segments, 0, newPath, 1, segments.length);
+		return new YamlPath(newPath);
+	}
+
+	/**
+	 * Append a segment.
+	 *
+	 * @param s the s
+	 * @return the yaml path
+	 */
+	public YamlPath append(YamlPathSegment s) {
+		YamlPathSegment[] newPath = Arrays.copyOf(segments, segments.length + 1);
+		newPath[segments.length] = s;
+		return new YamlPath(newPath);
+	}
+
+	public YamlPath dropFirst(int dropCount) {
+		if (dropCount >= size()) {
+			return EMPTY;
+		}
+		if (dropCount == 0) {
+			return this;
+		}
+		YamlPathSegment[] newPath = new YamlPathSegment[segments.length - dropCount];
+		for (int i = 0; i < newPath.length; i++) {
+			newPath[i] = segments[i + dropCount];
+		}
+		return new YamlPath(newPath);
+	}
+
+	/**
+	 * Drop last segment.
+	 *
+	 * @return the yaml path
+	 */
+	public YamlPath dropLast() {
+		return dropLast(1);
+	}
+
+	/**
+	 * Drop last segment(s).
+	 *
+	 * @return the yaml path
+	 */
+	public YamlPath dropLast(int dropCount) {
+		if (dropCount >= size()) {
+			return EMPTY;
+		}
+		if (dropCount == 0) {
+			return this;
+		}
+		YamlPathSegment[] newPath = new YamlPathSegment[segments.length - dropCount];
+		for (int i = 0; i < newPath.length; i++) {
+			newPath[i] = segments[i];
+		}
+		return new YamlPath(newPath);
+	}
+
+	/**
+	 * Checks if has segments.
+	 *
+	 * @return true, if is empty
+	 */
+	public boolean isEmpty() {
+		return segments.length == 0;
+	}
+
+	/**
+	 * Returns path with first dropped segment.
+	 *
+	 * @return the yaml path
+	 */
+	public YamlPath tail() {
+		return dropFirst(1);
+	}
+
+	/**
+	 * Gets the last segment.
+	 *
+	 * @return the last segment
+	 */
+	public YamlPathSegment getLastSegment() {
+		if (!isEmpty()) {
+			return segments[segments.length - 1];
+		}
+		return null;
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlPathSegment.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/yaml/YamlPathSegment.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support.yaml;
+
+/**
+ * A YamlPathSegment is a 'primitive' NodeNavigator operation. More complex
+ * operations (i.e {@link YamlPath}) are composed as sequences of 0 or more
+ * {@link YamlPathSegment}s.
+ *
+ * @author Kris De Volder
+ */
+abstract class YamlPathSegment {
+
+	protected abstract String getValueCode();
+
+	protected abstract char getTypeCode();
+
+	public boolean canEmpty() {
+		// All path segments implement a real 'one step' movement,
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return toNavString();
+	}
+
+	public abstract String toNavString();
+
+	public abstract String toPropString();
+
+	public abstract Integer toIndex();
+
+	public abstract YamlPathSegmentType getType();
+
+	public static YamlPathSegment valueAt(String key) {
+		return new ValAtKey(key);
+	}
+
+	public static YamlPathSegment valueAt(int index) {
+		return new AtIndex(index);
+	}
+
+	public static YamlPathSegment keyAt(String key) {
+		return new KeyAtKey(key);
+	}
+
+	public static YamlPathSegment anyChild() {
+		return AnyChild.INSTANCE;
+	}
+
+	public String encode() {
+		return getTypeCode() + getValueCode();
+	}
+
+	public static YamlPathSegment decode(String code) {
+		switch (code.charAt(0)) {
+		case '*':
+			return anyChild();
+		case '.':
+			return valueAt(code.substring(1));
+		case '&':
+			return keyAt(code.substring(1));
+		case '[':
+			return valueAt(Integer.parseInt(code.substring(1)));
+		default:
+			throw new IllegalArgumentException("Can't decode YamlPathSegment from '" + code + "'");
+		}
+	}
+
+	public enum YamlPathSegmentType {
+		// Go to value associate with given key in a map.
+		VAL_AT_KEY,
+		// Go to the key node associated with a given key in a map.
+		KEY_AT_KEY,
+		// Go to value associate with given index in a sequence
+		VAL_AT_INDEX,
+		// Go to any child (assumes you are using ambiguous traversal
+		// method, otherwise this is probably not very useful)
+		ANY_CHILD
+	}
+
+	public static final class AnyChild extends YamlPathSegment {
+
+		static AnyChild INSTANCE = new AnyChild();
+
+		private AnyChild() {
+		}
+
+		@Override
+		public String toNavString() {
+			return ".*";
+		}
+
+		@Override
+		public String toPropString() {
+			return "*";
+		}
+
+		@Override
+		public Integer toIndex() {
+			return null;
+		}
+
+		@Override
+		public YamlPathSegmentType getType() {
+			return YamlPathSegmentType.ANY_CHILD;
+		}
+
+		@Override
+		protected char getTypeCode() {
+			return '*';
+		};
+
+		@Override
+		protected String getValueCode() {
+			return "";
+		}
+
+	}
+
+	public static final class AtIndex extends YamlPathSegment {
+
+		private int index;
+
+		AtIndex(int index) {
+			this.index = index;
+		}
+
+		@Override
+		public String toNavString() {
+			return "[" + index + "]";
+		}
+
+		@Override
+		public String toPropString() {
+			return "[" + index + "]";
+		}
+
+		@Override
+		public YamlPathSegmentType getType() {
+			return YamlPathSegmentType.VAL_AT_INDEX;
+		}
+
+		@Override
+		public Integer toIndex() {
+			return index;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + index;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			AtIndex other = (AtIndex) obj;
+			if (index != other.index) {
+				return false;
+			}
+			return true;
+		}
+
+		@Override
+		protected char getTypeCode() {
+			return '[';
+		}
+
+		@Override
+		protected String getValueCode() {
+			return "" + index;
+		}
+	}
+
+	public static class ValAtKey extends YamlPathSegment {
+
+		private String key;
+
+		ValAtKey(String key) {
+			this.key = key;
+		}
+
+		@Override
+		public String toNavString() {
+			if (key.indexOf('.') >= 0) {
+				// TODO: what if key contains '[' or ']'??
+				return "[" + key + "]";
+			}
+			return "." + key;
+		}
+
+		@Override
+		public String toPropString() {
+			// Don't start with a '.' if trying to build a 'self contained'
+			// expression.
+			return key;
+		}
+
+		@Override
+		public YamlPathSegmentType getType() {
+			return YamlPathSegmentType.VAL_AT_KEY;
+		}
+
+		@Override
+		public Integer toIndex() {
+			return null;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((key == null) ? 0 : key.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			ValAtKey other = (ValAtKey) obj;
+			if (key == null) {
+				if (other.key != null) {
+					return false;
+				}
+			}
+			else if (!key.equals(other.key)) {
+				return false;
+			}
+			return true;
+		}
+
+		@Override
+		protected char getTypeCode() {
+			return '.';
+		}
+
+		@Override
+		protected String getValueCode() {
+			return key;
+		}
+	}
+
+	public static final class KeyAtKey extends ValAtKey {
+
+		KeyAtKey(String key) {
+			super(key);
+		}
+
+		@Override
+		public YamlPathSegmentType getType() {
+			return YamlPathSegmentType.KEY_AT_KEY;
+		}
+
+		@Override
+		protected char getTypeCode() {
+			return '&';
+		}
+
+	}
+}

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/support/DeploymentPropertiesUtilsTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/support/DeploymentPropertiesUtilsTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DeploymentPropertiesUtils}.
+ *
+ * @author Janne Valkealahti
+ */
+public class DeploymentPropertiesUtilsTests {
+
+	private static void assertArrays(String[] left, String[] right) {
+		ArrayList<String> params = new ArrayList<>(Arrays.asList(left));
+		assertThat(DeploymentPropertiesUtils.parseParams(params)).containsExactlyInAnyOrder(right);
+	}
+
+	@Test
+	public void testDeploymentPropertiesParsing() {
+		Map<String, String> props = DeploymentPropertiesUtils.parse("app.foo.bar=v, app.foo.wizz=v2  , deployer.foo"
+				+ ".pot=fern, app.other.key = value  , deployer.other.cow = meww");
+
+		assertThat(props).containsEntry("app.foo.bar", "v");
+		assertThat(props).containsEntry("app.other.key", "value");
+		assertThat(props).containsEntry("app.foo.wizz", "v2");
+		assertThat(props).containsEntry("deployer.foo.pot", "fern");
+		assertThat(props).containsEntry("deployer.other.cow", "meww");
+
+		props = DeploymentPropertiesUtils.parse("f=v");
+		assertThat(props).containsEntry("f", "v");
+
+		props = DeploymentPropertiesUtils.parse("foo1=bar1,app.foo2=bar2,foo3=bar3,xxx3");
+		assertThat(props).containsEntry("foo1", "bar1");
+		assertThat(props).containsEntry("app.foo2", "bar2");
+		assertThat(props).containsEntry("foo3", "bar3,xxx3");
+
+		props = DeploymentPropertiesUtils.parse("foo1 = bar1 , app.foo2= bar2,  foo3  = bar3,xxx3");
+		assertThat(props).containsEntry("foo1", "bar1");
+		assertThat(props).containsEntry("app.foo2", "bar2");
+		assertThat(props).containsEntry("foo3", "bar3,xxx3");
+
+		props = DeploymentPropertiesUtils.parse("app.*.count=1");
+		assertThat(props).containsEntry("app.*.count", "1");
+
+		props = DeploymentPropertiesUtils.parse("app.*.my-count=1");
+		assertThat(props).containsEntry("app.*.my-count", "1");
+
+		props = DeploymentPropertiesUtils.parse("app.transform.producer.partitionKeyExpression=fakeExpression('xxx')");
+		assertThat(props).containsEntry("app.transform.producer.partitionKeyExpression", "fakeExpression('xxx')");
+
+		props = DeploymentPropertiesUtils.parse("invalidkeyvalue");
+		assertThat(props.size()).isEqualTo(0);
+
+		props = DeploymentPropertiesUtils.parse("invalidkeyvalue1,invalidkeyvalue2");
+		assertThat(props.size()).isEqualTo(0);
+
+		props = DeploymentPropertiesUtils.parse("invalidkeyvalue1,invalidkeyvalue2,foo=bar");
+		assertThat(props.size()).isEqualTo(1);
+		assertThat(props).containsEntry("foo", "bar");
+
+		props = DeploymentPropertiesUtils.parse("invalidkeyvalue1,foo=bar,invalidkeyvalue2");
+		assertThat(props.size()).isEqualTo(1);
+		assertThat(props).containsEntry("foo", "bar,invalidkeyvalue2");
+
+		props = DeploymentPropertiesUtils.parse("foo.bar1=jee1,jee2,jee3,foo.bar2=jee4,jee5,jee6");
+		assertThat(props).containsEntry("foo.bar1", "jee1,jee2,jee3");
+		assertThat(props).containsEntry("foo.bar2", "jee4,jee5,jee6");
+
+		props = DeploymentPropertiesUtils.parse("foo.bar1=xxx=1,foo.bar2=xxx=2");
+		assertThat(props).containsEntry("foo.bar1", "xxx=1");
+		assertThat(props).containsEntry("foo.bar2", "xxx=2");
+	}
+
+	@Test
+	public void testLongDeploymentPropertyValues() {
+		Map<String, String> props = DeploymentPropertiesUtils
+				.parse("app.foo.bar=FoooooooooooooooooooooBar,app.foo" + ".bar2=FoooooooooooooooooooooBar");
+		assertThat(props).containsEntry("app.foo.bar", "FoooooooooooooooooooooBar");
+		props = DeploymentPropertiesUtils.parse("app.foo.bar=FooooooooooooooooooooooooooooooooooooooooooooooooooooBar");
+		assertThat(props).containsEntry("app.foo.bar", "FooooooooooooooooooooooooooooooooooooooooooooooooooooBar");
+	}
+
+	@Test
+	public void testCommandLineParamsParsing() {
+		assertArrays(new String[] { "--format=yyyy-MM-dd" }, new String[] { "--format=yyyy-MM-dd" });
+		assertArrays(new String[] { "'--format=yyyy-MM-dd HH:mm:ss.SSS'" },
+				new String[] { "--format=yyyy-MM-dd HH:mm:ss" + ".SSS" });
+		assertArrays(new String[] { "\"--format=yyyy-MM-dd HH:mm:ss.SSS\"" },
+				new String[] { "--format=yyyy-MM-dd HH:mm:ss" + ".SSS" });
+		assertArrays(new String[] { "--format='yyyy-MM-dd HH:mm:ss.SSS'" },
+				new String[] { "--format=yyyy-MM-dd HH:mm:ss" + ".SSS" });
+		assertArrays(new String[] { "--format=\"yyyy-MM-dd HH:mm:ss.SSS\"" },
+				new String[] { "--format=yyyy-MM-dd HH:mm:ss" + ".SSS" });
+		assertArrays(new String[] { "--foo1=bar1 --foo2=bar2" }, new String[] { "--foo1=bar1", "--foo2=bar2" });
+		assertArrays(new String[] { "--foo1=bar1", "--foo2=bar2" }, new String[] { "--foo1=bar1", "--foo2=bar2" });
+		assertArrays(new String[] { " --foo1=bar1 ", " --foo2=bar2 " }, new String[] { "--foo1=bar1", "--foo2=bar2" });
+		assertArrays(new String[] { "'--format=yyyy-MM-dd HH:mm:ss.SSS'", "--foo1=bar1" },
+				new String[] { "--format=yyyy-MM-dd HH:mm:ss.SSS", "--foo1=bar1" });
+	}
+}

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/support/yaml/YamlConverterTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/support/yaml/YamlConverterTests.java
@@ -253,6 +253,32 @@ public class YamlConverterTests {
 	}
 
 	@Test
+	public void forceFlattenMultiUseRegex() throws Exception {
+		do_conversionTest(
+				Mode.FLATTEN,
+				Arrays.asList("[a-z]*2\\.property"),
+				"some1.property.sub1.sub2=sub-value1\n" +
+				"some1.property.sub3.sub4=sub-value2\n" +
+				"some2.property.sub5.sub6=sub-value1\n" +
+				"some2.property.sub7.sub8=sub-value2",
+				// ==>
+				"some1:\n" +
+				"  property:\n" +
+				"    sub1:\n" +
+				"      sub2: sub-value1\n" +
+				"    sub3:\n" +
+				"      sub4: sub-value2\n" +
+				"some2:\n" +
+				"  property:\n" +
+				"    sub5.sub6: sub-value1\n" +
+				"    sub7.sub8: sub-value2\n",
+				(status) -> {
+					assertThat(status.getSeverity()).isEqualTo(0);
+				}
+		);
+	}
+
+	@Test
 	public void scalarAndMapConflictDeepFlatten() throws Exception {
 		do_conversionTest(
 				Mode.FLATTEN,

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/support/yaml/YamlConverterTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/support/yaml/YamlConverterTests.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.support.yaml;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.cloud.skipper.support.yaml.YamlConversionStatus.ConversionMessage;
+import org.springframework.cloud.skipper.support.yaml.YamlConverter.Builder;
+import org.springframework.cloud.skipper.support.yaml.YamlConverter.Mode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class YamlConverterTests {
+
+	@Test
+	public void conversionWithListItems() throws Exception {
+		doConversionTest(
+				"some.thing[0].a=first-a\n" +
+				"some.thing[0].b=first-b\n" +
+				"some.thing[1].a=second-a\n" +
+				"some.thing[1].b=second-b\n",
+				// ==>
+				"some:\n" +
+				"  thing:\n" +
+				"  - a: first-a\n" +
+				"    b: first-b\n" +
+				"  - a: second-a\n" +
+				"    b: second-b\n"
+		);
+	}
+
+	@Test
+	public void deepKeys1() throws Exception {
+		doConversionTest(
+				"hi.this.is.same=xxx.yyy\n",
+				// ==>
+				"hi:\n" +
+				"  this:\n" +
+				"    is:\n" +
+				"      same: xxx.yyy\n"
+		);
+
+		Map<String, String> input = new HashMap<String, String>();
+		input.put("hi.this.is.same", "xxx.yyy");
+		doMapConversionTest(
+				input,
+				// ==>
+				"hi:\n" +
+				"  this:\n" +
+				"    is:\n" +
+				"      same: xxx.yyy\n"
+		);
+
+	}
+
+	@Test
+	public void deepKeys2() throws Exception {
+		doConversionTest(
+				"bye.this.is.same=xxx.yyy\n" +
+				"hi.this.is.same=xxx.yyy\n",
+				// ==>
+				"bye:\n" +
+				"  this:\n" +
+				"    is:\n" +
+				"      same: xxx.yyy\n" +
+				"hi:\n" +
+				"  this:\n" +
+				"    is:\n" +
+				"      same: xxx.yyy\n"
+		);
+		Map<String, String> input = new HashMap<String, String>();
+		input.put("bye.this.is.same", "xxx.yyy");
+		input.put("hi.this.is.same", "xxx.yyy");
+		doMapConversionTest(
+				input,
+				// ==>
+				"bye:\n" +
+				"  this:\n" +
+				"    is:\n" +
+				"      same: xxx.yyy\n" +
+				"hi:\n" +
+				"  this:\n" +
+				"    is:\n" +
+				"      same: xxx.yyy\n"
+		);
+	}
+
+	@Test
+	public void hasComments() throws Exception {
+		do_hasComments_test("#comment");
+		do_hasComments_test("!comment");
+		do_hasComments_test("    \t!comment");
+		String yaml = do_hasComments_test("    #!comment");
+		assertYaml(yaml,
+				"other:\n" +
+				"  property: othervalue\n" +
+				"some:\n" +
+				"  property: somevalue\n"
+		);
+	}
+
+	private void assertYaml(String yaml, String expected) {
+		assertThat(yaml).isEqualTo(expected);
+	}
+
+	@Test
+	public void almostHasComments() throws Exception {
+		doConversionTest(
+			"my.hello=Good morning!\n" +
+			"my.goodbye=See ya # later\n",
+			// ==>
+			"my:\n" +
+			"  goodbye: 'See ya # later'\n" +
+			"  hello: Good morning!\n"
+		);
+	}
+
+
+	@Test
+	public void simpleConversion() throws Exception {
+		doConversionTest(
+				"some.thing=vvvv\n" +
+				"some.other.thing=blah\n",
+				// ==>
+				"some:\n" +
+				"  other:\n" +
+				"    thing: blah\n" +
+				"  thing: vvvv\n"
+		);
+	}
+
+	@Test
+	public void emptyFileConversion() throws Exception {
+		doConversionTest(
+				"",
+				// ==>
+				""
+		);
+	}
+
+	@Test
+	public void unusualName() throws Exception {
+		File input = createFile("no-extension",
+				"server.port: 6789"
+		);
+		YamlConversionResult result = YamlConverter.builder().file(input).build().convert();
+		assertOkStatus(result.getStatus());
+
+		assertThat(result.getYaml()).isEqualTo("server:\n" + "  port: '6789'\n");
+	}
+
+	@Test
+	public void multipleAssignmentProblem() throws Exception {
+		do_conversionTest(
+				"some.property=something\n" +
+				"some.property=something-else",
+				// ==>
+				"some:\n" +
+				"  property: something-else\n",
+				(status) -> {
+					assertThat(status.getSeverity()).isEqualTo(0);
+				}
+		);
+	}
+
+	@Test
+	public void scalarAndMapConflict() throws Exception {
+		do_conversionTest(
+				"some.property=a-scalar\n" +
+				"some.property.sub=sub-value",
+				// ==>
+				"some:\n" +
+				"  property:\n" +
+				"    sub: sub-value\n",
+				(status) -> {
+					assertStatus(status, YamlConversionStatus.ERROR,
+							"Direct assignment 'some.property=a-scalar' can not be combined with sub-property assignment 'some.property.sub...'");
+				}
+		);
+	}
+
+	@Test
+	public void scalarAndMapConflictFlatten() throws Exception {
+		do_conversionTest(
+				Mode.FLATTEN,
+				"some.property=a-scalar\n" +
+				"some.property.sub=sub-value",
+				// ==>
+				"some:\n" +
+				"  property: a-scalar\n" +
+				"  property.sub: sub-value\n",
+				(status) -> {
+					assertThat(status.getSeverity()).isEqualTo(0);
+				}
+		);
+	}
+
+	@Test
+	public void forceFlatten() throws Exception {
+		do_conversionTest(
+				Mode.FLATTEN,
+				Arrays.asList("some.property"),
+				"some.property.sub1.sub2=sub-value",
+				// ==>
+				"some:\n" +
+				"  property:\n" +
+				"    sub1.sub2: sub-value\n",
+				(status) -> {
+					assertThat(status.getSeverity()).isEqualTo(0);
+				}
+		);
+	}
+
+	@Test
+	public void forceFlattenMulti() throws Exception {
+		do_conversionTest(
+				Mode.FLATTEN,
+				Arrays.asList("some.property"),
+				"some.property.sub1.sub2=sub-value1\n" +
+				"some.property.sub3.sub4=sub-value2",
+				// ==>
+				"some:\n" +
+				"  property:\n" +
+				"    sub1.sub2: sub-value1\n" +
+				"    sub3.sub4: sub-value2\n",
+				(status) -> {
+					assertThat(status.getSeverity()).isEqualTo(0);
+				}
+		);
+	}
+
+	@Test
+	public void scalarAndMapConflictDeepFlatten() throws Exception {
+		do_conversionTest(
+				Mode.FLATTEN,
+				"log4j.appender.stdout=org.apache.log4j.ConsoleAppender\n" +
+				"log4j.appender.stdout.Target:System.out\n" +
+				"log4j.appender.stdout.layout:org.apache.log4j.PatternLayout\n" +
+				"log4j.appender.stdout.layout.ConversionPattern:%d{ABSOLUTE} %5p %c{1}:%L - %m%n\n" +
+				"log4j.rootLogger:INFO, stdout\n" +
+				"log4j.logger.org.hibernate:DEBUG\n" +
+				"log4j.logger.org.hibernate.type:ALL\n",
+				// ==>
+				"log4j:\n" +
+				"  appender:\n" +
+				"    stdout: org.apache.log4j.ConsoleAppender\n" +
+				"    stdout.Target: System.out\n" +
+				"    stdout.layout: org.apache.log4j.PatternLayout\n" +
+				"    stdout.layout.ConversionPattern: '%d{ABSOLUTE} %5p %c{1}:%L - %m%n'\n" +
+				"  logger:\n" +
+				"    org:\n" +
+				"      hibernate: DEBUG\n" +
+				"      hibernate.type: ALL\n" +
+				"  rootLogger: INFO, stdout\n",
+				(status) -> {
+					assertThat(status.getSeverity()).isEqualTo(0);
+				}
+		);
+	}
+
+	@Test
+	public void scalarAndMapConflictDeepFlatten2() throws Exception {
+		do_conversionTest(
+				Mode.FLATTEN,
+				"log4j.appender.stdout=org.apache.log4j.ConsoleAppender\n" +
+				"log4j.appender.stdout.Target:System.out\n" +
+				"log4j.appender.stdout.layout:org.apache.log4j.PatternLayout\n" +
+				"log4j.appender.stdout.layout.ConversionPattern:%d{ABSOLUTE} %5p %c{1}:%L - %m%n\n" +
+				"\n" +
+				"log4j.rootLogger:INFO, stdout\n" +
+				"\n" +
+				"log4j.logger.org.hibernate:DEBUG\n" +
+				"\n" +
+				"log4j.logger.org.hibernate.type:ALL\n" +
+				"\n",
+				// ==>
+				"log4j:\n" +
+				"  appender:\n" +
+				"    stdout: org.apache.log4j.ConsoleAppender\n" +
+				"    stdout.Target: System.out\n" +
+				"    stdout.layout: org.apache.log4j.PatternLayout\n" +
+				"    stdout.layout.ConversionPattern: '%d{ABSOLUTE} %5p %c{1}:%L - %m%n'\n" +
+				"  logger:\n" +
+				"    org:\n" +
+				"      hibernate: DEBUG\n" +
+				"      hibernate.type: ALL\n" +
+				"  rootLogger: INFO, stdout\n",
+				(status) -> {
+					assertThat(status.getSeverity()).isEqualTo(0);
+				}
+		);
+	}
+
+	@Test
+	public void scalarAndSequenceConflict() throws Exception {
+		do_conversionTest(
+				"some.property=a-scalar\n" +
+				"some.property[0]=zero\n" +
+				"some.property[1]=one\n",
+				// ==>
+				"some:\n" +
+				"  property:\n" +
+				"  - zero\n" +
+				"  - one\n",
+				(status) -> {
+					assertStatus(status, YamlConversionStatus.ERROR,
+							"Direct assignment 'some.property=a-scalar' can not be combined with sequence assignment 'some.property[0]...'");
+				}
+		);
+	}
+
+	@Test
+	public void mapAndSequenceConflict() throws Exception {
+		do_conversionTest(
+				"some.property.abc=val1\n" +
+				"some.property.def=val2\n" +
+				"some.property[0]=zero\n" +
+				"some.property[1]=one\n",
+				// ==>
+				"some:\n" +
+				"  property:\n" +
+				"    '0': zero\n" +
+				"    '1': one\n" +
+				"    abc: val1\n" +
+				"    def: val2\n",
+				(status) -> {
+					assertStatus(status, YamlConversionStatus.WARNING,
+							"'some.property' has some entries that look like list items and others that look like map entries");
+				}
+		);
+	}
+
+	@Test
+	public void scalarAndMapAndSequenceConflict() throws Exception {
+		do_conversionTest(
+				"some.property=a-scalar\n" +
+				"some.property.abc=val1\n" +
+				"some.property.def=val2\n" +
+				"some.property[0]=zero\n" +
+				"some.property[1]=one\n",
+				// ==>
+				"some:\n" +
+				"  property:\n" +
+				"    '0': zero\n" +
+				"    '1': one\n" +
+				"    abc: val1\n" +
+				"    def: val2\n",
+				(status) -> {
+					assertStatus(status, YamlConversionStatus.ERROR,
+							"Direct assignment 'some.property=a-scalar' can not be combined with sub-property assignment 'some.property.abc...'. ");
+					assertStatus(status, YamlConversionStatus.ERROR,
+							"'some.property' has some entries that look like list items and others that look like map entries");
+				}
+		);
+	}
+
+	private void doConversionTest(String input, String expectedOutput) throws Exception {
+		do_conversionTest(input, expectedOutput, (status) -> {
+			assertThat(status.getSeverity()).isEqualTo(YamlConversionStatus.OK);
+		});
+	}
+
+	private void do_conversionTest(String input, String expectedOutput, Checker<YamlConversionStatus> statusChecker) throws Exception {
+		do_conversionTest(Mode.DEFAULT, input, expectedOutput, statusChecker);
+	}
+
+	private void do_conversionTest(Mode mode, String input, String expectedOutput, Checker<YamlConversionStatus> statusChecker) throws Exception {
+		do_conversionTest(mode, null, input, expectedOutput, statusChecker);
+	}
+
+	private void do_conversionTest(Mode mode, List<String> keyspaces, String input, String expectedOutput, Checker<YamlConversionStatus> statusChecker) throws Exception {
+		File propertiesFile = createFile("application.properties", input);
+		assertThat(propertiesFile.exists()).isTrue();
+		Builder builder = YamlConverter.builder().mode(mode).file(propertiesFile);
+		if (keyspaces != null) {
+			for (String keyspace : keyspaces) {
+				builder.flat(keyspace);
+			}
+		}
+		YamlConversionResult result = builder.build().convert();
+		statusChecker.check(result.getStatus());
+		assertThat(result.getYaml()).isEqualTo(expectedOutput);
+	}
+
+	private void doMapConversionTest(Map<String, String> input, String expectedOutput) throws Exception {
+		do_mapConversionTest(input, expectedOutput, (status) -> {
+			assertThat(status.getSeverity()).isEqualTo(YamlConversionStatus.OK);
+		});
+	}
+
+	private void do_mapConversionTest(Map<String, String> input, String expectedOutput, Checker<YamlConversionStatus> statusChecker) throws Exception {
+		YamlConversionResult result = YamlConverter.builder().map(input).build().convert();
+		statusChecker.check(result.getStatus());
+		assertThat(result.getYaml()).isEqualTo(expectedOutput);
+	}
+
+	private File createFile(String prefix, String content) {
+		try {
+			File file = File.createTempFile(prefix, null);
+			BufferedWriter bw = new BufferedWriter(new FileWriter(file));
+			bw.append(content);
+			bw.close();
+			return file;
+		}
+		catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private String do_hasComments_test(String comment) throws Exception {
+		File propsFile = createFile("application.properties",
+				"some.property=somevalue\n" +
+				comment + "\n" +
+				"other.property=othervalue"
+		);
+		YamlConversionResult result = YamlConverter.builder().file(propsFile).build().convert();
+		assertStatus(result.getStatus(), YamlConversionStatus.WARNING, "has comments, which will be lost");
+		return result.getYaml();
+	}
+
+	private void assertOkStatus(YamlConversionStatus s) {
+		assertThat(s.getSeverity()).isEqualTo(YamlConversionStatus.OK);
+	}
+
+	private void assertStatus(YamlConversionStatus status, int expectedSeverity, String expectedMessageFragment) {
+		assertThat(status.getSeverity()).isEqualTo(expectedSeverity);
+		StringBuilder allMessages = new StringBuilder();
+		for (ConversionMessage entry : status.getEntries()) {
+			allMessages.append(entry.getMessage());
+			allMessages.append("\n-------------\n");
+		}
+		assertContains(expectedMessageFragment, allMessages.toString());
+	}
+
+	private void assertContains(String required, String inData) {
+		assert inData.indexOf(required) != -1;
+	}
+
+	public interface Checker<T> {
+		void check(T it) throws Exception;
+	}
+}


### PR DESCRIPTION
- Based on existing sample/poc code from sts people.
- Polish that code for skipper build.
- Add concepts to flatten properties.
- Bring over relevant parts of DeploymentPropertiesUtils from dataflow
  to easy one line properties parsing.
- Still keep YamlUtils around but remove all parsing/replacing hacks in it
  based on flattening support in a parser.
- Remove props2yaml
- Fixes #236