### PR TITLE
Allow deleting a release along with its package

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.skipper.domain.AboutResource;
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -182,9 +183,9 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Release delete(String releaseName) {
-		String url = String.format("%s/%s/%s/%s", baseUri, "release", "delete", releaseName);
-		return this.restTemplate.postForObject(url, null, Release.class);
+	public Release delete(String releaseName, DeleteProperties deleteProperties) {
+		String url = String.format("%s/%s/%s", baseUri, "delete", releaseName);
+		return this.restTemplate.postForObject(url, deleteProperties, Release.class);
 	}
 
 	@Override

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.client;
 import java.util.List;
 
 import org.springframework.cloud.skipper.domain.AboutResource;
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -92,9 +93,10 @@ public interface SkipperClient {
 	 * Delete a specific release.
 	 *
 	 * @param releaseName the release name
+	 * @param deleteProperties release delete properties
 	 * @return the deleted {@link Release}
 	 */
-	Release delete(String releaseName);
+	Release delete(String releaseName, DeleteProperties deleteProperties);
 
 	/**
 	 * Rollback a specific release.

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -60,7 +60,7 @@ public class DefaultSkipperClientTests {
 	private final String ERROR3 = "{\"timestamp\":1508161424577," +
 			"\"status\":409," +
 			"\"error\":\"Conflict\"," +
-			"\"exception\":\"org.springframework.cloud.skipper.PackageHasDeployedRelease\"," +
+			"\"exception\":\"org.springframework.cloud.skipper.PackageDeleteException\"," +
 			"\"message\":\"Can't delete package: [package1] because is used by deployed releases: [release2]\"," +
 			"\"path\":\"/api/status/mylog\",\"releaseName\":\"mylog\"}";
 

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -15,18 +15,23 @@
  */
 package org.springframework.cloud.skipper.client;
 
+import java.nio.charset.Charset;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -36,6 +41,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  *
  * @author Mark Pollack
  * @author Janne Valkealahti
+ * @author Christian Tzolov
  */
 public class DefaultSkipperClientTests {
 
@@ -50,6 +56,13 @@ public class DefaultSkipperClientTests {
 			"\"error\":\"Not Found\"," +
 			"\"exception\":\"org.springframework.cloud.skipper.SkipperException\"," +
 			"\"message\":\"Some skipper message\",\"path\":\"/api/status/mylog\"}";
+
+	private final String ERROR3 = "{\"timestamp\":1508161424577," +
+			"\"status\":409," +
+			"\"error\":\"Conflict\"," +
+			"\"exception\":\"org.springframework.cloud.skipper.PackageHasDeployedRelease\"," +
+			"\"message\":\"Can't delete package: [package1] because is used by deployed releases: [release2]\"," +
+			"\"path\":\"/api/status/mylog\",\"releaseName\":\"mylog\"}";
 
 	@Test
 	public void genericTemplateTest() {
@@ -97,5 +110,50 @@ public class DefaultSkipperClientTests {
 				.andRespond(withStatus(HttpStatus.NOT_FOUND).body(ERROR2).contentType(MediaType.APPLICATION_JSON));
 
 		skipperClient.status("mylog");
+	}
+
+	@Test
+	public void testDeleteReleaseWithoutPackageDeletion() {
+		testDeleteRelease(new DeleteProperties(), "{\"deletePackage\":false}");
+	}
+
+	@Test
+	public void testDeleteReleaseWithPackageDeletion() {
+		DeleteProperties deleteProperties = new DeleteProperties();
+		deleteProperties.setDeletePackage(true);
+		testDeleteRelease(deleteProperties, "{\"deletePackage\":true}");
+	}
+
+	private void testDeleteRelease(DeleteProperties deleteProperties, String expectedContent) {
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setErrorHandler(new SkipperClientResponseErrorHandler(new ObjectMapper()));
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+
+		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
+				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer.expect(requestTo("/delete/release1"))
+				.andExpect(content().string(expectedContent))
+				.andExpect(content().contentType(contentType))
+				.andRespond(withStatus(HttpStatus.CREATED).contentType(MediaType.APPLICATION_JSON));
+
+		skipperClient.delete("release1", deleteProperties);
+	}
+
+	@Test(expected = HttpClientErrorException.class)
+	public void testDeeltePackageHasDeployedRelease() {
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setErrorHandler(new SkipperClientResponseErrorHandler(new ObjectMapper()));
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer.expect(requestTo("/delete/release1"))
+				.andExpect(content().string("{\"deletePackage\":true}"))
+				.andRespond(withStatus(HttpStatus.CONFLICT).body(ERROR3).contentType(MediaType.APPLICATION_JSON));
+
+		DeleteProperties deleteProperties = new DeleteProperties();
+		deleteProperties.setDeletePackage(true);
+		skipperClient.delete("release1", deleteProperties);
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -206,11 +206,9 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 			PackageService packageService,
 			ReleaseManager releaseManager,
 			DeployerRepository deployerRepository,
-			ReleaseReportService releaseReportService,
-			RepositoryRepository repositoryRepository) {
+			PackageMetadataService packageMetadataService) {
 		return new ReleaseService(packageMetadataRepository, releaseRepository,
-				packageService, releaseManager,
-				deployerRepository, releaseReportService, repositoryRepository);
+				packageService, releaseManager, deployerRepository, packageMetadataService);
 	}
 
 	@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -206,10 +206,11 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 			PackageService packageService,
 			ReleaseManager releaseManager,
 			DeployerRepository deployerRepository,
-			ReleaseReportService releaseReportService) {
+			ReleaseReportService releaseReportService,
+			RepositoryRepository repositoryRepository) {
 		return new ReleaseService(packageMetadataRepository, releaseRepository,
 				packageService, releaseManager,
-				deployerRepository, releaseReportService);
+				deployerRepository, releaseReportService, repositoryRepository);
 	}
 
 	@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
@@ -51,7 +51,7 @@ public class SkipperServerPlatformConfiguration {
 		for (Map.Entry<String, LocalDeployerProperties> entry : localDeployerPropertiesMap
 				.entrySet()) {
 			LocalAppDeployer localAppDeployer = new LocalAppDeployer(entry.getValue());
-			Deployer deployer = new Deployer(entry.getKey(), "default", localAppDeployer);
+			Deployer deployer = new Deployer(entry.getKey(), "local", localAppDeployer);
 			deployer.setDescription(prettyPrintLocalDeployerProperties(entry.getValue()));
 			deployers.add(deployer);
 		}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/PackageController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/PackageController.java
@@ -92,7 +92,7 @@ public class PackageController {
 	@RequestMapping(path = "/{name}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
 	public void packageDelete(@PathVariable("name") String name) {
-		this.packageMetadataService.deleteIfAllReleasesDeleted(name);
+		this.packageMetadataService.deleteIfAllReleasesDeleted(name, PackageMetadataService.DEFAULT_RELEASE_ACTIVITY_CHECK);
 	}
 
 	/**

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
@@ -171,5 +172,10 @@ public class ReleaseController {
 
 		public ReleaseControllerLinksResource() {
 		}
+	}
+
+	@ExceptionHandler(PackageDeleteException.class)
+	public ResponseEntity<String> handlePackageDeleteException(PackageDeleteException e) {
+		return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
@@ -81,7 +82,7 @@ public class ReleaseController {
 		resource.add(
 				ControllerLinkBuilder.linkTo(methodOn(ReleaseController.class).rollback(null, null))
 						.withRel("rollback"));
-		resource.add(ControllerLinkBuilder.linkTo(methodOn(ReleaseController.class).delete(null))
+		resource.add(ControllerLinkBuilder.linkTo(methodOn(ReleaseController.class).delete(null, null))
 							.withRel("delete"));
 		resource.add(
 				ControllerLinkBuilder.linkTo(methodOn(ReleaseController.class).history(null, null))
@@ -133,8 +134,9 @@ public class ReleaseController {
 
 	@RequestMapping(path = "/delete/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
-	public Release delete(@PathVariable("name") String releaseName) {
-		return this.skipperStateMachineService.deleteRelease(releaseName);
+	public Release delete(@PathVariable("name") String releaseName,
+			@RequestBody DeleteProperties deleteProperties) {
+		return this.skipperStateMachineService.deleteRelease(releaseName, deleteProperties);
 	}
 
 	@RequestMapping(path = "/history/{name}/{max}", method = RequestMethod.GET)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/PackageMetadataRepository.java
@@ -27,6 +27,7 @@ import org.springframework.data.rest.core.annotation.RestResource;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  * @author Janne Valkealahti
+ * @author Christian Tzolov
  */
 @RepositoryRestResource(path = "packageMetadata", collectionResourceRel = "packageMetadata")
 public interface PackageMetadataRepository extends PagingAndSortingRepository<PackageMetadata, Long>,
@@ -56,5 +57,4 @@ public interface PackageMetadataRepository extends PagingAndSortingRepository<Pa
 	@RestResource(exported = false)
 	void deleteByRepositoryIdAndName(@Param("repositoryId") Long repositoryId,
 			@Param("name") String name);
-
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageService.java
@@ -201,6 +201,16 @@ public class PackageService implements ResourceLoaderAware {
 	}
 
 	@Transactional
+	public void delete(PackageMetadata packageMetadata) {
+		Assert.notNull(packageMetadata, "Can't download PackageMetadata, it is a null value.");
+		Assert.hasText(packageMetadata.getName(), "Package name can not be empty.");
+		Assert.hasText(packageMetadata.getVersion(), "Package version can not be empty.");
+		Assert.isTrue(packageMetadata.getRepositoryId() > 0, "Invalid Repository ID.");
+
+		this.packageMetadataRepository.delete(packageMetadata);
+	}
+
+	@Transactional
 	public PackageMetadata upload(UploadRequest uploadRequest) {
 		validateUploadRequest(uploadRequest);
 		Repository localRepositoryToUpload = getRepositoryToUpload(uploadRequest.getRepoName());

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/DeleteDeleteAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/DeleteDeleteAction.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.statemachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.server.service.ReleaseService;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
@@ -32,6 +33,7 @@ import org.springframework.util.Assert;
  * StateMachine {@link Action} handling delete with a {@link ReleaseService}.
  *
  * @author Janne Valkealahti
+ * @author Christian Tzolov
  *
  */
 public class DeleteDeleteAction extends AbstractAction {
@@ -56,7 +58,9 @@ public class DeleteDeleteAction extends AbstractAction {
 		log.debug("Starting action " + context);
 		String releaseName = context.getMessageHeaders().get(SkipperEventHeaders.RELEASE_NAME, String.class);
 		log.info("About to delete {}", releaseName);
-		Release release = this.releaseService.delete(releaseName);
+		DeleteProperties deleteProperties = context.getMessageHeaders()
+				.get(SkipperEventHeaders.RELEASE_DELETE_PROPERTIES, DeleteProperties.class);
+		Release release = this.releaseService.delete(releaseName, deleteProperties.isDeletePackage());
 		context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, release);
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/SkipperStateMachineService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/SkipperStateMachineService.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
@@ -107,10 +108,11 @@ public class SkipperStateMachineService {
 	 * @param releaseName the release name
 	 * @return the release
 	 */
-	public Release deleteRelease(String releaseName) {
+	public Release deleteRelease(String releaseName, DeleteProperties deleteProperties) {
 		Message<SkipperEvents> message = MessageBuilder
 				.withPayload(SkipperEvents.DELETE)
 				.setHeader(SkipperEventHeaders.RELEASE_NAME, releaseName)
+				.setHeader(SkipperEventHeaders.RELEASE_DELETE_PROPERTIES, deleteProperties)
 				.build();
 		return handleMessageAndWait(message, releaseName);
 	}
@@ -448,6 +450,11 @@ public class SkipperStateMachineService {
 		 * Header for rollback version.
 		 */
 		public static final String ROLLBACK_VERSION = "ROLLBACK_VERSION";
+
+		/**
+		 * SCDF specific extension to allow deletion of
+		 */
+		public static final String RELEASE_DELETE_PROPERTIES = "RELEASE_DELETE_PROPERTIES";
 	}
 
 	/**

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
@@ -170,8 +170,12 @@ public abstract class AbstractIntegrationTest extends AbstractAssertReleaseDeplo
 	}
 
 	protected Release delete(String releaseName) {
-		logger.info("Deleting release {}", releaseName);
-		return releaseService.delete(releaseName);
+		return releaseService.delete(releaseName, false);
+	}
+
+	protected Release delete(String releaseName, boolean deleteReleasePackage) {
+		logger.info("Deleting release {} with package {}", releaseName, deleteReleasePackage);
+		return releaseService.delete(releaseName, deleteReleasePackage);
 	}
 
 	@Configuration

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/AbstractControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/AbstractControllerTests.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
@@ -74,7 +75,8 @@ public abstract class AbstractControllerTests extends AbstractMockMvcTests {
 		for (Release release : releaseRepository.findAll()) {
 			if (release.getInfo().getStatus().getStatusCode() != StatusCode.DELETED) {
 				try {
-					mockMvc.perform(post("/api/release/delete/" + release.getName()))
+					mockMvc.perform(post("/api/release/delete/" + release.getName())
+								.content(convertObjectToJson(new DeleteProperties())))
 							.andDo(print())
 							.andExpect(status().isCreated()).andReturn();
 				}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -118,7 +118,8 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 				.andDo(print()).andExpect(status().isConflict()).andReturn();
 
 		assertThat(result.getResponse().getContentAsString())
-				.contains("Can't delete package: [log] because is used by deployed releases: [test2]");
+				.contains("Can not delete Package Metadata [log:1.0.0] in Repository [test]. Not all releases of " +
+						"this package have the status DELETED. Active Releases [test2]");
 
 		assertThat(this.packageMetadataRepository.findByName("log").size()).isEqualTo(3);
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -20,12 +20,15 @@ import javax.servlet.ServletContext;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.Repository;
 import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.repository.RepositoryRepository;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -46,6 +49,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("repo-test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class ReleaseControllerTests extends AbstractControllerTests {
+
+	@Autowired
+	private RepositoryRepository repositoryRepository;
 
 	@Test
 	public void deployTickTock() throws Exception {
@@ -88,6 +94,11 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 
 	@Test
 	public void checkDeleteReleaseWithPackage() throws Exception {
+
+		// Make the test repo Local
+		Repository repo = this.repositoryRepository.findByName("test");
+		repo.setLocal(true);
+		this.repositoryRepository.save(repo);
 
 		// Deploy
 		String releaseNameOne = "test1";

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -113,7 +113,7 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 		DeleteProperties deleteProperties = new DeleteProperties();
 		deleteProperties.setDeletePackage(true);
 
-		MvcResult result = mockMvc.perform(post("/api/delete/" + releaseNameOne)
+		MvcResult result = mockMvc.perform(post("/api/release/delete/" + releaseNameOne)
 				.content(convertObjectToJson(deleteProperties)))
 				.andDo(print()).andExpect(status().isConflict()).andReturn();
 
@@ -125,14 +125,14 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 
 		// Delete the 'release2' only not the package.
 		deleteProperties.setDeletePackage(false);
-		mockMvc.perform(post("/api/delete/" + releaseNameTwo)
+		mockMvc.perform(post("/api/release/delete/" + releaseNameTwo)
 				.content(convertObjectToJson(deleteProperties)))
 				.andDo(print()).andExpect(status().isCreated()).andReturn();
 		assertThat(this.packageMetadataRepository.findByName("log").size()).isEqualTo(3);
 
 		// Second attempt to delete 'release1' along with its package 'log'.
 		deleteProperties.setDeletePackage(true);
-		mockMvc.perform(post("/api/delete/" + releaseNameOne)
+		mockMvc.perform(post("/api/release/delete/" + releaseNameOne)
 				.content(convertObjectToJson(deleteProperties)))
 				.andDo(print()).andExpect(status().isCreated()).andReturn();
 		assertThat(this.packageMetadataRepository.findByName("log").size()).isEqualTo(0);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -16,11 +16,15 @@
 
 package org.springframework.cloud.skipper.server.controller.docs;
 
+import java.nio.charset.Charset;
+
 import org.junit.Test;
 
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.StringUtils;
 
@@ -49,8 +53,14 @@ public class DeleteDocumentation extends BaseDocumentation {
 
 		installPackage(installRequest);
 
+		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
+				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+
 		this.mockMvc.perform(
-				post("/api/release/delete/{releaseName}", releaseName)).andDo(print())
+				post("/api/release/delete/{releaseName}", releaseName)
+						.accept(MediaType.APPLICATION_JSON).contentType(contentType)
+						.content(convertObjectToJson(new DeleteProperties())))
+				.andDo(print())
 				.andExpect(status().isCreated())
 				.andDo(this.documentationHandler.document(
 						responseFields(

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
@@ -356,9 +356,11 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		assertThat(foundByRepositoryIdAndPackageMetadataId).hasSize(6);
 
 		try {
-			this.packageMetadataService.deleteIfAllReleasesDeleted(packageMetadata2.getName());
+			this.packageMetadataService.deleteIfAllReleasesDeleted(packageMetadata2.getName(),
+					PackageMetadataService.DEFAULT_RELEASE_ACTIVITY_CHECK);
 			fail("SkipperException is expected");
-		} catch (SkipperException e) {
+		}
+		catch (SkipperException e) {
 			assertThat(e.getMessage())
 					.contains("Can not delete Package Metadata [package2:1.0.1] in Repository [local]")
 					.contains("Not all releases of this package have the status DELETED.")
@@ -370,9 +372,11 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 		this.releaseRepository.save(release5);
 
 		try {
-			this.packageMetadataService.deleteIfAllReleasesDeleted(packageMetadata2.getName());
+			this.packageMetadataService.deleteIfAllReleasesDeleted(packageMetadata2.getName(),
+					PackageMetadataService.DEFAULT_RELEASE_ACTIVITY_CHECK);
 			fail("SkipperException is expected");
-		} catch (SkipperException e) {
+		}
+		catch (SkipperException e) {
 			assertThat(e.getMessage())
 					.contains("Can not delete Package Metadata [package2:1.0.1] in Repository [local]")
 					.contains("Not all releases of this package have the status DELETED.")
@@ -466,9 +470,11 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 
 		Long ticktockPackageMetadataId = this.packageMetadataRepository.findByName("ticktock").get(0).getId();
 		try {
-			this.packageMetadataService.deleteIfAllReleasesDeleted(packageMetadata1.getName());
+			this.packageMetadataService.deleteIfAllReleasesDeleted(packageMetadata1.getName(),
+					PackageMetadataService.DEFAULT_RELEASE_ACTIVITY_CHECK);
 			fail("SkipperException is expected");
-		} catch (SkipperException e) {
+		}
+		catch (SkipperException e) {
 			assertThat(e.getMessage())
 					.contains("Can not delete Package Metadata [ticktock:1.0.0] in Repository [local]")
 					.contains("Not all releases of this package have the status DELETED.")
@@ -478,7 +484,8 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 
 		release3.setInfo(deletedInfo);
 		this.releaseRepository.save(release3);
-		this.packageMetadataService.deleteIfAllReleasesDeleted(packageMetadata1.getName());
+		this.packageMetadataService.deleteIfAllReleasesDeleted(packageMetadata1.getName(),
+				PackageMetadataService.DEFAULT_RELEASE_ACTIVITY_CHECK);
 		List<Release> foundByRepositoryIdAndPackageMetadataId =
 				this.releaseRepository.findByRepositoryIdAndPackageMetadataIdOrderByNameAscVersionDesc(REMOTE_REPO,
 						ticktockPackageMetadataId);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
 import org.springframework.cloud.deployer.resource.support.LRUCleaningResourceLoader;
-import org.springframework.cloud.skipper.PackageHasDeployedRelease;
+import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.ConfigValues;
@@ -340,9 +340,9 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 			delete(RELEASE_ONE, DELETE_RELEASE_PACKAGE);
 			fail("Attempt to delete a package with other deployed releases should fail");
 		}
-		catch (PackageHasDeployedRelease se) {
-			assertThat(se.getMessage()).isEqualTo("Can't delete package: [log] because is used by deployed releases: " +
-					"[RELEASE_TWO]");
+		catch (PackageDeleteException se) {
+			assertThat(se.getMessage()).isEqualTo("Can not delete Package Metadata [log:1.0.0] in Repository [test]. " +
+					"Not all releases of this package have the status DELETED. Active Releases [RELEASE_TWO]");
 		}
 
 		// Verify that neither the releases nor the package have been deleted
@@ -359,9 +359,9 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 			delete(RELEASE_ONE, DELETE_RELEASE_PACKAGE);
 			fail("Attempt to delete a package with other deployed releases must fail.");
 		}
-		catch (PackageHasDeployedRelease se) {
-			assertThat(se.getMessage()).isEqualTo("Can't delete package: [log] because is used by deployed releases: " +
-					"[RELEASE_TWO, RELEASE_THREE]");
+		catch (PackageDeleteException se) {
+			assertThat(se.getMessage()).isEqualTo("Can not delete Package Metadata [log:1.0.0] in Repository [test]. " +
+					"Not all releases of this package have the status DELETED. Active Releases [RELEASE_THREE,RELEASE_TWO]");
 		}
 
 		// Verify that nothing has been deleted

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.skipper.server.service;
 
+import java.util.List;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
 import org.springframework.cloud.deployer.resource.support.LRUCleaningResourceLoader;
+import org.springframework.cloud.skipper.PackageHasDeployedRelease;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.ConfigValues;
@@ -48,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  * @author Glenn Renfro
+ * @author Christian Tzolov
  */
 @ActiveProfiles("repo-test")
 public class ReleaseServiceTests extends AbstractIntegrationTest {
@@ -222,6 +226,131 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		// Install again
 		Release release2 = install(installRequest);
 		assertThat(release2.getVersion()).isEqualTo(2);
+	}
+
+	@Test
+	public void testDeletedReleaseWithPackage() throws InterruptedException {
+		String releaseName = "deletedRelease";
+		InstallRequest installRequest = new InstallRequest();
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
+		PackageIdentifier packageIdentifier = new PackageIdentifier();
+		packageIdentifier.setPackageName("log");
+		packageIdentifier.setPackageVersion("1.0.0");
+		installRequest.setPackageIdentifier(packageIdentifier);
+
+		List<PackageMetadata> releasePackage = this.packageMetadataRepository.findByNameAndVersionOrderByApiVersionDesc(
+				packageIdentifier.getPackageName(), packageIdentifier.getPackageVersion());
+
+		assertThat(releasePackage).isNotNull();
+		assertThat(releasePackage.size()).isEqualTo(1);
+
+		assertThat(this.packageMetadataRepository.findByName(packageIdentifier.getPackageName()).size()).isEqualTo(3);
+
+		// Install
+		Release release = install(installRequest);
+		assertThat(release).isNotNull();
+		// Delete
+		delete(releaseName, true);
+
+		assertThat(this.packageMetadataRepository.findByName(packageIdentifier.getPackageName()).size()).isEqualTo(0);
+	}
+
+	@Test
+	public void testInstallDeleteOfdMultipleReleasesFromSingePackage() throws InterruptedException {
+
+		boolean DELETE_RELEASE_PACKAGE = true;
+		String RELEASE_ONE = "RELEASE_ONE";
+		String RELEASE_TWO = "RELEASE_TWO";
+		String RELEASE_THREE = "RELEASE_THREE";
+
+		// 3 versions of package "log" exists
+		PackageIdentifier logPackageIdentifier = new PackageIdentifier();
+		logPackageIdentifier.setPackageName("log");
+		logPackageIdentifier.setPackageVersion("1.0.0");
+
+		List<PackageMetadata> releasePackage = this.packageMetadataRepository.findByNameAndVersionOrderByApiVersionDesc(
+				logPackageIdentifier.getPackageName(), logPackageIdentifier.getPackageVersion());
+		assertThat(releasePackage).isNotNull();
+		assertThat(releasePackage.size()).isEqualTo(1);
+		assertThat(this.packageMetadataRepository.findByName(logPackageIdentifier.getPackageName()).size()).isEqualTo(3);
+
+		// Install 2 releases (RELEASE_ONE, RELEASE_TWO) from the same "log" package
+		install(RELEASE_ONE, logPackageIdentifier);
+		install(RELEASE_TWO, logPackageIdentifier);
+
+		assertReleaseStatus(RELEASE_ONE, StatusCode.DEPLOYED);
+		assertReleaseStatus(RELEASE_TWO, StatusCode.DEPLOYED);
+
+		// Attempt to delete release one together with its package
+		try {
+			delete(RELEASE_ONE, DELETE_RELEASE_PACKAGE);
+			fail("Attempt to delete a package with other deployed releases should fail");
+		}
+		catch (PackageHasDeployedRelease se) {
+			assertThat(se.getMessage()).isEqualTo("Can't delete package: [log] because is used by deployed releases: " +
+					"[RELEASE_TWO]");
+		}
+
+		// Verify that neither the releases nor the package have been deleted
+		assertReleaseStatus(RELEASE_ONE, StatusCode.DEPLOYED);
+		assertReleaseStatus(RELEASE_TWO, StatusCode.DEPLOYED);
+		assertThat(this.packageMetadataRepository.findByName(logPackageIdentifier.getPackageName()).size()).isEqualTo(3);
+
+		// Install a third release (RELEASE_THREE) from the same package (log)
+		install(RELEASE_THREE, logPackageIdentifier);
+		assertReleaseStatus(RELEASE_THREE, StatusCode.DEPLOYED);
+
+		// Attempt to delete release one together with its package
+		try {
+			delete(RELEASE_ONE, DELETE_RELEASE_PACKAGE);
+			fail("Attempt to delete a package with other deployed releases must fail.");
+		}
+		catch (PackageHasDeployedRelease se) {
+			assertThat(se.getMessage()).isEqualTo("Can't delete package: [log] because is used by deployed releases: " +
+					"[RELEASE_TWO, RELEASE_THREE]");
+		}
+
+		// Verify that nothing has been deleted
+		assertReleaseStatus(RELEASE_ONE, StatusCode.DEPLOYED);
+		assertReleaseStatus(RELEASE_TWO, StatusCode.DEPLOYED);
+		assertReleaseStatus(RELEASE_THREE, StatusCode.DEPLOYED);
+		assertThat(this.packageMetadataRepository.findByName(logPackageIdentifier.getPackageName()).size()).isEqualTo(3);
+
+		// Delete releases two and three without without deleting their package.
+		delete(RELEASE_TWO, !DELETE_RELEASE_PACKAGE);
+		delete(RELEASE_THREE, !DELETE_RELEASE_PACKAGE);
+
+		// Release One is still deployed
+		assertReleaseStatus(RELEASE_ONE, StatusCode.DEPLOYED);
+
+		// Releases Two and Three were undeployed
+		assertReleaseStatus(RELEASE_TWO, StatusCode.DELETED);
+		assertReleaseStatus(RELEASE_THREE, StatusCode.DELETED);
+
+		// Package "log" still has 3 registered versions
+		assertThat(this.packageMetadataRepository.findByName(logPackageIdentifier.getPackageName()).size()).isEqualTo(3);
+
+		// Attempt to delete release one together with its package
+		delete(RELEASE_ONE, DELETE_RELEASE_PACKAGE);
+
+		// Successful deletion of release and its package.
+		assertReleaseStatus(RELEASE_ONE, StatusCode.DELETED);
+		assertThat(this.packageMetadataRepository.findByName(logPackageIdentifier.getPackageName()).size()).isEqualTo(0);
+	}
+
+	private Release install(String releaseName, PackageIdentifier packageIdentifier) throws InterruptedException {
+		InstallRequest installRequest = new InstallRequest();
+		installRequest.setPackageIdentifier(packageIdentifier);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
+		Release release = install(installRequest);
+		assertThat(release).isNotNull();
+		return release;
+	}
+
+	private void assertReleaseStatus(String releaseName, StatusCode expectedStatusCode) {
+		assertThat(this.releaseRepository.findByNameIgnoreCaseContaining(releaseName).size()).isEqualTo(1);
+		assertThat(this.releaseRepository.findByNameIgnoreCaseContaining(releaseName).iterator().next()
+				.getInfo().getStatus().getStatusCode()).isEqualTo(expectedStatusCode);
 	}
 
 	@Test

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/SkipperCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/SkipperCommands.java
@@ -32,6 +32,7 @@ import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.ConfigValues;
+import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
@@ -192,8 +193,11 @@ public class SkipperCommands extends AbstractSkipperCommand {
 
 	@ShellMethod(key = "release delete", value = "Delete the release.")
 	public String delete(
-			@ShellOption(help = "the name of the release to delete") String releaseName) {
-		Release release = skipperClient.delete(releaseName);
+			@ShellOption(help = "the name of the release to delete") String releaseName,
+			@ShellOption(help = "delete the release package", defaultValue = "false") boolean deletePackage) {
+		DeleteProperties deleteProperties = new DeleteProperties();
+		deleteProperties.setDeletePackage(deletePackage);
+		Release release = skipperClient.delete(releaseName, deleteProperties);
 		StringBuilder sb = new StringBuilder();
 		sb.append(release.getName() + " has been deleted.");
 		return sb.toString();

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/PackageDeleteException.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/PackageDeleteException.java
@@ -15,29 +15,31 @@
  */
 package org.springframework.cloud.skipper;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.cloud.skipper.domain.Release;
-
 /**
  * Thrown if an attempt to alter a package still used by a deployed releases.
  *
  * @author Christian Tzolov
  */
-public class PackageHasDeployedRelease extends SkipperException {
+public class PackageDeleteException extends SkipperException {
 
-	public PackageHasDeployedRelease(String packageName, List<Release> releases) {
-		super(getMessage(packageName, releases));
+	public PackageDeleteException(String message) {
+		super(message);
 	}
 
-	public PackageHasDeployedRelease(String packageName, Release releases) {
-		super(getMessage(packageName, Arrays.asList(releases)));
+	public PackageDeleteException(String message, Throwable cause) {
+		super(message, cause);
 	}
 
-	private static String getMessage(String packageName, List<Release> releases) {
-		return String.format("Can't delete package: [%s] because is used by deployed releases: %s",
-				packageName, releases.stream().map(Release::getName).collect(Collectors.toList()));
-	}
+//	public PackageDeleteException(String packageName, List<Release> releases) {
+//		super(getMessage(packageName, releases));
+//	}
+//
+//	public PackageDeleteException(String packageName, Release releases) {
+//		super(getMessage(packageName, Arrays.asList(releases)));
+//	}
+//
+//	private static String getMessage(String packageName, List<Release> releases) {
+//		return String.format("Can't delete package: [%s] because is used by deployed releases: %s",
+//				packageName, releases.stream().map(Release::getName).collect(Collectors.toList()));
+//	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/PackageHasDeployedRelease.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/PackageHasDeployedRelease.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.cloud.skipper.domain.Release;
+
+/**
+ * Thrown if an attempt to alter a package still used by a deployed releases.
+ *
+ * @author Christian Tzolov
+ */
+public class PackageHasDeployedRelease extends SkipperException {
+
+	public PackageHasDeployedRelease(String packageName, List<Release> releases) {
+		super(getMessage(packageName, releases));
+	}
+
+	public PackageHasDeployedRelease(String packageName, Release releases) {
+		super(getMessage(packageName, Arrays.asList(releases)));
+	}
+
+	private static String getMessage(String packageName, List<Release> releases) {
+		return String.format("Can't delete package: [%s] because is used by deployed releases: %s",
+				packageName, releases.stream().map(Release::getName).collect(Collectors.toList()));
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/DeleteProperties.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/DeleteProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+/**
+ * @author Christian Tzolov
+ */
+public class DeleteProperties {
+
+	private boolean deletePackage;
+
+	public boolean isDeletePackage() {
+		return deletePackage;
+	}
+
+	public void setDeletePackage(boolean deletePackage) {
+		this.deletePackage = deletePackage;
+	}
+}


### PR DESCRIPTION
Resolves #431

  - Add PackageService#delete(PackageMetadata) method
  - Add ReleseService#delete(releaseName, deleteReleasePackage), previous delete(releaseName) defaults to delete(releaseName, false)
     - the deleteReleasePackage method attempts to delete all package versions for this release or throws PackageHasDeployedRelease if the packages is used by other deployed releases
  - SkipperController delete method to delete(String releaseName, DeleteProperties deleteProperties).
  - Extend SkipperStateMachineService to handle DeleteProperties for delete actions
  - SkipperClient - delete(String releaseName, DeleteProperties deleteProperties);
  - add optional deletePackage boolean argument to the delete command (default to false)
  - SkipperServerPlatformConfiguration: fix the deployer’s type to 'local' instead of 'default'
  - Tests for ReleaseServce, Skipper Controller and SkipperCommands