### PR TITLE
Update DELETE request

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.skipper.domain.AboutResource;
-import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -224,10 +223,10 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Release delete(String releaseName, DeleteProperties deleteProperties) {
-		String url = String.format("%s/%s/%s/%s", baseUri, "release", "delete", releaseName);
-		log.debug("Posting Delete to " + url + ". DeleteProperties = " + deleteProperties);
-		return this.restTemplate.postForObject(url, deleteProperties, Release.class);
+	public void delete(String releaseName, boolean deletePackage) {
+		String url = String.format("%s/%s/%s/%s", baseUri, "release", releaseName, deletePackage);
+		log.debug("Sending Delete request to " + url + " with the option deletePackage = " + deletePackage);
+		this.restTemplate.delete(url, deletePackage);
 	}
 
 	@Override
@@ -327,7 +326,7 @@ public class DefaultSkipperClient implements SkipperClient {
 	@Override
 	public void packageDelete(String packageName) {
 		String url = String.format("%s/%s/%s", baseUri, "package", packageName);
-		restTemplate.delete(url);
+		this.restTemplate.delete(url);
 	}
 
 	protected Traverson createTraverson(String baseUrl, RestOperations restOperations) {

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.skipper.client;
 import java.util.List;
 
 import org.springframework.cloud.skipper.domain.AboutResource;
-import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -91,12 +90,10 @@ public interface SkipperClient {
 
 	/**
 	 * Delete a specific release.
-	 *
-	 * @param releaseName the release name
-	 * @param deleteProperties release delete properties
-	 * @return the deleted {@link Release}
-	 */
-	Release delete(String releaseName, DeleteProperties deleteProperties);
+	 *  @param releaseName the release name
+	 * @param deletePackage delete package when deleting the release
+	 * */
+	void delete(String releaseName, boolean deletePackage);
 
 	/**
 	 * Rollback a specific release.

--- a/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
@@ -510,7 +510,28 @@ include::{snippets}/manifest-documentation/get-manifest-of-release-for-version/h
 
 ===== Delete a release
 
-Delete an existing release by uninstalling the installed packages corresponding to the release.
+Delete an existing release.
+This doesn't uninstall the uploaded packages corresponding to the release.
+
+====== Request structure
+
+include::{snippets}/delete-documentation/delete-release-default/http-request.adoc[]
+
+====== Example request
+
+include::{snippets}/delete-documentation/delete-release-default/curl-request.adoc[]
+
+====== Response structure
+
+include::{snippets}/delete-documentation/delete-release-default/http-response.adoc[]
+
+====== Response fields
+
+include::{snippets}/delete-documentation/delete-release-default/response-fields.adoc[]
+
+===== Delete a release
+
+Delete an existing release by providing an option to uninstall the installed packages corresponding to the release.
 
 ====== Request structure
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/security.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/security.adoc
@@ -253,7 +253,7 @@ no way to merge lists). Always refer to your version of `application.yml`, as th
 
             # Delete
 
-            - POST /api/release/delete/**        => hasRole('ROLE_CREATE')
+            - DELETE /api/release/**             => hasRole('ROLE_CREATE')
 
             # History
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -90,7 +90,7 @@ public class ReleaseController {
 		resource.add(
 				ControllerLinkBuilder.linkTo(methodOn(ReleaseController.class).rollback(null, 123))
 						.withRel("rollback"));
-		resource.add(ControllerLinkBuilder.linkTo(methodOn(ReleaseController.class).delete(null, null))
+		resource.add(ControllerLinkBuilder.linkTo(methodOn(ReleaseController.class).delete(null, true))
 							.withRel("delete"));
 		resource.add(ControllerLinkBuilder.linkTo(methodOn(ReleaseController.class).list())
 				.withRel("list"));
@@ -141,10 +141,19 @@ public class ReleaseController {
 		return this.releaseResourceAssembler.toResource(release);
 	}
 
-	@RequestMapping(path = "/delete/{name}", method = RequestMethod.POST)
-	@ResponseStatus(HttpStatus.CREATED)
+	@RequestMapping(path = "/{name}", method = RequestMethod.DELETE)
+	@ResponseStatus(HttpStatus.OK)
+	public Resource<Release> delete(@PathVariable("name") String releaseName) {
+		Release release = this.skipperStateMachineService.deleteRelease(releaseName, new DeleteProperties());
+		return this.releaseResourceAssembler.toResource(release);
+	}
+
+	@RequestMapping(path = "/{name}/{deletePackage}", method = RequestMethod.DELETE)
+	@ResponseStatus(HttpStatus.OK)
 	public Resource<Release> delete(@PathVariable("name") String releaseName,
-			@RequestBody DeleteProperties deleteProperties) {
+			@PathVariable("deletePackage") boolean deletePackage) {
+		DeleteProperties deleteProperties = new DeleteProperties();
+		deleteProperties.setDeletePackage(deletePackage);
 		Release release = this.skipperStateMachineService.deleteRelease(releaseName, deleteProperties);
 		return this.releaseResourceAssembler.toResource(release);
 	}

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -87,16 +87,16 @@ spring:
 
             # Delete
 
-            - POST /api/release/delete/**        => hasRole('ROLE_CREATE')
+            - DELETE /api/release/**             => hasRole('ROLE_CREATE')
 
             # History
 
-            - GET /api/release/history/**           => hasRole('ROLE_VIEW')
+            - GET /api/release/history/**        => hasRole('ROLE_VIEW')
 
             # List
 
-            - GET /api/release/list                         => hasRole('ROLE_VIEW')
-            - GET /api/release/list/**                      => hasRole('ROLE_VIEW')
+            - GET /api/release/list              => hasRole('ROLE_VIEW')
+            - GET /api/release/list/**           => hasRole('ROLE_VIEW')
 
             # Packages
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/AbstractControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/AbstractControllerTests.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
@@ -38,6 +37,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -75,10 +75,9 @@ public abstract class AbstractControllerTests extends AbstractMockMvcTests {
 		for (Release release : releaseRepository.findAll()) {
 			if (release.getInfo().getStatus().getStatusCode() != StatusCode.DELETED) {
 				try {
-					mockMvc.perform(post("/api/release/delete/" + release.getName())
-								.content(convertObjectToJson(new DeleteProperties())))
+					mockMvc.perform(delete("/api/release/" + release.getName()))
 							.andDo(print())
-							.andExpect(status().isCreated()).andReturn();
+							.andExpect(status().isOk()).andReturn();
 				}
 				catch (Exception e) {
 					logger.warn("Can not delete release {}-v{}, as it has not yet deployed.", release.getName(),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.nio.charset.Charset;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.StatusCode;
@@ -28,7 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.StringUtils;
 
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
@@ -37,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
 @ActiveProfiles("repo-test")
 public class DeleteDocumentation extends BaseDocumentation {
@@ -58,11 +58,87 @@ public class DeleteDocumentation extends BaseDocumentation {
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
 		this.mockMvc.perform(
-				post("/api/release/delete/{releaseName}", releaseName)
-						.accept(MediaType.APPLICATION_JSON).contentType(contentType)
-						.content(convertObjectToJson(new DeleteProperties())))
+				delete("/api/release/{releaseName}/{deletePackage}", releaseName, false)
+						.accept(MediaType.APPLICATION_JSON).contentType(contentType))
 				.andDo(print())
-				.andExpect(status().isCreated())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						responseFields(
+								subsectionWithPath("links").ignored(),
+								fieldWithPath("name").description("Name of the release"),
+								fieldWithPath("version").description("Version of the release"),
+								fieldWithPath("info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("pkg.metadata.repositoryId")
+										.description("The repository ID this Package belongs to."),
+								fieldWithPath("pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
+								fieldWithPath("pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.displayName").description("Display name of the release"),
+								fieldWithPath("pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
+								fieldWithPath("pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("manifest.data").description("The manifest of the release"),
+								fieldWithPath("platformName").description("Platform name of the release"))));
+	}
+
+	@Test
+	public void deleteReleaseDefault() throws Exception {
+		final String releaseName = "myLogRelease1";
+		final InstallRequest installRequest = new InstallRequest();
+		final PackageIdentifier packageIdentifier = new PackageIdentifier();
+		packageIdentifier.setPackageName("log");
+		packageIdentifier.setPackageVersion("1.0.0");
+		packageIdentifier.setRepositoryName("notused");
+		installRequest.setPackageIdentifier(packageIdentifier);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
+
+		installPackage(installRequest);
+
+		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
+				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+
+		this.mockMvc.perform(
+				delete("/api/release/{releaseName}", releaseName)
+						.accept(MediaType.APPLICATION_JSON).contentType(contentType))
+				.andDo(print())
+				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						responseFields(
 								subsectionWithPath("links").ignored(),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2017 the original author or authors.
  *

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/PackageCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/PackageCommands.java
@@ -155,7 +155,7 @@ public class PackageCommands extends AbstractSkipperCommand {
 
 	@ShellMethod(key = "package delete", value = "Delete a package.")
 	public String packageDelete(@ShellOption(help = "the package name to be deleted") String packageName) {
-		skipperClient.packageDelete(packageName);
+		this.skipperClient.packageDelete(packageName);
 		return String.format("Deleted Package '%s'", packageName);
 	}
 

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
@@ -15,13 +15,12 @@
  */
 package org.springframework.cloud.skipper.shell.command;
 
+import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
-
-import javax.validation.constraints.NotNull;
 
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
@@ -32,7 +31,6 @@ import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.ConfigValues;
-import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
@@ -195,11 +193,9 @@ public class ReleaseCommands extends AbstractSkipperCommand {
 	public String delete(
 			@ShellOption(help = "the name of the release to delete") String releaseName,
 			@ShellOption(help = "delete the release package", defaultValue = "false") boolean deletePackage) {
-		DeleteProperties deleteProperties = new DeleteProperties();
-		deleteProperties.setDeletePackage(deletePackage);
-		Release release = skipperClient.delete(releaseName, deleteProperties);
+		this.skipperClient.delete(releaseName, deletePackage);
 		StringBuilder sb = new StringBuilder();
-		sb.append(release.getName() + " has been deleted.");
+		sb.append(releaseName + " has been deleted.");
 		return sb.toString();
 	}
 


### PR DESCRIPTION
 - Use DELETE HTTP request instead of POST
 - Update ReleaseController `delete` method
   - Since this causes removal of request body in DELETE request, update the REST endpoint to use `deletePackage` as a path variable
   - Add a default DELETE request method that has `deletePackage` set to `false` in DeleteProperties
 - Update security config for the DELETE request endpoint changes
 - Update tests

Resolves #444