### PR TITLE
Add Repository name to PackageMetadata, update equals update finders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <spring-shell.version>2.0.0.M2</spring-shell.version>
         <spring-statemachine.version>1.2.8.RC1</spring-statemachine.version>
         <jsonpath.version>2.2.0</jsonpath.version>
+        <equalverifier.version>2.4.1</equalverifier.version>
 
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <surefire-maven-plugin.version>2.20</surefire-maven-plugin.version>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/PackageSummary.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/PackageSummary.java
@@ -40,4 +40,6 @@ public interface PackageSummary {
 	String getIconUrl();
 
 	String getDescription();
+
+	String getRepositoryName();
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepository.java
@@ -41,7 +41,11 @@ public interface PackageMetadataRepository extends PagingAndSortingRepository<Pa
 	PackageMetadata findFirstByNameOrderByVersionDesc(@Param("name") String name);
 
 	PackageMetadata findByRepositoryIdAndNameAndVersion(@Param("repositoryId") Long repositoryId,
-														@Param("name") String name,
-														@Param("version") String version);
+			@Param("name") String name,
+			@Param("version") String version);
+
+	PackageMetadata findByRepositoryNameAndNameAndVersion(@Param("repositoryName") String repositoryName,
+			@Param("name") String name,
+			@Param("version") String version);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageMetadataService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageMetadataService.java
@@ -80,6 +80,7 @@ public class PackageMetadataService implements ResourceLoaderAware {
 									downloadedFileAsList);
 							for (PackageMetadata packageMetadata : downloadedPackageMetadata) {
 								packageMetadata.setRepositoryId(packageRepository.getId());
+								packageMetadata.setRepositoryName(packageRepository.getName());
 							}
 							finalMetadataList.addAll(downloadedPackageMetadata);
 						}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageService.java
@@ -220,9 +220,9 @@ public class PackageService implements ResourceLoaderAware {
 			Assert.isTrue(unpackagedFile.exists(), "Package is expected to be unpacked, but it doesn't exist");
 			Package packageToUpload = this.packageReader.read(unpackagedFile);
 			PackageMetadata packageMetadata = packageToUpload.getMetadata();
-			// TODO: Model the PackageMetadata -> Repository relationship in the DB.
 			if (localRepositoryToUpload != null) {
 				packageMetadata.setRepositoryId(localRepositoryToUpload.getId());
+				packageMetadata.setRepositoryName(localRepositoryToUpload.getName());
 			}
 			packageMetadata.setPackageFileBytes(uploadRequest.getPackageFileAsBytes());
 			return this.packageMetadataRepository.save(packageMetadata);
@@ -261,16 +261,13 @@ public class PackageService implements ResourceLoaderAware {
 		Assert.notNull(uploadRequest.getPackageFileAsBytes(), "Package file as bytes must not be null");
 		Assert.isTrue(uploadRequest.getPackageFileAsBytes().length != 0, "Package file as bytes must not be empty");
 
-		Repository repository = this.repositoryRepository.findByName(uploadRequest.getRepoName());
-		if (repository != null) {
-			PackageMetadata existingPackageMetadata = this.packageMetadataRepository.findByRepositoryIdAndNameAndVersion(
-					repository.getId(), uploadRequest.getName(), uploadRequest.getVersion());
+		PackageMetadata existingPackageMetadata = this.packageMetadataRepository.findByRepositoryNameAndNameAndVersion(
+				uploadRequest.getRepoName().trim(), uploadRequest.getName().trim(), uploadRequest.getVersion().trim());
 
-			if (existingPackageMetadata != null) {
-				throw new SkipperException(String.format("Failed to upload the package. " + "" +
-						"Package [%s:%s] in Repository [%s] already exists.",
-						uploadRequest.getName(), uploadRequest.getVersion(), repository.getName()));
-			}
+		if (existingPackageMetadata != null) {
+			throw new SkipperException(String.format("Failed to upload the package. " + "" +
+					"Package [%s:%s] in Repository [%s] already exists.",
+					uploadRequest.getName(), uploadRequest.getVersion(), uploadRequest.getRepoName().trim()));
 		}
 	}
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -71,7 +71,9 @@ public class DeleteDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.origin")
 										.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("pkg.metadata.repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to."),
+								fieldWithPath("pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
@@ -72,7 +72,9 @@ public class HistoryDocumentation extends BaseDocumentation {
 								fieldWithPath("[].pkg.metadata.origin")
 								.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("[].pkg.metadata.repositoryId")
-								.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to"),
+								fieldWithPath("[].pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("[].pkg.metadata.kind")
 								.description("What type of package system is being used"),
 								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
@@ -78,7 +78,9 @@ public class InstallDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.apiVersion")
 										.description("The Package Index spec version this file is based on"),
 								fieldWithPath("pkg.metadata.repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to"),
+								fieldWithPath("pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),
@@ -155,7 +157,9 @@ public class InstallDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.origin")
 										.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("pkg.metadata.repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to"),
+								fieldWithPath("pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
@@ -74,7 +74,9 @@ public class ListDocumentation extends BaseDocumentation {
 								fieldWithPath("[].pkg.metadata.origin")
 										.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("[].pkg.metadata.repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to"),
+								fieldWithPath("[].pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("[].pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),
@@ -145,7 +147,9 @@ public class ListDocumentation extends BaseDocumentation {
 								fieldWithPath("[].pkg.metadata.origin")
 										.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("[].pkg.metadata.repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to"),
+								fieldWithPath("[].pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("[].pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("[].pkg.metadata.name").description("The name of the package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
@@ -52,7 +52,9 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.packageMetadata[].origin")
 										.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("_embedded.packageMetadata[].repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to"),
+								fieldWithPath("_embedded.packageMetadata[].repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("_embedded.packageMetadata[].kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("_embedded.packageMetadata[].name")
@@ -100,7 +102,9 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 								fieldWithPath("origin")
 										.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to."),
+								fieldWithPath("repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("kind").description("What type of package system is being used"),
 								fieldWithPath("name").description("The name of the package"),
 								fieldWithPath("displayName").description("The display name of the package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
@@ -74,7 +74,9 @@ public class RollbackDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.origin")
 										.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("pkg.metadata.repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to."),
+								fieldWithPath("pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
@@ -94,7 +94,9 @@ public class UpgradeDocumentation extends BaseDocumentation {
 								fieldWithPath("pkg.metadata.origin")
 										.description("Indicates the origin of the repository (free form text)"),
 								fieldWithPath("pkg.metadata.repositoryId")
-										.description("The repository ID this Package Index file belongs to"),
+										.description("The repository ID this Package belongs to."),
+								fieldWithPath("pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
 								fieldWithPath("pkg.metadata.kind")
 										.description("What type of package system is being used"),
 								fieldWithPath("pkg.metadata.name").description("The name of the package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UploadDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UploadDocumentation.java
@@ -81,7 +81,9 @@ public class UploadDocumentation extends BaseDocumentation {
 										fieldWithPath("origin")
 												.description("Indicates the origin of the repository (free form text)"),
 										fieldWithPath("repositoryId")
-												.description("The repository ID this Package Index file belongs to"),
+												.description("The repository ID this Package belongs to."),
+										fieldWithPath("repositoryName")
+												.description("The repository nane this Package belongs to."),
 										fieldWithPath("kind").description("What type of package system is being used"),
 										fieldWithPath("name").description("The name of the package"),
 										fieldWithPath("displayName").description("The display name of the package"),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataCreator.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataCreator.java
@@ -22,11 +22,16 @@ import org.springframework.cloud.skipper.domain.PackageMetadata;
  */
 public class PackageMetadataCreator {
 
+	public static Long TEST_REPO_ID = 1L;
+	
+	public static String TEST_REPO_NAME = "testRepo";
+	
 	public static void createTwoPackages(PackageMetadataRepository repository) {
 		PackageMetadata packageMetadata = new PackageMetadata();
 		packageMetadata.setApiVersion("1");
 		packageMetadata.setOrigin("www.package-repos.com/repo1");
-		packageMetadata.setRepositoryId(1L);
+		packageMetadata.setRepositoryId(TEST_REPO_ID);
+		packageMetadata.setRepositoryName(TEST_REPO_NAME);
 		packageMetadata.setKind("skipper");
 		packageMetadata.setName("package1");
 		packageMetadata.setVersion("1.0.0");
@@ -36,7 +41,8 @@ public class PackageMetadataCreator {
 		repository.save(packageMetadata);
 		packageMetadata = new PackageMetadata();
 		packageMetadata.setApiVersion("1");
-		packageMetadata.setRepositoryId(1L);
+		packageMetadata.setRepositoryId(TEST_REPO_ID);
+		packageMetadata.setRepositoryName(TEST_REPO_NAME);
 		packageMetadata.setOrigin("www.package-repos.com/repo2");
 		packageMetadata.setKind("skipper");
 		packageMetadata.setName("package2");
@@ -50,7 +56,8 @@ public class PackageMetadataCreator {
 	public static void createPackageWithMultipleVersions(PackageMetadataRepository repository) {
 		PackageMetadata packageMetadata = new PackageMetadata();
 		packageMetadata.setApiVersion("1");
-		packageMetadata.setRepositoryId(1L);
+		packageMetadata.setRepositoryId(TEST_REPO_ID);
+		packageMetadata.setRepositoryName(TEST_REPO_NAME);
 		packageMetadata.setKind("skipper");
 		packageMetadata.setName("package1");
 		packageMetadata.setVersion("1.0.0");
@@ -60,7 +67,8 @@ public class PackageMetadataCreator {
 		repository.save(packageMetadata);
 		packageMetadata = new PackageMetadata();
 		packageMetadata.setApiVersion("1");
-		packageMetadata.setRepositoryId(1L);
+		packageMetadata.setRepositoryId(TEST_REPO_ID);
+		packageMetadata.setRepositoryName(TEST_REPO_NAME);
 		packageMetadata.setKind("skipper");
 		packageMetadata.setName("package1");
 		packageMetadata.setVersion("2.0.0");
@@ -70,7 +78,8 @@ public class PackageMetadataCreator {
 		repository.save(packageMetadata);
 		packageMetadata = new PackageMetadata();
 		packageMetadata.setApiVersion("1");
-		packageMetadata.setRepositoryId(1L);
+		packageMetadata.setRepositoryId(TEST_REPO_ID);
+		packageMetadata.setRepositoryName(TEST_REPO_NAME);
 		packageMetadata.setKind("skipper");
 		packageMetadata.setName("package2");
 		packageMetadata.setVersion("1.0.1");
@@ -80,7 +89,8 @@ public class PackageMetadataCreator {
 		repository.save(packageMetadata);
 		packageMetadata = new PackageMetadata();
 		packageMetadata.setApiVersion("1");
-		packageMetadata.setRepositoryId(1L);
+		packageMetadata.setRepositoryId(TEST_REPO_ID);
+		packageMetadata.setRepositoryName(TEST_REPO_NAME);
 		packageMetadata.setKind("skipper");
 		packageMetadata.setName("package2");
 		packageMetadata.setVersion("1.1.0");
@@ -94,6 +104,7 @@ public class PackageMetadataCreator {
 		PackageMetadata packageMetadata = new PackageMetadata();
 		packageMetadata.setApiVersion(apiVersion);
 		packageMetadata.setRepositoryId(repoId);
+		packageMetadata.setRepositoryName(TEST_REPO_NAME);
 		packageMetadata.setKind("skipper");
 		packageMetadata.setName("package1");
 		packageMetadata.setVersion("1.0.0");
@@ -104,6 +115,7 @@ public class PackageMetadataCreator {
 		packageMetadata = new PackageMetadata();
 		packageMetadata.setApiVersion(apiVersion);
 		packageMetadata.setRepositoryId(repoId);
+		packageMetadata.setRepositoryName(TEST_REPO_NAME);
 		packageMetadata.setKind("skipper");
 		packageMetadata.setName("package2");
 		packageMetadata.setVersion("2.0.0");

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepositoryTests.java
@@ -66,8 +66,10 @@ public class PackageMetadataRepositoryTests extends AbstractIntegrationTest {
 		PackageMetadata latestPackage2 = this.packageMetadataRepository.findFirstByNameOrderByVersionDesc("package2");
 		assertThat(latestPackage2.getVersion()).isEqualTo("1.1.0");
 
-		PackageMetadata aPackage = this.packageMetadataRepository.findByRepositoryIdAndNameAndVersion(1L,
-				"package1", "2.0.0");
+		PackageMetadata aPackage =
+				this.packageMetadataRepository.findByRepositoryNameAndNameAndVersion(
+						PackageMetadataCreator.TEST_REPO_NAME,
+						"package1", "2.0.0");
 		assertThat(aPackage.getVersion()).isEqualTo("2.0.0");
 
 	}

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/SkipperCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/SkipperCommands.java
@@ -145,6 +145,7 @@ public class SkipperCommands extends AbstractSkipperCommand {
 			headers.put("name", "Name");
 			headers.put("version", "Version");
 			headers.put("description", "Description");
+			headers.put("repositoryName","Repository Name");
 			TableModel model = new BeanListTableModel<>(resources.getContent(), headers);
 			TableBuilder tableBuilder = new TableBuilder(model);
 			TableUtils.applyStyle(tableBuilder);

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -57,6 +57,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>${equalverifier.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
             <version>0.23.0.RELEASE</version>

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -258,20 +258,20 @@ public class PackageMetadata extends AbstractEntity {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (!(o instanceof PackageMetadata)) return false;
 
 		PackageMetadata that = (PackageMetadata) o;
 
-		if (!repositoryId.equals(that.repositoryId)) return false;
-		if (!name.equals(that.name)) return false;
-		return version.equals(that.version);
+		if (repositoryId != null ? !repositoryId.equals(that.repositoryId) : that.repositoryId != null) return false;
+		if (name != null ? !name.equals(that.name) : that.name != null) return false;
+		return version != null ? version.equals(that.version) : that.version == null;
 	}
 
 	@Override
 	public int hashCode() {
-		int result = repositoryId.hashCode();
-		result = 31 * result + name.hashCode();
-		result = 31 * result + version.hashCode();
+		int result = repositoryId != null ? repositoryId.hashCode() : 0;
+		result = 31 * result + (name != null ? name.hashCode() : 0);
+		result = 31 * result + (version != null ? version.hashCode() : 0);
 		return result;
 	}
 

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/PackageMetadata.java
@@ -45,9 +45,16 @@ public class PackageMetadata extends AbstractEntity {
 	private String origin;
 
 	/**
-	 * The repository ID this Package Index file belongs to.
+	 * The repository ID this Package belongs to.
 	 */
+	@NotNull
 	private Long repositoryId;
+
+	/**
+	 * The repository name this Package belongs to.
+	 */
+	@NotNull
+	private String repositoryName;
 
 	/**
 	 * What type of package system is being used.
@@ -240,71 +247,31 @@ public class PackageMetadata extends AbstractEntity {
 		this.repositoryId = repositoryId;
 	}
 
+	public String getRepositoryName() {
+		return repositoryName;
+	}
+
+	public void setRepositoryName(String repositoryName) {
+		this.repositoryName = repositoryName;
+	}
+
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
 
 		PackageMetadata that = (PackageMetadata) o;
 
-		if (apiVersion != null ? !apiVersion.equals(that.apiVersion) : that.apiVersion != null) {
-			return false;
-		}
-		if (origin != null ? !origin.equals(that.origin) : that.origin != null) {
-			return false;
-		}
-		if (repositoryId != null ? !repositoryId.equals(that.repositoryId) : that.repositoryId != null) {
-			return false;
-		}
-		if (kind != null ? !kind.equals(that.kind) : that.kind != null) {
-			return false;
-		}
-		if (name != null ? !name.equals(that.name) : that.name != null) {
-			return false;
-		}
-		if (version != null ? !version.equals(that.version) : that.version != null) {
-			return false;
-		}
-		if (packageSourceUrl != null ? !packageSourceUrl.equals(that.packageSourceUrl)
-				: that.packageSourceUrl != null) {
-			return false;
-		}
-		if (packageHomeUrl != null ? !packageHomeUrl.equals(that.packageHomeUrl) : that.packageHomeUrl != null) {
-			return false;
-		}
-		if (tags != null ? !tags.equals(that.tags) : that.tags != null) {
-			return false;
-		}
-		if (maintainer != null ? !maintainer.equals(that.maintainer) : that.maintainer != null) {
-			return false;
-		}
-		if (description != null ? !description.equals(that.description) : that.description != null) {
-			return false;
-		}
-		if (sha256 != null ? !sha256.equals(that.sha256) : that.sha256 != null) {
-			return false;
-		}
-		return iconUrl != null ? iconUrl.equals(that.iconUrl) : that.iconUrl == null;
+		if (!repositoryId.equals(that.repositoryId)) return false;
+		if (!name.equals(that.name)) return false;
+		return version.equals(that.version);
 	}
 
 	@Override
 	public int hashCode() {
-		int result = apiVersion != null ? apiVersion.hashCode() : 0;
-		result = 31 * result + (origin != null ? origin.hashCode() : 0);
-		result = 31 * result + (kind != null ? kind.hashCode() : 0);
-		result = 31 * result + (name != null ? name.hashCode() : 0);
-		result = 31 * result + (version != null ? version.hashCode() : 0);
-		result = 31 * result + (packageSourceUrl != null ? packageSourceUrl.hashCode() : 0);
-		result = 31 * result + (packageHomeUrl != null ? packageHomeUrl.hashCode() : 0);
-		result = 31 * result + (tags != null ? tags.hashCode() : 0);
-		result = 31 * result + (maintainer != null ? maintainer.hashCode() : 0);
-		result = 31 * result + (description != null ? description.hashCode() : 0);
-		result = 31 * result + (sha256 != null ? sha256.hashCode() : 0);
-		result = 31 * result + (iconUrl != null ? iconUrl.hashCode() : 0);
+		int result = repositoryId.hashCode();
+		result = 31 * result + name.hashCode();
+		result = 31 * result + version.hashCode();
 		return result;
 	}
 
@@ -314,7 +281,7 @@ public class PackageMetadata extends AbstractEntity {
 				"id='" + getId() + '\'' +
 				", apiVersion='" + apiVersion + '\'' +
 				", origin='" + origin + '\'' +
-				", repositoryId='" + repositoryId + '\'' +
+				", repositoryName='" + repositoryName + '\'' +
 				", kind='" + kind + '\'' +
 				", name='" + name + '\'' +
 				", version='" + version + '\'' +

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/domain/PackageMetadataTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/domain/PackageMetadataTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+/**
+ * @author Mark Pollack
+ */
+public class PackageMetadataTests {
+
+	@Test
+	public void equalsContract() {
+		EqualsVerifier.forClass(PackageMetadata.class)
+				.withOnlyTheseFields("repositoryId", "name", "version")
+				.verify();
+	}
+}


### PR DESCRIPTION
- Add RepositoryName property to PackageMetadata
- PackageMetadata equals/hashcode includes only repoId,name,version
- Add findByRepositoryNameAndNameAndVersion to PackageMetadataRepository
- Update doc generation to match new field and descriptions

Fixes #436
Fixes #437
Fixes #438