### PR TITLE
Fix commands doc after controller refactoring

### DIFF
--- a/spring-cloud-skipper-docs/src/main/asciidoc/command-reference.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/command-reference.adoc
@@ -9,7 +9,7 @@ The command `search` shows all the packages available to be installed by the Ski
 
 [source,bash,options="nowrap"]
 ----
-skipper:>search
+skipper:>package search
 ╔═════════════════╤═══════╤════════════════════════════════════════════════════════════════════════════════╗
 ║      Name       │Version│                                  Description                                   ║
 ╠═════════════════╪═══════╪════════════════════════════════════════════════════════════════════════════════╣
@@ -24,7 +24,7 @@ The `search` command can use `--name` option to search for the package name cont
 
 [source,bash,options="nowrap"]
 ----
-skipper:>search --name helloworld-
+skipper:>package search --name helloworld-
 ╔═════════════════╤═══════╤════════════════════════════════════════════════════════════════════════════════╗
 ║      Name       │Version│                                  Description                                   ║
 ╠═════════════════╪═══════╪════════════════════════════════════════════════════════════════════════════════╣
@@ -37,7 +37,7 @@ To search for more details of the packages, the option `--details` can be used.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>search --name helloworld- --details
+skipper:>package search --name helloworld- --details
 ╔════════════════╤═════════════════════════════════════════════════════════════════════════════╗
 ║      Name      │                                    Value                                    ║
 ╠════════════════╪═════════════════════════════════════════════════════════════════════════════╣
@@ -82,7 +82,7 @@ This command installs a package.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>install --release-name helloworldlocal --package-name helloworld --package-version 1.0.0 --properties spec.applicationProperties.server.port=8099
+skipper:>package install --release-name helloworldlocal --package-name helloworld --package-version 1.0.0 --properties spec.applicationProperties.server.port=8099
 Released helloworldlocal. Now at version v1.
 ----
 
@@ -99,7 +99,7 @@ This command upgrades a package.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name helloworldlocal --package-name helloworld --package-version 1.0.0 --properties spec.applicationProperties.server.port=9090
+skipper:>release upgrade --release-name helloworldlocal --package-name helloworld --package-version 1.0.0 --properties spec.applicationProperties.server.port=9090
 helloworldpcf has been upgraded.  Now at version v2.
 ----
 
@@ -118,7 +118,7 @@ For example, the `ticktock` package that contains a `time` and a `log` applicati
 
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name ticktockskipper --package-name ticktock --file /home/mpollack/log-level-change.yml
+skipper:>release upgrade --release-name ticktockskipper --package-name ticktock --file /home/mpollack/log-level-change.yml
 ----
 
 where `log-level-change.yml` is
@@ -150,7 +150,7 @@ You can then use the `--properties` option in the `upgrade` command as shown bel
 
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name ticktockskipper --package-name ticktock --properties log.version=1.1.1.RELEASE
+skipper:>release upgrade --release-name ticktockskipper --package-name ticktock --properties log.version=1.1.1.RELEASE
 ----
 
 === Status command
@@ -159,7 +159,7 @@ This command shows the `status` of a specific release and version.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>status --release-name helloworldlocal
+skipper:>release status --release-name helloworldlocal
 ╔═══════════════╤═══════════════════════════════════════════════════════════════════════════════════╗
 ║Last Deployed  │Mon Oct 30 17:53:50 IST 2017                                                       ║
 ║Status         │DEPLOYED                                                                           ║
@@ -172,7 +172,7 @@ If no `--release-version` specifed, then the latest release version will be used
 
 [source,bash,options="nowrap"]
 ----
-skipper:>status --release-name helloworldlocal --release-version 1
+skipper:>release status --release-name helloworldlocal --release-version 1
 ╔═══════════════╤════════════════════════════════════════════════════════════════════════╗
 ║Last Deployed  │Mon Oct 30 17:52:57 IST 2017                                            ║
 ║Status         │DELETED                                                                 ║
@@ -187,7 +187,7 @@ This command rollsback the release to a specific version.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>rollback --release-name helloworldlocal --release-version 1
+skipper:>release rollback --release-name helloworldlocal --release-version 1
 helloworldlocal has been rolled back.  Now at version v3.
 ----
 
@@ -200,7 +200,7 @@ This command lists the latest deployed or failed release.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>list
+skipper:>release list
 ╔═══════════════╤═══════╤═════════════════════════╤════════╤═══════════╤══════════════╤════════════╤══════════════════════════════════════════════════════════════════════════════╗
 ║     Name      │Version│      Last updated       │ Status │  Package  │   Package    │  Platform  │                               Platform Status                                ║
 ║               │       │                         │        │   Name    │   Version    │    Name    │                                                                              ║
@@ -217,7 +217,7 @@ This command shows the history of a specific release.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldlocal
+skipper:>release history --release-name helloworldlocal
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -231,7 +231,7 @@ The number of revisions in the history result can be limited using `--max` optio
 
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldlocal --max 2
+skipper:>release history --release-name helloworldlocal --max 2
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -246,7 +246,7 @@ This command deletes a specific release's latest deployed revision.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>delete --release-name helloworldlocal
+skipper:>release delete --release-name helloworldlocal
 helloworldlocal has been deleted.
 ----
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/getting-started.adoc
@@ -84,7 +84,7 @@ skipper:>repo list
 Search for the available packages using the `search` command.
 [source,bash,options="nowrap"]
 ----
-skipper:>search
+skipper:>package search
 ╔═════════════════╤═══════╤════════════════════════════════════════════════════════════════════════════════╗
 ║      Name       │Version│                                  Description                                   ║
 ╠═════════════════╪═══════╪════════════════════════════════════════════════════════════════════════════════╣
@@ -98,7 +98,7 @@ skipper:>search
 Install the Maven based Hello World application using the `install` command.  Since this application picks a random port for the http server by default, we specify the Spring Boot property `server.port`, prefixed via `spec.applicationProperties`.
 [source,bash,options="nowrap"]
 ----
-skipper:>install --release-name helloworld-local --package-name helloworld --package-version 1.0.0 --properties spec.applicationProperties.server.port=8099
+skipper:>package install --release-name helloworld-local --package-name helloworld --package-version 1.0.0 --properties spec.applicationProperties.server.port=8099
 Released helloworld-local. Now at version v1.
 ----
 You can now curl the `greeting` endpoint.
@@ -112,7 +112,7 @@ The release name `helloworld-local` is used for subsequent commands such as stat
 To see the status of the release, use the `status` command
 [source,bash,options="nowrap"]
 ----
-skipper:>status --release-name helloworld-local
+skipper:>release status --release-name helloworld-local
 ╔═══════════════╤═════════════════════════════════════════════════════════════════════════════════════╗
 ║Last Deployed  │Fri Oct 27 16:17:53 IST 2017                                                         ║
 ║Status         │DEPLOYED                                                                             ║
@@ -125,7 +125,7 @@ of the greeting to be in `Portuguese`.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name helloworld-local --package-name helloworld --package-version 1.0.1  --properties spec.applicationProperties.server.port=8100
+skipper:>release upgrade --release-name helloworld-local --package-name helloworld --package-version 1.0.1  --properties spec.applicationProperties.server.port=8100
 helloworld-local has been upgraded.  Now at version v2.
 ----
 
@@ -133,7 +133,7 @@ This will deploy the new version of the application, wait until it is healthy, a
 
 [source,bash,options="nowrap"]
 ----
-skipper:>status --release-name helloworld-local
+skipper:>release status --release-name helloworld-local
 ╔═══════════════╤═════════════════════════════════════════════════════════════════════════════════════╗
 ║Last Deployed  │Fri Oct 27 16:20:07 IST 2017                                                         ║
 ║Status         │DEPLOYED                                                                             ║
@@ -153,7 +153,7 @@ To delete the release, use the `delete` command.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>delete --release-name helloworld-local
+skipper:>release delete --release-name helloworld-local
 helloworld-local has been deleted.
 ----
 NOTE: This example where the upgrade changed only a property of the application is not realistic. A more realistic example is the case where code has changed in the updated application so that it behaves differently.

--- a/spring-cloud-skipper-docs/src/main/asciidoc/security.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/security.adoc
@@ -219,69 +219,77 @@ no way to merge lists). Always refer to your version of `application.yml`, as th
 
 [source,yaml]
 ----
-# About
+            # About
 
-            - GET    /api/about                      => hasRole('ROLE_VIEW')
+            - GET /api/about                      => hasRole('ROLE_VIEW')
 
-             # AppDeployerDatas
+            # AppDeployerDatas
 
-            - GET    /api/appDeployerDatas           => hasRole('ROLE_VIEW')
-
-            # Delete
-
-            - DELETE /api/delete/**                  => hasRole('ROLE_CREATE')
+            - GET /api/appDeployerDatas           => hasRole('ROLE_VIEW')
 
             # Deployers
 
-            - GET /api/deployers                     => hasRole('ROLE_VIEW')
+            - GET /api/deployers                  => hasRole('ROLE_VIEW')
 
-            # History
+            ## Releases
 
-            - GET /api/history/**                    => hasRole('ROLE_VIEW')
+            - GET /api/releases                   => hasRole('ROLE_VIEW')
 
-            # Install
+            # Status
 
-            - POST /api/install                      => hasRole('ROLE_CREATE')
-            - POST /api/install/**                   => hasRole('ROLE_CREATE')
-
-            # List
-
-            - GET /api/list                         => hasRole('ROLE_VIEW')
-            - GET /api/list/**                      => hasRole('ROLE_VIEW')
+            - GET /api/release/status/**         => hasRole('ROLE_VIEW')
 
             # Manifest
 
-            - GET /api/manifest/**                  => hasRole('ROLE_VIEW')
+            - GET /api/release/manifest/**       => hasRole('ROLE_VIEW')
+
+            # Upgrade
+
+            - POST /api/release/upgrade          => hasRole('ROLE_CREATE')
+
+            # Rollback
+
+            - POST /api/release/rollback/**      => hasRole('ROLE_CREATE')
+
+            # Delete
+
+            - POST /api/release/delete/**        => hasRole('ROLE_CREATE')
+
+            # History
+
+            - GET /api/release/history/**           => hasRole('ROLE_VIEW')
+
+            # List
+
+            - GET /api/release/list                         => hasRole('ROLE_VIEW')
+            - GET /api/release/list/**                      => hasRole('ROLE_VIEW')
+
+            # Packages
+
+            - GET /api/packages                    => hasRole('ROLE_VIEW')
+
+            # Upload
+
+            - POST /api/package/upload             => hasRole('ROLE_CREATE')
+
+            # Install
+
+            - POST /api/package/install             => hasRole('ROLE_CREATE')
+            - POST /api/package/install/**          => hasRole('ROLE_CREATE')
+
+            # Delete
+
+            - DELETE /api/package/**                => hasRole('ROLE_CREATE')
 
             # PackageMetaData
 
             - GET /api/packageMetadata              => hasRole('ROLE_VIEW')
             - GET /api/packageMetadata/**           => hasRole('ROLE_VIEW')
 
-            # Release
-
-            - GET /api/releases                     => hasRole('ROLE_VIEW')
-
             # Repositories
 
             - GET /api/repositories                 => hasRole('ROLE_VIEW')
             - GET /api/repositories/**              => hasRole('ROLE_VIEW')
-
-            # Rollback
-
-            - POST /api/rollback/**                 => hasRole('ROLE_CREATE')
-
-            # Status
-
-            - POST /api/status/**                   => hasRole('ROLE_VIEW')
-
-            # Upgrade
-
-            - POST /api/upgrade                     => hasRole('ROLE_CREATE')
-
-            # Upload
-
-            - POST /api/upload                      => hasRole('ROLE_CREATE')
 
             # Boot Endpoints
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
@@ -424,7 +424,7 @@ Using the Skipper Shell, we can upload the package zip into Skipper server's one
 
 [source,bash,options="nowrap"]
 ----
-skipper:>upload --path /path-to-package/mypackage-1.0.0.zip
+skipper:>package upload --path /path-to-package/mypackage-1.0.0.zip
 Package uploaded successfully:[mypackage:1.0.0]
 ----
 
@@ -432,7 +432,7 @@ If no `--repo-name` is set, the `upload` command will use `local` as the reposit
 
 [source,bash,options="nowrap"]
 ----
-skipper:>search
+skipper:>package search
 ╔═════════════════╤═══════╤════════════════════════════════════════════════════════════════════════════════╗
 ║      Name       │Version│                                  Description                                   ║
 ╠═════════════════╪═══════╪════════════════════════════════════════════════════════════════════════════════╣
@@ -540,14 +540,14 @@ $ zip -r demo-1.0.0.zip demo-1.0.0/
 Armed with our zipped file and the path to it, we can head to skipper and use the `upload` command:
 
 ----
-skipper:> upload --path /Users/path-to-your-zip/demo-1.0.0.zip
+skipper:>package upload --path /Users/path-to-your-zip/demo-1.0.0.zip
 Package uploaded successfully:[demo:1.0.0]
 ----
 
 Now you can search for it as shown above, then install it!
 
 ----
-skipper:>install --package-name demo --package-version 1.0.0 --release-name demo
+skipper:>package install --package-name demo --package-version 1.0.0 --release-name demo
 Released demo. Now at version v1.
 ----
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-minute-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-minute-tour.adoc
@@ -13,7 +13,7 @@ Let's install and then update the hello world application.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>install --release-name helloworldlocal --package-name helloworld --package-version 1.0.0 --properties spec.applicationProperties.server.port=8099
+skipper:>package install --release-name helloworldlocal --package-name helloworld --package-version 1.0.0 --properties spec.applicationProperties.server.port=8099
 Released helloworldlocal. Now at version v1.
 ----
 
@@ -41,7 +41,7 @@ spec:
 The `upgrade` command
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name helloworldlocal --package-name helloworld --package-version 1.0.1 --file /home/mpollack/helloworld-upgrade-local.yml
+skipper:>release upgrade --release-name helloworldlocal --package-name helloworld --package-version 1.0.1 --file /home/mpollack/helloworld-upgrade-local.yml
 helloworldlocal has been upgraded.  Now at version v2.
 ----
 
@@ -62,7 +62,7 @@ In this case there is just one entry
 
 [source,bash,options="nowrap"]
 ----
-skipper:>list
+skipper:>release list
 ╔═══════════════╤═══════╤═════════════╤════════╤══════════╤═════════╤═════════╤════════════════════════════════════════════════════╗
 ║     Name      │Version│Last updated │ Status │ Package  │ Package │Platform │                  Platform Status                   ║
 ║               │       │             │        │   Name   │ Version │  Name   │                                                    ║
@@ -76,7 +76,7 @@ skipper:>list
 You can get the full history of the release using the `history` command.
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldlocal
+skipper:>release history --release-name helloworldlocal
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -135,7 +135,7 @@ Since we have the manifest for that version, we have all we need to redeploy an 
 
 [source,bash,options="nowrap"]
 ----
-skipper:>rollback --release-name helloworldlocal --release-version 1
+skipper:>release rollback --release-name helloworldlocal --release-version 1
 helloworldlocal has been rolled back.  Now at version v3.
 ----
 
@@ -143,7 +143,7 @@ The history now shows a new `v3` version, even though it is identical in terms o
 
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldlocal
+skipper:>release history --release-name helloworldlocal
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -248,7 +248,7 @@ skipper:>repo list
 and the `search` command shows
 [source,bash,options="nowrap"]
 ----
-skipper:>search
+skipper:>package search
 ╔═════════════════╤═══════╤════════════════════════════════════════════════════════════════════════════════╗
 ║      Name       │Version│                                  Description                                   ║
 ╠═════════════════╪═══════╪════════════════════════════════════════════════════════════════════════════════╣
@@ -275,7 +275,7 @@ Let's install the Hello World app, specifically, the maven based artifact.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>install --release-name helloworldpcf --package-name helloworld --package-version 1.0.0 --platform-name cf-dev --properties spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=helloworldpcf.cfapps.io
+skipper:>package install --release-name helloworldpcf --package-name helloworld --package-version 1.0.0 --platform-name cf-dev --properties spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=helloworldpcf.cfapps.io
 Released helloworldpcf. Now at version v1.
 ----
 
@@ -285,7 +285,7 @@ You can monitor the process using the `status command`.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>status --release-name helloworldpcf
+skipper:>release status --release-name helloworldpcf
 ╔═══════════════╤════════════════════════════════════════════════╗
 ║Last Deployed  │Tue Oct 24 22:54:30 EDT 2017                    ║
 ║Status         │DEPLOYED                                        ║
@@ -365,7 +365,7 @@ spec:
 The `upgrade` command
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name helloworldpcf --package-name helloworld --package-version 1.0.0 --file /home/mpollack/helloworld-upgrade.yml
+skipper:>release upgrade --release-name helloworldpcf --package-name helloworld --package-version 1.0.0 --file /home/mpollack/helloworld-upgrade.yml
 helloworldpcf has been upgraded.  Now at version v2.
 ----
 
@@ -414,7 +414,7 @@ $ curl http://helloworldpcf.cfapps.io/about
 Hello World v1.0.0.RELEASE
 ----
 
-The `list` command shows you the current `DEPLOYED` and `DELETED` releases for every release name.
+The `release list` command shows you the current `DEPLOYED` and `DELETED` releases for every release name.
 In this case there is just one entry
 
 [source,bash,options="nowrap"]
@@ -432,7 +432,7 @@ You can get the full history of the release using the `history` command
 
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldpcf
+skipper:>release history --release-name helloworldpcf
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -446,7 +446,7 @@ In this case, we will not add any additional properties other than the route.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name helloworldpcf --package-name helloworld --package-version 1.0.1 --properties spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=helloworldpcf.cfapps.io
+skipper:>release upgrade --release-name helloworldpcf --package-name helloworld --package-version 1.0.1 --properties spec.deploymentProperties.spring.cloud.deployer.cloudfoundry.route=helloworldpcf.cfapps.io
 helloworldpcf has been upgraded.  Now at version v3.
 ----
 
@@ -456,7 +456,7 @@ You can monitor the status of the upgrade using the `status` command
 
 [source,bash,options="nowrap"]
 ----
-skipper:>status --release-name helloworldpcf
+skipper:>release status --release-name helloworldpcf
 ╔═══════════════╤═════════════════════════════════════════════════════════════════════════════════╗
 ║Last Deployed  │Tue Oct 24 23:09:39 EDT 2017                                                     ║
 ║Status         │DEPLOYED                                                                         ║
@@ -479,7 +479,7 @@ Our history now looks like
 
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldpcf
+skipper:>release history --release-name helloworldpcf
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -494,7 +494,7 @@ Since we have the manifest for that version, we have all we need to redeploy an 
 
 [source,bash,options="nowrap"]
 ----
-skipper:>rollback --release-name helloworldpcf --release-version 2
+skipper:>release rollback --release-name helloworldpcf --release-version 2
 helloworldpcf has been rolled back.  Now at version v4.
 ----
 
@@ -502,7 +502,7 @@ The history now shows a new `v4` version, even though it is identical in terms o
 
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldpcf
+skipper:>release history --release-name helloworldpcf
 ╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
@@ -560,7 +560,7 @@ skipper:>repo list
 and the `search` command shows
 [source,bash,options="nowrap"]
 ----
-skipper:>search
+skipper:>package search
 ╔═════════════════╤═══════╤════════════════════════════════════════════════════════════════════════════════╗
 ║      Name       │Version│                                  Description                                   ║
 ╠═════════════════╪═══════╪════════════════════════════════════════════════════════════════════════════════╣
@@ -586,7 +586,7 @@ skipper:>platform list
 Let's install the Hello World app, specifically, the Docker based artifact.
 [source,bash,options="nowrap"]
 ----
-skipper:>install --release-name helloworldk8s --package-name helloworld-docker --package-version 1.0.0 --platform-name minikube --properties spec.deploymentProperties.spring.cloud.deployer.kubernetes.createNodePort=32123
+skipper:>package install --release-name helloworldk8s --package-name helloworld-docker --package-version 1.0.0 --platform-name minikube --properties spec.deploymentProperties.spring.cloud.deployer.kubernetes.createNodePort=32123
 Released helloworldk8s. Now at version v1.
 ----
 
@@ -595,7 +595,7 @@ If you do not specify `--platform-name minikube` the command will fail since the
 You can monitor the process using the `status command`.
 [source,bash,options="nowrap"]
 ----
-skipper:>status --release-name helloworldk8s
+skipper:>release status --release-name helloworldk8s
 ╔═══════════════╤══════════════════════════════════════════════════════════════════════════════════════════════════╗
 ║Last Deployed  │Wed Oct 25 17:34:24 EDT 2017                                                                      ║
 ║Status         │DEPLOYED                                                                                          ║
@@ -678,10 +678,10 @@ spec:
     spring.cloud.deployer.memory: 2048m
 ----
 
-The `upgrade` command
+The `release upgrade` command
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name helloworldk8s --package-name helloworld-docker --package-version 1.0.0 --file /home/mpollack/helloworld-upgrade-k8s.yml
+skipper:>release upgrade --release-name helloworldk8s --package-name helloworld-docker --package-version 1.0.0 --file /home/mpollack/helloworld-upgrade-k8s.yml
 helloworldk8s has been upgraded.  Now at version v2.
 ----
 
@@ -729,11 +729,11 @@ Hello World v1.0.0.RELEASE
 ----
 
 
-The `list` command shows you the current `DEPLOYED` and `DELETED` release for every release name.
+The `release list` command shows you the current `DEPLOYED` and `DELETED` release for every release name.
 In this case there is just one entry
 [source,bash,options="nowrap"]
 ----
-skipper:>list
+skipper:>release list
 ╔═════════════╤═══════╤════════════════════════════╤════════╤═════════════════╤═══════════════╤═════════════╤═══════════════╗
 ║    Name     │Version│        Last updated        │ Status │  Package Name   │Package Version│Platform Name│Platform Status║
 ╠═════════════╪═══════╪════════════════════════════╪════════╪═════════════════╪═══════════════╪═════════════╪═══════════════╣
@@ -744,7 +744,7 @@ skipper:>list
 You can get the full history of the release using the `history` command.
 
 ----
-skipper:>history --release-name helloworldk8s
+skipper:>release history --release-name helloworldk8s
 ╔═══════╤════════════════════════════╤════════╤═════════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │  Package Name   │Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪═════════════════╪═══════════════╪════════════════╣
@@ -757,7 +757,7 @@ In this case we will not add any additional properties other than the NodePort.
 
 [source,bash,options="nowrap"]
 ----
-skipper:>upgrade --release-name helloworldk8s --package-name helloworld-docker --package-version 1.0.1 --properties spec.deploymentProperties.spring.cloud.deployer.kubernetes.createNodePort=32125
+skipper:>release upgrade --release-name helloworldk8s --package-name helloworld-docker --package-version 1.0.1 --properties spec.deploymentProperties.spring.cloud.deployer.kubernetes.createNodePort=32125
 Released helloworldk8s. Now at version v3.
 ----
 
@@ -767,7 +767,7 @@ You can monitor the status of the upgrade using the `status` command
 
 [source,bash,options="nowrap"]
 ----
-skipper:>status --release-name helloworldk8s
+skipper:>release status --release-name helloworldk8s
 ╔═══════════════╤══════════════════════════════════════════════════════════════════════════════════════════════════╗
 ║Last Deployed  │Wed Oct 25 17:41:33 EDT 2017                                                                      ║
 ║Status         │DEPLOYED                                                                                          ║
@@ -789,7 +789,7 @@ Hello World v1.0.1.RELEASE
 Our history now looks like
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldk8s
+skipper:>release history --release-name helloworldk8s
 ╔═══════╤════════════════════════════╤════════╤═════════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │  Package Name   │Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪═════════════════╪═══════════════╪════════════════╣
@@ -804,7 +804,7 @@ Since we have the manifest for that version, we have all we need to redeploy an 
 
 [source,bash,options="nowrap"]
 ----
-skipper:>rollback --release-name helloworldk8s --release-version 2
+skipper:>release rollback --release-name helloworldk8s --release-version 2
 helloworldk8s has been rolled back.  Now at version v4.
 ----
 
@@ -812,7 +812,7 @@ The history now shows a new `v4` version, even though it is identical to the `v2
 
 [source,bash,options="nowrap"]
 ----
-skipper:>history --release-name helloworldk8s
+skipper:>release history --release-name helloworldk8s
 ╔═══════╤════════════════════════════╤════════╤═════════════════╤═══════════════╤════════════════╗
 ║Version│        Last updated        │ Status │  Package Name   │Package Version│  Description   ║
 ╠═══════╪════════════════════════════╪════════╪═════════════════╪═══════════════╪════════════════╣


### PR DESCRIPTION
 - Add appropriate prefixes such as `package`, `release` for the newly refactored controllers PackageController and ReleaseController respectively.

Resolves #457