### PR TITLE
Overhaul about info

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.cloud.skipper.domain.AboutInfo;
+import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -114,8 +114,8 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public AboutInfo info() {
-		return this.restTemplate.getForObject(baseUri + "/about", AboutInfo.class);
+	public AboutResource info() {
+		return this.restTemplate.getForObject(baseUri + "/about", AboutResource.class);
 	}
 
 	@Override

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.springframework.cloud.skipper.client;
 
 import java.util.List;
 
-import org.springframework.cloud.skipper.domain.AboutInfo;
+import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -50,7 +50,7 @@ public interface SkipperClient {
 	/**
 	 * @return The AboutInfo for the server
 	 */
-	AboutInfo info();
+	AboutResource info();
 
 	/**
 	 * Search for package metadata.
@@ -74,7 +74,7 @@ public interface SkipperClient {
 	 */
 	Release upgrade(UpgradeRequest upgradeRequest);
 
-	/*
+	/**
 	 * Upload the package.
 	 *
 	 * @param uploadRequest the properties for the package upload

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,11 @@ import org.springframework.cloud.skipper.io.DefaultPackageReader;
 import org.springframework.cloud.skipper.io.DefaultPackageWriter;
 import org.springframework.cloud.skipper.io.PackageReader;
 import org.springframework.cloud.skipper.io.PackageWriter;
+import org.springframework.cloud.skipper.server.controller.AboutController;
 import org.springframework.cloud.skipper.server.controller.RootController;
 import org.springframework.cloud.skipper.server.controller.SkipperController;
 import org.springframework.cloud.skipper.server.controller.SkipperErrorAttributes;
+import org.springframework.cloud.skipper.server.controller.VersionInfoProperties;
 import org.springframework.cloud.skipper.server.deployer.AppDeployerReleaseManager;
 import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalyzer;
@@ -94,9 +96,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * @author Donovan Muller
  */
 @Configuration
-@EnableConfigurationProperties({ SkipperServerProperties.class,
-		LocalPlatformProperties.class, MavenConfigurationProperties.class,
-		HealthCheckProperties.class })
+@EnableConfigurationProperties({ SkipperServerProperties.class, VersionInfoProperties.class,
+		LocalPlatformProperties.class, MavenConfigurationProperties.class, HealthCheckProperties.class })
 @EntityScan({ "org.springframework.cloud.skipper.domain",
 		"org.springframework.cloud.skipper.server.domain" })
 @EnableMapRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
@@ -136,6 +137,11 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 	public SkipperController skipperController(ReleaseService releaseService, PackageService packageService,
 			SkipperStateMachineService skipperStateMachineService) {
 		return new SkipperController(releaseService, packageService, skipperStateMachineService);
+	}
+
+	@Bean
+	public AboutController aboutController(VersionInfoProperties versionInfoProperties) {
+		return new AboutController(versionInfoProperties);
 	}
 
 	@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/AboutController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/AboutController.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.controller;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.domain.AboutResource;
+import org.springframework.cloud.skipper.domain.Dependency;
+import org.springframework.cloud.skipper.domain.VersionInfo;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * REST controller that provides meta information regarding the skipper server.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@RestController
+@RequestMapping("/api/about")
+public class AboutController {
+
+	private static final Logger logger = LoggerFactory.getLogger(AboutController.class);
+	private final VersionInfoProperties versionInfoProperties;
+
+	public AboutController(VersionInfoProperties versionInfoProperties) {
+		this.versionInfoProperties = versionInfoProperties;
+	}
+
+	/**
+	 * Return meta information about the Skipper server.
+	 *
+	 * @return Detailed information about the enabled features, versions of implementation
+	 * libraries, and security configuration
+	 */
+	@RequestMapping(method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public AboutResource getAboutResource() {
+		final AboutResource aboutResource = new AboutResource();
+		final VersionInfo versionInfo = getVersionInfo();
+		aboutResource.setVersionInfo(versionInfo);
+		return aboutResource;
+	}
+
+	private VersionInfo getVersionInfo() {
+		final VersionInfo versionInfo = new VersionInfo();
+
+		updateDependency(versionInfo.getServer(),
+				versionInfoProperties.getDependencies().getSpringCloudSkipperServer());
+		updateDependency(versionInfo.getShell(),
+				versionInfoProperties.getDependencies().getSpringCloudSkipperShell());
+
+		if (versionInfoProperties.getDependencyFetch().isEnabled()) {
+			versionInfo.getShell().setChecksumSha1(getChecksum(
+					versionInfoProperties.getDependencies().getSpringCloudSkipperShell().getChecksumSha1(),
+					versionInfoProperties.getDependencies().getSpringCloudSkipperShell().getChecksumSha1Url(),
+					versionInfoProperties.getDependencies().getSpringCloudSkipperShell().getVersion()));
+			versionInfo.getShell().setChecksumSha256(getChecksum(
+					versionInfoProperties.getDependencies().getSpringCloudSkipperShell().getChecksumSha256(),
+					versionInfoProperties.getDependencies().getSpringCloudSkipperShell().getChecksumSha256Url(),
+					versionInfoProperties.getDependencies().getSpringCloudSkipperShell().getVersion()));
+		}
+		return versionInfo;
+	}
+
+	private String getChecksum(String defaultValue, String url,
+			String version) {
+		String result = defaultValue;
+		if (result == null && StringUtils.hasText(url)) {
+			CloseableHttpClient httpClient = HttpClients.custom()
+					.setSSLHostnameVerifier(new NoopHostnameVerifier())
+					.build();
+			HttpComponentsClientHttpRequestFactory requestFactory
+					= new HttpComponentsClientHttpRequestFactory();
+			requestFactory.setHttpClient(httpClient);
+			url = constructUrl(url, version);
+			try {
+				ResponseEntity<String> response
+						= new RestTemplate(requestFactory).exchange(
+						url, HttpMethod.GET, null, String.class);
+				if (response.getStatusCode().equals(HttpStatus.OK)) {
+					result = response.getBody();
+				}
+			}
+			catch (HttpClientErrorException httpException) {
+				// no action necessary set result to undefined
+				logger.debug("Didn't retrieve checksum because", httpException);
+			}
+		}
+		return result;
+	}
+
+	private void updateDependency(Dependency dependency, VersionInfoProperties.DependencyAboutInfo dependencyAboutInfo) {
+		dependency.setName(dependencyAboutInfo.getName());
+		if (dependencyAboutInfo.getUrl() != null) {
+			dependency.setUrl(constructUrl(dependencyAboutInfo.getUrl(),
+					dependencyAboutInfo.getVersion()));
+		}
+		dependency.setVersion(dependencyAboutInfo.getVersion());
+	}
+
+	private String constructUrl(String url, String version) {
+		final String VERSION_TAG = "{version}";
+		final String REPOSITORY_TAG = "{repository}";
+		if (url.contains(VERSION_TAG)) {
+			url = StringUtils.replace(url, VERSION_TAG, version);
+			url = StringUtils.replace(url, REPOSITORY_TAG, repoSelector(version));
+		}
+		return url;
+	}
+
+	private String repoSelector(String version) {
+		final String BUILD_SNAPSHOT_CRITERIA = "BUILD-SNAPSHOT";
+		final String REPO_SNAPSHOT_ROOT = "https://repo.spring.io/libs-snapshot";
+		final String REPO_MILESTONE_ROOT = "https://repo.spring.io/libs-milestone";
+		final String REPO_RELEASE_ROOT = "https://repo.spring.io/libs-release";
+		final String MAVEN_ROOT = "https://repo1.maven.org/maven2";
+		String result = MAVEN_ROOT;
+		if (version.endsWith(BUILD_SNAPSHOT_CRITERIA)) {
+			result = REPO_SNAPSHOT_ROOT;
+		}
+		else if (version.contains(".M")) {
+			result = REPO_MILESTONE_ROOT;
+		}
+		else if (version.contains(".RC")) {
+			result = REPO_RELEASE_ROOT;
+		}
+		return result;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperController.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
-import org.springframework.cloud.skipper.domain.AboutInfo;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -68,12 +67,6 @@ public class SkipperController {
 		this.releaseService = releaseService;
 		this.packageService = packageService;
 		this.skipperStateMachineService = skipperStateMachineService;
-	}
-
-	@RequestMapping(path = "/about", method = RequestMethod.GET)
-	@ResponseStatus(HttpStatus.OK)
-	public AboutInfo getAboutInfo() {
-		return new AboutInfo(appName, appVersion);
 	}
 
 	@RequestMapping(path = "/upload", method = RequestMethod.POST)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/VersionInfoProperties.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/VersionInfoProperties.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.controller;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties for version information of core dependencies.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(prefix = VersionInfoProperties.VERSION_INFO_PREFIX)
+public class VersionInfoProperties {
+
+	public static final String VERSION_INFO_PREFIX = "spring.cloud.skipper.server.version-info";
+
+	private DependencyStatus dependencyFetch;
+
+	private Dependencies dependencies;
+
+	/**
+	 * @return instance of a {@link DependencyStatus} that determines if
+	 * checksum information should be returned.
+	 */
+	public DependencyStatus getDependencyFetch() {
+		return dependencyFetch;
+	}
+
+	/**
+	 * Establish whether checksum information should be returned.
+	 *
+	 * @param dependencyFetch instance of {@link DependencyStatus}
+	 */
+	public void setDependencyFetch(DependencyStatus dependencyFetch) {
+		this.dependencyFetch = dependencyFetch;
+	}
+
+	/**
+	 *
+	 * @return an instance of {@link Dependencies} containing about information
+	 * about dependencies.
+	 */
+	public Dependencies getDependencies() {
+		return dependencies;
+	}
+
+	/**
+	 * Establishes the {@link Dependencies} instance that contains information
+	 * about the dependencies.
+	 *
+	 * @param dependencies instance of {@link Dependencies}
+	 */
+	public void setDependencies(Dependencies dependencies) {
+		this.dependencies = dependencies;
+	}
+
+
+	/**
+	 * Represents whether dependency information should be returned as a part
+	 * of the about result set.
+	 */
+	public static class DependencyStatus {
+		private boolean enabled;
+
+		/**
+		 * @return true if dependencies should be returned.
+		 * False if dependencies should not be returned.
+		 */
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		/**
+		 * Establishes if dependencies should returned.
+		 *
+		 * @param enabled true if dependencies should be returned, otherwise false.
+		 */
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+	}
+
+	/**
+	 * The dependencies that will be returned by the about controller.
+	 */
+	public static class Dependencies {
+		private DependencyAboutInfo springCloudSkipperShell;
+
+		private DependencyAboutInfo springCloudSkipperServer;
+
+		/**
+		 * @return {@link DependencyAboutInfo} for the shell.
+		 */
+		public DependencyAboutInfo getSpringCloudSkipperShell() {
+			return springCloudSkipperShell;
+		}
+
+		/**
+		 * Establish the {@link DependencyAboutInfo} for the shell.
+		 *
+		 * @param springCloudSkipperShell the {@link DependencyAboutInfo} containing information about the shell.
+		 */
+		public void setSpringCloudSkipperShell(DependencyAboutInfo springCloudSkipperShell) {
+			this.springCloudSkipperShell = springCloudSkipperShell;
+		}
+
+		/**
+		 * @return {@link DependencyAboutInfo} for the core.
+		 */
+		public DependencyAboutInfo getSpringCloudSkipperServer() {
+			return springCloudSkipperServer;
+		}
+
+		/**
+		 * Establish the {@link DependencyAboutInfo} for the core.
+		 *
+		 * @param springCloudSkipperServer the {@link DependencyAboutInfo} containing information about the core.
+		 */
+		public void setSpringCloudSkipperServer(DependencyAboutInfo springCloudSkipperServer) {
+			this.springCloudSkipperServer = springCloudSkipperServer;
+		}
+	}
+
+	/**
+	 * Information about the dependency.
+	 */
+	public static class DependencyAboutInfo {
+		private String name;
+
+		private String version;
+
+		private String url;
+
+		private String checksumSha1;
+
+		private String checksumSha1Url;
+
+		private String checksumSha256;
+
+		private String checksumSha256Url;
+
+		/**
+		 *
+		 * @return the display name of the dependency.
+		 */
+		public String getName() {
+			return name;
+		}
+
+		/**
+		 * Establish the display name for the dependency.
+		 *
+		 * @param name String containing the name to be displayed.
+		 */
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		/**
+		 *
+		 * @return the version of the dependency.
+		 */
+		public String getVersion() {
+			return version;
+		}
+
+		/**
+		 * Establish the version for the dependency.
+		 *
+		 * @param version String containing the version.
+		 */
+		public void setVersion(String version) {
+			this.version = version;
+		}
+
+		/**
+		 *
+		 * @return the url of the dependency.
+		 */
+		public String getUrl() {
+			return url;
+		}
+
+		/**
+		 * Establish the url for the dependency.
+		 *
+		 * @param url String containing the url.
+		 */
+		public void setUrl(String url) {
+			this.url = url;
+		}
+
+		/**
+		 *
+		 * @return the sha1 encoding that should be returned for the dependency.
+		 */
+		public String getChecksumSha1() {
+			return checksumSha1;
+		}
+
+		/**
+		 * Establish the checksumSha1 for the dependency.
+		 *
+		 * @param checksumSha1 String containing the checksum value.
+		 */
+		public void setChecksumSha1(String checksumSha1) {
+			this.checksumSha1 = checksumSha1;
+		}
+
+		/**
+		 *
+		 * @return the url to the file that contains the sha1 checksum.
+		 */
+		public String getChecksumSha1Url() {
+			return checksumSha1Url;
+		}
+
+		/**
+		 * Establish the url where the checksumSha1 file exists..
+		 *
+		 * @param checksumSha1Url String containing the url.
+		 */
+		public void setChecksumSha1Url(String checksumSha1Url) {
+			this.checksumSha1Url = checksumSha1Url;
+		}
+
+		/**
+		 *
+		 * @return the sha256 encoding that should be returned for the dependency.
+		 */
+		public String getChecksumSha256() {
+			return checksumSha256;
+		}
+
+		/**
+		 * Establish the checksumSha256 for the dependency.
+		 *
+		 * @param checksumSha256 String containing the checksum value.
+		 */
+		public void setChecksumSha256(String checksumSha256) {
+			this.checksumSha256 = checksumSha256;
+		}
+
+		/**
+		 *
+		 * @return the url to the file that contains the sha256 checksum.
+		 */
+		public String getChecksumSha256Url() {
+			return checksumSha256Url;
+		}
+
+		/**
+		 * Establish the url where the checksumSha256 file exists..
+		 *
+		 * @param checksumSha256Url String containing the url.
+		 */
+		public void setChecksumSha256Url(String checksumSha256Url) {
+			this.checksumSha256Url = checksumSha256Url;
+		}
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/index/SkipperControllerResourceProcessor.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/index/SkipperControllerResourceProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.index;
 
+import org.springframework.cloud.skipper.server.controller.AboutController;
 import org.springframework.cloud.skipper.server.controller.SkipperController;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.hateoas.ResourceProcessor;
@@ -32,7 +33,7 @@ public class SkipperControllerResourceProcessor implements ResourceProcessor<Rep
 
 	@Override
 	public RepositoryLinksResource process(RepositoryLinksResource resource) {
-		resource.add(ControllerLinkBuilder.linkTo(methodOn(SkipperController.class).getAboutInfo()).withRel("about"));
+		resource.add(ControllerLinkBuilder.linkTo(methodOn(AboutController.class).getAboutResource()).withRel("about"));
 		resource.add(ControllerLinkBuilder.linkTo(methodOn(SkipperController.class).upload(null)).withRel("upload"));
 		resource.add(ControllerLinkBuilder.linkTo(methodOn(SkipperController.class).install(null)).withRel("install"));
 		resource.add(ControllerLinkBuilder.linkTo(methodOn(SkipperController.class).install(null, null))

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -22,6 +22,19 @@ spring:
   cloud:
     skipper:
       server:
+        version-info:
+          dependency-fetch:
+            enabled: false
+          dependencies:
+            spring-cloud-skipper-server:
+              name: Spring Cloud Skipper Server
+              version: "@project.version@"
+            spring-cloud-skipper-shell:
+              name: Spring Cloud Skipper Shell
+              version: "@project.version@"
+              url: "{repository}/org/springframework/cloud/spring-cloud-skipper-shell/{version}/spring-cloud-skipper-shell-{version}.jar"
+              checksum-sha1-url: "{repository}/org/springframework/cloud/spring-cloud-skipper-shell/{version}/spring-cloud-skipper-shell-{version}.jar.sha1"
+              checksum-sha256-url: "{repository}/org/springframework/cloud/spring-cloud-skipper-shell/{version}/spring-cloud-skipper-shell-{version}.jar.sha256"
         packageRepositories:
           -
             name: experimental

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/AboutDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/AboutDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,10 @@ public class AboutDocumentation extends BaseDocumentation {
 		this.mockMvc.perform(get("/api/about").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						responseFields(
-								fieldWithPath("name").description("Name of the Skipper server."),
-								fieldWithPath("version").description(
-										"Version of the Skipper server."))));
+								fieldWithPath("versionInfo.server.name").description("Spring Cloud Skipper Server dependency."),
+								fieldWithPath("versionInfo.server.version").description("Spring Cloud Skipper Server dependency version."),
+								fieldWithPath("versionInfo.shell.name").description("Spring Cloud Skipper Shell dependency."),
+								fieldWithPath("versionInfo.shell.version").description("Spring Cloud Skipper Shell dependency version."),
+								fieldWithPath("links").description("Links."))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/application.yml
@@ -14,6 +14,20 @@ spring:
     generate-ddl: true
     hibernate:
       ddl-auto: create
+  cloud:
+    skipper:
+      server:
+        version-info:
+          dependency-fetch:
+            enabled: false
+          dependencies:
+            spring-cloud-skipper-server:
+              name: Spring Cloud Skipper Server
+              version: fake-server-version
+            spring-cloud-skipper-shell:
+              name: Spring Cloud Skipper Shell
+              version: fake-shell-version
+
 
 maven:
   remoteRepositories:

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/local/security/LocalServerSecurityWithOAuth2Tests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/local/security/LocalServerSecurityWithOAuth2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,8 +148,8 @@ public class LocalServerSecurityWithOAuth2Tests {
 		localSkipperResource.getMockMvc()
 				.perform(get("/api/about").header("Authorization", "bearer " + accessTokenAsString)).andDo(print())
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.name", is("spring-cloud-skipper-server-core")))
-				.andExpect(jsonPath("$.version", notNullValue()));
+				.andExpect(jsonPath("$.versionInfo.server.name", is("Spring Cloud Skipper Server")))
+				.andExpect(jsonPath("$.versionInfo.server.version", notNullValue()));
 	}
 
 	@Test

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ConfigCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ConfigCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.springframework.cloud.skipper.shell.command;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.client.SkipperServerException;
-import org.springframework.cloud.skipper.domain.AboutInfo;
+import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.shell.command.support.ConsoleUserInput;
 import org.springframework.cloud.skipper.shell.command.support.Target;
 import org.springframework.cloud.skipper.shell.command.support.TargetHolder;
@@ -86,7 +86,7 @@ public class ConfigCommands extends AbstractSkipperCommand {
 	}
 
 	@ShellMethod(key = "info", value = "Show the Skipper server being used.")
-	public AboutInfo info() {
+	public AboutResource info() {
 		Target target = targetHolder.getTarget();
 		if (target.getTargetException() != null) {
 			throw new SkipperServerException(this.targetHolder.getTarget().getTargetResultMessage());

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/AboutResource.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/AboutResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,36 +15,34 @@
  */
 package org.springframework.cloud.skipper.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.hateoas.ResourceSupport;
 
 /**
- * This contains information about the underlying Skipper server.
+ * Provides meta-information about the Spring Cloud Skipper server.
  *
- * @author Mark Pollack
+ * @author Janne Valkealahti
+ *
  */
-public class AboutInfo {
+public class AboutResource extends ResourceSupport {
 
-	private String version;
+	private VersionInfo versionInfo = new VersionInfo();
 
-	private String name;
-
-	@JsonCreator
-	public AboutInfo(@JsonProperty("name") String name, @JsonProperty("version") String version) {
-		this.name = name;
-		this.version = version;
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public AboutResource() {
 	}
 
-	public String getVersion() {
-		return version;
+	public VersionInfo getVersionInfo() {
+		return versionInfo;
 	}
 
-	public String getName() {
-		return name;
+	public void setVersionInfo(VersionInfo versionInfo) {
+		this.versionInfo = versionInfo;
 	}
 
 	@Override
 	public String toString() {
-		return name + " v" + version;
+		return getVersionInfo().getServer().getName() + " v" + getVersionInfo().getServer().getVersion();
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Dependency.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Dependency.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Holds dependency information of a libraries used by Spring Cloud Skipper.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class Dependency {
+
+	private String name;
+
+	private String version;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String checksumSha1;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String checksumSha256;
+
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String url;
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public Dependency() {
+	}
+
+	public Dependency(String name, String version, String checksumsha1,
+			String checksumsha256, String url) {
+		super();
+		this.name = name;
+		this.version = version;
+		this.checksumSha1 = checksumsha1;
+		this.checksumSha256 = checksumsha256;
+		this.url = url;
+	}
+
+	/**
+	 * Retrieve the current name for the {@link Dependency}
+
+	 * @return the name for the {@link Dependency}
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Establish the name for the {@link Dependency}.
+	 *
+	 * @param name {@link String} representing the name.
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * Retrieve the current version for the {@link Dependency}
+	 *
+	 * @return the version for the {@link Dependency}
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * Establish the version for the {@link Dependency}.
+	 *
+	 * @param version {@link String} representing the version.
+	 */
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	/**
+	 * Retrieve the current checksumSha1 for the {@link Dependency}
+	 *
+	 * @return the checksumSha1 for the {@link Dependency}
+	 */
+	public String getChecksumSha1() {
+		return checksumSha1;
+	}
+
+	/**
+	 * Establish the checksumSha1 for the {@link Dependency}.
+	 *
+	 * @param checksumSha1 {@link String} representing the checksumSha1.
+	 */
+	public void setChecksumSha1(String checksumSha1)
+	{
+		this.checksumSha1 = checksumSha1;
+	}
+
+	/**
+	 * Retrieve the current url for the {@link Dependency}
+	 *
+	 * @return the url for the {@link Dependency}
+	 */
+	public String getUrl() {
+		return url;
+	}
+
+	/**
+	 * Establish the url for the {@link Dependency}.
+	 *
+	 * @param url {@link String} representing the url.
+	 */
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	/**
+	 * Retrieve the current checksumSha256 for the {@link Dependency}
+	 *
+	 * @return the checksumSha256 for the {@link Dependency}
+	 */
+	public String getChecksumSha256() {
+		return checksumSha256;
+	}
+
+	/**
+	 * Establish the checksumSha1256 for the {@link Dependency}.
+	 *
+	 * @param checksumSha256 {@link String} representing the checksumSha256.
+	 */
+	public void setChecksumSha256(String checksumSha256) {
+		this.checksumSha256 = checksumSha256;
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/VersionInfo.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/VersionInfo.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+/**
+ * Provides version information about core libraries used.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class VersionInfo {
+
+	private Dependency server = new Dependency();
+
+	private Dependency shell = new Dependency();
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	public VersionInfo() {
+	}
+
+	/**
+	 * Retrieves the current {@link Dependency} for the core Data Flow instance.
+	 *
+	 * @return {@link Dependency} instance containing core Data Flow information.
+	 */
+	public Dependency getServer() {
+		return server;
+	}
+
+	/**
+	 * Establish the {@link Dependency} for the Skipper server.
+	 *
+	 * @param core the {@link Dependency} instance for the Skipper server.
+	 */
+	public void setServer(Dependency server) {
+		this.server = server;
+	}
+
+	/**
+	 * Retrieves the current {@link Dependency} for the shell instance.
+	 *
+	 * @return {@link Dependency} instance containing shell information.
+	 */
+	public Dependency getShell() {
+		return shell;
+	}
+
+	/**
+	 * Establish the {@link Dependency} for the shell.
+	 *
+	 * @param shell the {@link Dependency} instance for the shell.
+	 */
+	public void setShell(Dependency shell) {
+		this.shell = shell;
+	}
+}


### PR DESCRIPTION
- Similarly like in a dataflow, add new AboutController
  and facilities around it to provide dependencies versions
  for server and shell.
- Keep new domain classes in a shared package.
- Fix shell command usage for new replaced /api/about
- HAL links will be added later.
- Fixes #423 
http://localhost:7577/api/about
```
{
  "versionInfo": {
    "server": {
      "name": "Spring Cloud Skipper Server",
      "version": "1.0.0.BUILD-SNAPSHOT"
    },
    "shell": {
      "name": "Spring Cloud Skipper Shell",
      "version": "1.0.0.BUILD-SNAPSHOT",
      "url": "https://repo.spring.io/libs-snapshot/org/springframework/cloud/spring-cloud-skipper-shell/1.0.0.BUILD-SNAPSHOT/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar"
    }
  }
}
```

With `--spring.cloud.skipper.server.version-info.dependency-fetch.enabled=true` you then get:
```
{
  "versionInfo": {
    "server": {
      "name": "Spring Cloud Skipper Server",
      "version": "1.0.0.BUILD-SNAPSHOT"
    },
    "shell": {
      "name": "Spring Cloud Skipper Shell",
      "version": "1.0.0.BUILD-SNAPSHOT",
      "checksumSha1": "e209a95cf4521cce647f06da0e0611a39e33dddf",
      "checksumSha256": "09925d262c845263a1f0c350fad10594299203655f5268983e6243c8b887222b",
      "url": "https://repo.spring.io/libs-snapshot/org/springframework/cloud/spring-cloud-skipper-shell/1.0.0.BUILD-SNAPSHOT/spring-cloud-skipper-shell-1.0.0.BUILD-SNAPSHOT.jar"
    }
  }
}
```
