### PR TITLE
Add Flyway support for the DB schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <spring-cloud-deployer-local.version>1.3.0.M2</spring-cloud-deployer-local.version>
         <reactor.version>3.0.7.RELEASE</reactor.version>
         <spring-shell.version>2.0.0.RELEASE</spring-shell.version>
-        <spring-statemachine.version>1.2.8.RC3</spring-statemachine.version>
+        <spring-statemachine.version>1.2.8.BUILD-SNAPSHOT</spring-statemachine.version>
         <jsonpath.version>2.2.0</jsonpath.version>
         <equalverifier.version>2.4.1</equalverifier.version>
 

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <version>5.0.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-keyvalue</artifactId>
         </dependency>
@@ -79,6 +84,9 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -108,6 +116,11 @@
         <dependency>
             <groupId>org.springframework.statemachine</groupId>
             <artifactId>spring-statemachine-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>oracle.sucks</groupId>
+            <artifactId>ojdbc6</artifactId>
+            <version>1.0.0.whocares</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.statemachine</groupId>
@@ -188,6 +201,7 @@
                 <filtering>true</filtering>
                 <includes>
                     <include>application.yml</include>
+                    <include>db/**</include>
                 </includes>
             </resource>
         </resources>
@@ -204,4 +218,5 @@
             </plugin>
         </plugins>
     </build>
+   
 </project>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -73,7 +73,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
-       
+
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
@@ -117,11 +117,6 @@
         <dependency>
             <groupId>org.springframework.statemachine</groupId>
             <artifactId>spring-statemachine-data-jpa</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>oracle.sucks</groupId>
-            <artifactId>ojdbc6</artifactId>
-            <version>1.0.0.whocares</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.statemachine</groupId>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -73,6 +73,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
+       
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     rest:
       base-path: /api
   jpa:
-    generate-ddl: true
+    generate-ddl: false
     properties:
       hibernate.id.new_generator_mappings: true
   cloud:
@@ -153,4 +153,6 @@ logging:
     # The following INFO is to log the generated password when using basic security
     org.springframework.boot.autoconfigure.security: 'INFO'
     org.springframework.cloud.skipper: 'INFO'
-    org.springframework.statemachine: 'INFO'    
+    org.springframework.statemachine: 'INFO'
+flyway:
+  locations: /db/migration/{vendor}

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/db2/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/db2/V1__INITIAL_SETUP.sql
@@ -1,0 +1,262 @@
+create sequence hibernate_sequence start with 1 increment by 1;
+
+create table action (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table deferred_events (
+    jpa_repository_state_id bigint not null,
+    deferred_events varchar(255)
+);
+
+create table guard (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table skipper_app_deployer_data (
+    id bigint not null,
+    object_version bigint,
+    deployment_data clob(255),
+    release_name varchar(255),
+    release_version integer,
+    primary key (id)
+);
+
+create table skipper_info (
+    id bigint not null,
+    object_version bigint,
+    deleted timestamp,
+    description varchar(255),
+    first_deployed timestamp,
+    last_deployed timestamp,
+    status_id bigint,
+    primary key (id)
+);
+
+create table skipper_manifest (
+    id bigint not null,
+    object_version bigint,
+    data clob(255),
+    primary key (id)
+);
+
+create table skipper_package_file (
+    id bigint not null,
+    package_bytes blob(255),
+    primary key (id)
+);
+
+create table skipper_package_metadata (
+    id bigint not null,
+    object_version bigint,
+    api_version varchar(255),
+    description clob(255),
+    display_name varchar(255),
+    icon_url clob(255),
+    kind varchar(255),
+    maintainer varchar(255),
+    name varchar(255),
+    origin varchar(255),
+    package_home_url clob(255),
+    package_source_url clob(255),
+    repository_id bigint,
+    repository_name varchar(255),
+    sha256 varchar(255),
+    tags clob(255),
+    version varchar(255),
+    packagefile_id bigint,
+    primary key (id)
+);
+
+create table skipper_release (
+    id bigint not null,
+    object_version bigint,
+    config_values_string clob(255),
+    name varchar(255),
+    package_metadata_id bigint,
+    pkg_json_string clob(255),
+    platform_name varchar(255),
+    repository_id bigint,
+    version integer not null,
+    info_id bigint,
+    manifest_id bigint,
+    primary key (id)
+);
+
+create table skipper_repository (
+    id bigint not null,
+    object_version bigint,
+    description varchar(255),
+    local smallint,
+    name varchar(255),
+    repo_order integer,
+    source_url varchar(255),
+    url varchar(255),
+    primary key (id)
+);
+
+create table skipper_status (
+    id bigint not null,
+    platform_status clob(255),
+    status_code varchar(255),
+    primary key (id)
+);
+
+create table state (
+    id bigint not null,
+    initial_state smallint not null,
+    kind integer,
+    machine_id varchar(255),
+    region varchar(255),
+    state varchar(255),
+    submachine_id varchar(255),
+    initial_action_id bigint,
+    parent_state_id bigint,
+    primary key (id)
+);
+
+create table state_entry_actions (
+    jpa_repository_state_id bigint not null,
+    entry_actions_id bigint not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table state_exit_actions (
+    jpa_repository_state_id bigint not null,
+    exit_actions_id bigint not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table state_state_actions (
+    jpa_repository_state_id bigint not null,
+    state_actions_id bigint not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table state_machine (
+    machine_id varchar(255) not null,
+    state varchar(255),
+    state_machine_context blob(255),
+    primary key (machine_id)
+);
+
+create table transition (
+    id bigint not null,
+    event varchar(255),
+    kind integer,
+    machine_id varchar(255),
+    guard_id bigint,
+    source_id bigint,
+    target_id bigint,
+    primary key (id)
+);
+
+create table transition_actions (
+    jpa_repository_transition_id bigint not null,
+    actions_id bigint not null,
+    primary key (jpa_repository_transition_id, actions_id)
+);
+
+create index idx_pkg_name on skipper_package_metadata (name);
+
+create index idx_rel_name on skipper_release (name);
+
+create index idx_repo_name on skipper_repository (name);
+
+create unique index uk_repository on skipper_repository (name);
+
+alter table deferred_events
+    add constraint fk_state_deferred_events
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table skipper_info
+    add constraint fk_info_status
+    foreign key (status_id)
+    references skipper_status;
+
+alter table skipper_package_metadata
+    add constraint FKq2maocius5sr76isk7xlhn7b4
+    foreign key (packagefile_id)
+    references skipper_package_file;
+
+alter table skipper_release
+    add constraint fk_release_info
+    foreign key (info_id)
+    references skipper_info;
+
+alter table skipper_release
+    add constraint fk_release_manifest
+    foreign key (manifest_id)
+    references skipper_manifest;
+
+alter table state
+    add constraint fk_state_initial_action
+    foreign key (initial_action_id)
+    references action;
+
+alter table state
+    add constraint fk_state_parent_state
+    foreign key (parent_state_id)
+    references state;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_a
+    foreign key (entry_actions_id)
+    references action;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_a
+    foreign key (exit_actions_id)
+    references action;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_a
+    foreign key (state_actions_id)
+    references action;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_guard
+    foreign key (guard_id)
+    references guard;
+
+alter table transition
+    add constraint fk_transition_source
+    foreign key (source_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_target
+    foreign key (target_id)
+    references state;
+
+alter table transition_actions
+    add constraint fk_transition_actions_a
+    foreign key (actions_id)
+    references action;
+
+alter table transition_actions
+    add constraint fk_transition_actions_t
+    foreign key (jpa_repository_transition_id)
+    references transition;

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/h2/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/h2/V1__INITIAL_SETUP.sql
@@ -1,0 +1,263 @@
+create sequence hibernate_sequence start with 1 increment by 1;
+
+create table action (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table deferred_events (
+    jpa_repository_state_id bigint not null,
+    deferred_events varchar(255)
+);
+
+create table guard (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table skipper_app_deployer_data (
+    id bigint not null,
+    object_version bigint,
+    deployment_data clob,
+    release_name varchar(255),
+    release_version integer,
+    primary key (id)
+);
+
+create table skipper_info (
+    id bigint not null,
+    object_version bigint,
+    deleted timestamp,
+    description varchar(255),
+    first_deployed timestamp,
+    last_deployed timestamp,
+    status_id bigint,
+    primary key (id)
+);
+
+create table skipper_manifest (
+    id bigint not null,
+    object_version bigint,
+    data clob,
+    primary key (id)
+);
+
+create table skipper_package_file (
+    id bigint not null,
+    package_bytes blob,
+    primary key (id)
+);
+
+create table skipper_package_metadata (
+    id bigint not null,
+    object_version bigint,
+    api_version varchar(255),
+    description clob,
+    display_name varchar(255),
+    icon_url clob,
+    kind varchar(255),
+    maintainer varchar(255),
+    name varchar(255),
+    origin varchar(255),
+    package_home_url clob,
+    package_source_url clob,
+    repository_id bigint,
+    repository_name varchar(255),
+    sha256 varchar(255),
+    tags clob,
+    version varchar(255),
+    packagefile_id bigint,
+    primary key (id)
+);
+
+create table skipper_release (
+    id bigint not null,
+    object_version bigint,
+    config_values_string clob,
+    name varchar(255),
+    package_metadata_id bigint,
+    pkg_json_string clob,
+    platform_name varchar(255),
+    repository_id bigint,
+    version integer not null,
+    info_id bigint,
+    manifest_id bigint,
+    primary key (id)
+);
+
+create table skipper_repository (
+    id bigint not null,
+    object_version bigint,
+    description varchar(255),
+    local boolean,
+    name varchar(255),
+    repo_order integer,
+    source_url varchar(255),
+    url varchar(255),
+    primary key (id)
+);
+
+create table skipper_status (
+    id bigint not null,
+    platform_status clob,
+    status_code varchar(255),
+    primary key (id)
+);
+
+create table state (
+    id bigint not null,
+    initial_state boolean not null,
+    kind integer,
+    machine_id varchar(255),
+    region varchar(255),
+    state varchar(255),
+    submachine_id varchar(255),
+    initial_action_id bigint,
+    parent_state_id bigint,
+    primary key (id)
+);
+
+create table state_entry_actions (
+    jpa_repository_state_id bigint not null,
+    entry_actions_id bigint not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table state_exit_actions (
+    jpa_repository_state_id bigint not null,
+    exit_actions_id bigint not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table state_state_actions (
+    jpa_repository_state_id bigint not null,
+    state_actions_id bigint not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table state_machine (
+    machine_id varchar(255) not null,
+    state varchar(255),
+    state_machine_context blob,
+    primary key (machine_id)
+);
+
+create table transition (
+    id bigint not null,
+    event varchar(255),
+    kind integer,
+    machine_id varchar(255),
+    guard_id bigint,
+    source_id bigint,
+    target_id bigint,
+    primary key (id)
+);
+
+create table transition_actions (
+    jpa_repository_transition_id bigint not null,
+    actions_id bigint not null,
+    primary key (jpa_repository_transition_id, actions_id)
+);
+
+create index idx_pkg_name on skipper_package_metadata (name);
+
+create index idx_rel_name on skipper_release (name);
+
+create index idx_repo_name on skipper_repository (name);
+
+alter table skipper_repository
+    add constraint uk_repository unique (name);
+
+alter table deferred_events
+    add constraint fk_state_deferred_events
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table skipper_info
+    add constraint fk_info_status
+    foreign key (status_id)
+    references skipper_status;
+
+alter table skipper_package_metadata
+    add constraint FKq2maocius5sr76isk7xlhn7b4
+    foreign key (packagefile_id)
+    references skipper_package_file;
+
+alter table skipper_release
+    add constraint fk_release_info
+    foreign key (info_id)
+    references skipper_info;
+
+alter table skipper_release
+    add constraint fk_release_manifest
+    foreign key (manifest_id)
+    references skipper_manifest;
+
+alter table state
+    add constraint fk_state_initial_action
+    foreign key (initial_action_id)
+    references action;
+
+alter table state
+    add constraint fk_state_parent_state
+    foreign key (parent_state_id)
+    references state;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_a
+    foreign key (entry_actions_id)
+    references action;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_a
+    foreign key (exit_actions_id)
+    references action;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_a
+    foreign key (state_actions_id)
+    references action;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_guard
+    foreign key (guard_id)
+    references guard;
+
+alter table transition
+    add constraint fk_transition_source
+    foreign key (source_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_target
+    foreign key (target_id)
+    references state;
+
+alter table transition_actions
+    add constraint fk_transition_actions_a
+    foreign key (actions_id)
+    references action;
+
+alter table transition_actions
+    add constraint fk_transition_actions_t
+    foreign key (jpa_repository_transition_id)
+    references transition;

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/hsqldb/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/hsqldb/V1__INITIAL_SETUP.sql
@@ -1,0 +1,263 @@
+create sequence hibernate_sequence start with 1 increment by 1;
+
+create table action (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table deferred_events (
+    jpa_repository_state_id bigint not null,
+    deferred_events varchar(255)
+);
+
+create table guard (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table skipper_app_deployer_data (
+    id bigint not null,
+    object_version bigint,
+    deployment_data clob(255),
+    release_name varchar(255),
+    release_version integer,
+    primary key (id)
+);
+
+create table skipper_info (
+    id bigint not null,
+    object_version bigint,
+    deleted timestamp,
+    description varchar(255),
+    first_deployed timestamp,
+    last_deployed timestamp,
+    status_id bigint,
+    primary key (id)
+);
+
+create table skipper_manifest (
+    id bigint not null,
+    object_version bigint,
+    data clob(255),
+    primary key (id)
+);
+
+create table skipper_package_file (
+    id bigint not null,
+    package_bytes blob(255),
+    primary key (id)
+);
+
+create table skipper_package_metadata (
+    id bigint not null,
+    object_version bigint,
+    api_version varchar(255),
+    description clob(255),
+    display_name varchar(255),
+    icon_url clob(255),
+    kind varchar(255),
+    maintainer varchar(255),
+    name varchar(255),
+    origin varchar(255),
+    package_home_url clob(255),
+    package_source_url clob(255),
+    repository_id bigint,
+    repository_name varchar(255),
+    sha256 varchar(255),
+    tags clob(255),
+    version varchar(255),
+    packagefile_id bigint,
+    primary key (id)
+);
+
+create table skipper_release (
+    id bigint not null,
+    object_version bigint,
+    config_values_string clob(255),
+    name varchar(255),
+    package_metadata_id bigint,
+    pkg_json_string clob(255),
+    platform_name varchar(255),
+    repository_id bigint,
+    version integer not null,
+    info_id bigint,
+    manifest_id bigint,
+    primary key (id)
+);
+
+create table skipper_repository (
+    id bigint not null,
+    object_version bigint,
+    description varchar(255),
+    local boolean,
+    name varchar(255),
+    repo_order integer,
+    source_url varchar(255),
+    url varchar(255),
+    primary key (id)
+);
+
+create table skipper_status (
+    id bigint not null,
+    platform_status clob(255),
+    status_code varchar(255),
+    primary key (id)
+);
+
+create table state (
+    id bigint not null,
+    initial_state boolean not null,
+    kind integer,
+    machine_id varchar(255),
+    region varchar(255),
+    state varchar(255),
+    submachine_id varchar(255),
+    initial_action_id bigint,
+    parent_state_id bigint,
+    primary key (id)
+);
+
+create table state_entry_actions (
+    jpa_repository_state_id bigint not null,
+    entry_actions_id bigint not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table state_exit_actions (
+    jpa_repository_state_id bigint not null,
+    exit_actions_id bigint not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table state_state_actions (
+    jpa_repository_state_id bigint not null,
+    state_actions_id bigint not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table state_machine (
+    machine_id varchar(255) not null,
+    state varchar(255),
+    state_machine_context blob(255),
+    primary key (machine_id)
+);
+
+create table transition (
+    id bigint not null,
+    event varchar(255),
+    kind integer,
+    machine_id varchar(255),
+    guard_id bigint,
+    source_id bigint,
+    target_id bigint,
+    primary key (id)
+);
+
+create table transition_actions (
+    jpa_repository_transition_id bigint not null,
+    actions_id bigint not null,
+    primary key (jpa_repository_transition_id, actions_id)
+);
+
+create index idx_pkg_name on skipper_package_metadata (name);
+
+create index idx_rel_name on skipper_release (name);
+
+create index idx_repo_name on skipper_repository (name);
+
+alter table skipper_repository
+    add constraint uk_repository unique (name);
+
+alter table deferred_events
+    add constraint fk_state_deferred_events
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table skipper_info
+    add constraint fk_info_status
+    foreign key (status_id)
+    references skipper_status;
+
+alter table skipper_package_metadata
+    add constraint FKq2maocius5sr76isk7xlhn7b4
+    foreign key (packagefile_id)
+    references skipper_package_file;
+
+alter table skipper_release
+    add constraint fk_release_info
+    foreign key (info_id)
+    references skipper_info;
+
+alter table skipper_release
+    add constraint fk_release_manifest
+    foreign key (manifest_id)
+    references skipper_manifest;
+
+alter table state
+    add constraint fk_state_initial_action
+    foreign key (initial_action_id)
+    references action;
+
+alter table state
+    add constraint fk_state_parent_state
+    foreign key (parent_state_id)
+    references state;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_a
+    foreign key (entry_actions_id)
+    references action;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_a
+    foreign key (exit_actions_id)
+    references action;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_a
+    foreign key (state_actions_id)
+    references action;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_guard
+    foreign key (guard_id)
+    references guard;
+
+alter table transition
+    add constraint fk_transition_source
+    foreign key (source_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_target
+    foreign key (target_id)
+    references state;
+
+alter table transition_actions
+    add constraint fk_transition_actions_a
+    foreign key (actions_id)
+    references action;
+
+alter table transition_actions
+    add constraint fk_transition_actions_t
+    foreign key (jpa_repository_transition_id)
+    references transition;

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/mysql/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/mysql/V1__INITIAL_SETUP.sql
@@ -1,0 +1,267 @@
+create table action (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table deferred_events (
+    jpa_repository_state_id bigint not null,
+    deferred_events varchar(255)
+);
+
+create table guard (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table hibernate_sequence (
+    next_val bigint
+);
+
+insert into hibernate_sequence values ( 1 );
+
+create table skipper_app_deployer_data (
+    id bigint not null,
+    object_version bigint,
+    deployment_data longtext,
+    release_name varchar(255),
+    release_version integer,
+    primary key (id)
+);
+
+create table skipper_info (
+    id bigint not null,
+    object_version bigint,
+    deleted datetime,
+    description varchar(255),
+    first_deployed datetime,
+    last_deployed datetime,
+    status_id bigint,
+    primary key (id)
+);
+
+create table skipper_manifest (
+    id bigint not null,
+    object_version bigint,
+    data longtext,
+    primary key (id)
+);
+
+create table skipper_package_file (
+    id bigint not null,
+    package_bytes longblob,
+    primary key (id)
+);
+
+create table skipper_package_metadata (
+    id bigint not null,
+    object_version bigint,
+    api_version varchar(255),
+    description longtext,
+    display_name varchar(255),
+    icon_url longtext,
+    kind varchar(255),
+    maintainer varchar(255),
+    name varchar(255),
+    origin varchar(255),
+    package_home_url longtext,
+    package_source_url longtext,
+    repository_id bigint,
+    repository_name varchar(255),
+    sha256 varchar(255),
+    tags longtext,
+    version varchar(255),
+    packagefile_id bigint,
+    primary key (id)
+);
+
+create table skipper_release (
+    id bigint not null,
+    object_version bigint,
+    config_values_string longtext,
+    name varchar(255),
+    package_metadata_id bigint,
+    pkg_json_string longtext,
+    platform_name varchar(255),
+    repository_id bigint,
+    version integer not null,
+    info_id bigint,
+    manifest_id bigint,
+    primary key (id)
+);
+
+create table skipper_repository (
+    id bigint not null,
+    object_version bigint,
+    description varchar(255),
+    local bit,
+    name varchar(255),
+    repo_order integer,
+    source_url varchar(255),
+    url varchar(255),
+    primary key (id)
+);
+
+create table skipper_status (
+    id bigint not null,
+    platform_status longtext,
+    status_code varchar(255),
+    primary key (id)
+);
+
+create table state (
+    id bigint not null,
+    initial_state bit not null,
+    kind integer,
+    machine_id varchar(255),
+    region varchar(255),
+    state varchar(255),
+    submachine_id varchar(255),
+    initial_action_id bigint,
+    parent_state_id bigint,
+    primary key (id)
+);
+
+create table state_entry_actions (
+    jpa_repository_state_id bigint not null,
+    entry_actions_id bigint not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table state_exit_actions (
+    jpa_repository_state_id bigint not null,
+    exit_actions_id bigint not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table state_state_actions (
+    jpa_repository_state_id bigint not null,
+    state_actions_id bigint not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table state_machine (
+    machine_id varchar(255) not null,
+    state varchar(255),
+    state_machine_context longblob,
+    primary key (machine_id)
+);
+
+create table transition (
+    id bigint not null,
+    event varchar(255),
+    kind integer,
+    machine_id varchar(255),
+    guard_id bigint,
+    source_id bigint,
+    target_id bigint,
+    primary key (id)
+);
+
+create table transition_actions (
+    jpa_repository_transition_id bigint not null,
+    actions_id bigint not null,
+    primary key (jpa_repository_transition_id, actions_id)
+);
+
+create index idx_pkg_name on skipper_package_metadata (name);
+
+create index idx_rel_name on skipper_release (name);
+
+create index idx_repo_name on skipper_repository (name);
+
+alter table skipper_repository
+    add constraint uk_repository unique (name);
+
+alter table deferred_events
+    add constraint fk_state_deferred_events
+    foreign key (jpa_repository_state_id)
+    references state (id);
+
+alter table skipper_info
+    add constraint fk_info_status
+    foreign key (status_id)
+    references skipper_status (id);
+
+alter table skipper_package_metadata
+    add constraint FKq2maocius5sr76isk7xlhn7b4
+    foreign key (packagefile_id)
+    references skipper_package_file (id);
+
+alter table skipper_release
+    add constraint fk_release_info
+    foreign key (info_id)
+    references skipper_info (id);
+
+alter table skipper_release
+    add constraint fk_release_manifest
+    foreign key (manifest_id)
+    references skipper_manifest (id);
+
+alter table state
+    add constraint fk_state_initial_action
+    foreign key (initial_action_id)
+    references action (id);
+
+alter table state
+    add constraint fk_state_parent_state
+    foreign key (parent_state_id)
+    references state (id);
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_a
+    foreign key (entry_actions_id)
+    references action (id);
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_s
+    foreign key (jpa_repository_state_id)
+    references state (id);
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_a
+    foreign key (exit_actions_id)
+    references action (id);
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_s
+    foreign key (jpa_repository_state_id)
+    references state (id);
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_a
+    foreign key (state_actions_id)
+    references action (id);
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_s
+    foreign key (jpa_repository_state_id)
+    references state (id);
+
+alter table transition
+    add constraint fk_transition_guard
+    foreign key (guard_id)
+    references guard (id);
+
+alter table transition
+    add constraint fk_transition_source
+    foreign key (source_id)
+    references state (id);
+
+alter table transition
+    add constraint fk_transition_target
+    foreign key (target_id)
+    references state (id);
+
+alter table transition_actions
+    add constraint fk_transition_actions_a
+    foreign key (actions_id)
+    references action (id);
+
+alter table transition_actions
+    add constraint fk_transition_actions_t
+    foreign key (jpa_repository_transition_id)
+    references transition (id);

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/oracle/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/oracle/V1__INITIAL_SETUP.sql
@@ -1,0 +1,250 @@
+create sequence hibernate_sequence start with 1 increment by 1;
+
+create table jpa_repository_action (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table jpa_repository_guard (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table jpa_repository_state (
+    id bigint not null,
+    initial smallint not null,
+    kind integer,
+    machine_id varchar(255),
+    region varchar(255),
+    state varchar(255),
+    submachine_id varchar(255),
+    initial_action_id bigint,
+    parent_state_id bigint,
+    primary key (id)
+);
+
+create table jpa_repository_state_deferred_events (
+    jpa_repository_state_id bigint not null,
+    deferred_events varchar(255)
+);
+
+create table jpa_repository_state_entry_actions (
+    jpa_repository_state_id bigint not null,
+    entry_actions_id bigint not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table jpa_repository_state_exit_actions (
+    jpa_repository_state_id bigint not null,
+    exit_actions_id bigint not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table jpa_repository_state_state_actions (
+    jpa_repository_state_id bigint not null,
+    state_actions_id bigint not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table jpa_repository_state_machine (
+    machine_id varchar(255) not null,
+    state varchar(255),
+    state_machine_context blob(255),
+    primary key (machine_id)
+);
+
+create table jpa_repository_transition (
+    id bigint not null,
+    event varchar(255),
+    kind integer,
+    machine_id varchar(255),
+    guard_id bigint,
+    source_id bigint,
+    target_id bigint,
+    primary key (id)
+);
+
+create table jpa_repository_transition_actions (
+    jpa_repository_transition_id bigint not null,
+    actions_id bigint not null,
+    primary key (jpa_repository_transition_id, actions_id)
+);
+
+create table skipper_app_deployer_data (
+    id bigint not null,
+    object_version bigint,
+    deployment_data clob(255),
+    release_name varchar(255),
+    release_version integer,
+    primary key (id)
+);
+
+create table skipper_info (
+    id bigint not null,
+    object_version bigint,
+    deleted timestamp,
+    description varchar(255),
+    first_deployed timestamp,
+    last_deployed timestamp,
+    status_id bigint,
+    primary key (id)
+);
+
+create table skipper_package_file (
+    id bigint not null,
+    package_bytes blob(255),
+    primary key (id)
+);
+
+create table skipper_package_metadata (
+    id bigint not null,
+    object_version bigint,
+    api_version varchar(255),
+    description clob(255),
+    display_name varchar(255),
+    icon_url clob(255),
+    kind varchar(255),
+    maintainer varchar(255),
+    name varchar(255),
+    origin varchar(255),
+    package_home_url clob(255),
+    package_source_url clob(255),
+    repository_id bigint,
+    repository_name varchar(255),
+    sha256 varchar(255),
+    tags clob(255),
+    version varchar(255),
+    packagefile_id bigint,
+    primary key (id)
+);
+
+create table skipper_release (
+    id bigint not null,
+    object_version bigint,
+    config_values_string clob(255),
+    manifest clob(255),
+    name varchar(255),
+    package_metadata_id bigint,
+    pkg_json_string clob(255),
+    platform_name varchar(255),
+    repository_id bigint,
+    version integer not null,
+    info_id bigint,
+    primary key (id)
+);
+
+create table skipper_repository (
+    id bigint not null,
+    object_version bigint,
+    description varchar(255),
+    local smallint,
+    name varchar(255),
+    repo_order integer,
+    source_url varchar(255),
+    url varchar(255),
+    primary key (id)
+);
+
+create table skipper_status (
+    id bigint not null,
+    platform_status clob(255),
+    status_code varchar(255),
+    primary key (id)
+);
+
+create index idx_pkg_name on skipper_package_metadata (name);
+
+create index idx_rel_name on skipper_release (name);
+
+create index idx_repo_name on skipper_repository (name);
+
+create unique index uk_repository on skipper_repository (name);
+
+alter table jpa_repository_state
+    add constraint FKl7uw0stk3ta9k0i64ve8viv8b
+    foreign key (initial_action_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_state
+    add constraint FK85uu4no99eoivtd6elb2rp9dg
+    foreign key (parent_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_state_deferred_events
+    add constraint FKoodyqp0kxbmkjtmskj9m79h73
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_state_entry_actions
+    add constraint FKp9g3iq1ngku1imrsf5dnmmnww
+    foreign key (entry_actions_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_state_entry_actions
+    add constraint FKalgdctnelpb0xriggiufbfcd5
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_state_exit_actions
+    add constraint FKlhwv3oxyp5hprnlvs56gnyxdh
+    foreign key (exit_actions_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_state_exit_actions
+    add constraint FKnuahuplj5vp27hxqdult5y2su
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_state_state_actions
+    add constraint FK8wgwopqvhfnb1xe5sqf2213pw
+    foreign key (state_actions_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_state_state_actions
+    add constraint FKqqpkvnpqb8madraq2l57niagx
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_transition
+    add constraint FKrs9l0ayy1i7t5pjnixkohgrlm
+    foreign key (guard_id)
+    references jpa_repository_guard;
+
+alter table jpa_repository_transition
+    add constraint FK4dahkov2dttpljo5mfcid5gxh
+    foreign key (source_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_transition
+    add constraint FK6jymhcao9w1786ldrnbdlsacu
+    foreign key (target_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_transition_actions
+    add constraint FKhwdl9g5s5htj2jcb1xrkq6wpw
+    foreign key (actions_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_transition_actions
+    add constraint FK6287nce3o7soy1bjdyi04heih
+    foreign key (jpa_repository_transition_id)
+    references jpa_repository_transition;
+
+alter table skipper_info
+    add constraint fk_info_status
+    foreign key (status_id)
+    references skipper_status;
+
+alter table skipper_package_metadata
+    add constraint FKq2maocius5sr76isk7xlhn7b4
+    foreign key (packagefile_id)
+    references skipper_package_file;
+
+alter table skipper_release
+    add constraint fk_release_info
+    foreign key (info_id)
+    references skipper_info;

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/oracle/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/oracle/V1__INITIAL_SETUP.sql
@@ -1,159 +1,166 @@
 create sequence hibernate_sequence start with 1 increment by 1;
 
-create table jpa_repository_action (
-    id bigint not null,
-    name varchar(255),
-    spel varchar(255),
+create table action (
+    id number(19,0) not null,
+    name varchar2(255 char),
+    spel varchar2(255 char),
     primary key (id)
 );
 
-create table jpa_repository_guard (
-    id bigint not null,
-    name varchar(255),
-    spel varchar(255),
+create table deferred_events (
+    jpa_repository_state_id number(19,0) not null,
+    deferred_events varchar2(255 char)
+);
+
+create table guard (
+    id number(19,0) not null,
+    name varchar2(255 char),
+    spel varchar2(255 char),
     primary key (id)
-);
-
-create table jpa_repository_state (
-    id bigint not null,
-    initial smallint not null,
-    kind integer,
-    machine_id varchar(255),
-    region varchar(255),
-    state varchar(255),
-    submachine_id varchar(255),
-    initial_action_id bigint,
-    parent_state_id bigint,
-    primary key (id)
-);
-
-create table jpa_repository_state_deferred_events (
-    jpa_repository_state_id bigint not null,
-    deferred_events varchar(255)
-);
-
-create table jpa_repository_state_entry_actions (
-    jpa_repository_state_id bigint not null,
-    entry_actions_id bigint not null,
-    primary key (jpa_repository_state_id, entry_actions_id)
-);
-
-create table jpa_repository_state_exit_actions (
-    jpa_repository_state_id bigint not null,
-    exit_actions_id bigint not null,
-    primary key (jpa_repository_state_id, exit_actions_id)
-);
-
-create table jpa_repository_state_state_actions (
-    jpa_repository_state_id bigint not null,
-    state_actions_id bigint not null,
-    primary key (jpa_repository_state_id, state_actions_id)
-);
-
-create table jpa_repository_state_machine (
-    machine_id varchar(255) not null,
-    state varchar(255),
-    state_machine_context blob(255),
-    primary key (machine_id)
-);
-
-create table jpa_repository_transition (
-    id bigint not null,
-    event varchar(255),
-    kind integer,
-    machine_id varchar(255),
-    guard_id bigint,
-    source_id bigint,
-    target_id bigint,
-    primary key (id)
-);
-
-create table jpa_repository_transition_actions (
-    jpa_repository_transition_id bigint not null,
-    actions_id bigint not null,
-    primary key (jpa_repository_transition_id, actions_id)
 );
 
 create table skipper_app_deployer_data (
-    id bigint not null,
-    object_version bigint,
-    deployment_data clob(255),
-    release_name varchar(255),
-    release_version integer,
+    id number(19,0) not null,
+    object_version number(19,0),
+    deployment_data clob,
+    release_name varchar2(255 char),
+    release_version number(10,0),
     primary key (id)
 );
 
 create table skipper_info (
-    id bigint not null,
-    object_version bigint,
+    id number(19,0) not null,
+    object_version number(19,0),
     deleted timestamp,
-    description varchar(255),
+    description varchar2(255 char),
     first_deployed timestamp,
     last_deployed timestamp,
-    status_id bigint,
+    status_id number(19,0),
+    primary key (id)
+);
+
+create table skipper_manifest (
+    id number(19,0) not null,
+    object_version number(19,0),
+    data clob,
     primary key (id)
 );
 
 create table skipper_package_file (
-    id bigint not null,
-    package_bytes blob(255),
+    id number(19,0) not null,
+    package_bytes blob,
     primary key (id)
 );
 
 create table skipper_package_metadata (
-    id bigint not null,
-    object_version bigint,
-    api_version varchar(255),
-    description clob(255),
-    display_name varchar(255),
-    icon_url clob(255),
-    kind varchar(255),
-    maintainer varchar(255),
-    name varchar(255),
-    origin varchar(255),
-    package_home_url clob(255),
-    package_source_url clob(255),
-    repository_id bigint,
-    repository_name varchar(255),
-    sha256 varchar(255),
-    tags clob(255),
-    version varchar(255),
-    packagefile_id bigint,
+    id number(19,0) not null,
+    object_version number(19,0),
+    api_version varchar2(255 char),
+    description clob,
+    display_name varchar2(255 char),
+    icon_url clob,
+    kind varchar2(255 char),
+    maintainer varchar2(255 char),
+    name varchar2(255 char),
+    origin varchar2(255 char),
+    package_home_url clob,
+    package_source_url clob,
+    repository_id number(19,0),
+    repository_name varchar2(255 char),
+    sha256 varchar2(255 char),
+    tags clob,
+    version varchar2(255 char),
+    packagefile_id number(19,0),
     primary key (id)
 );
 
 create table skipper_release (
-    id bigint not null,
-    object_version bigint,
-    config_values_string clob(255),
-    manifest clob(255),
-    name varchar(255),
-    package_metadata_id bigint,
-    pkg_json_string clob(255),
-    platform_name varchar(255),
-    repository_id bigint,
-    version integer not null,
-    info_id bigint,
+    id number(19,0) not null,
+    object_version number(19,0),
+    config_values_string clob,
+    name varchar2(255 char),
+    package_metadata_id number(19,0),
+    pkg_json_string clob,
+    platform_name varchar2(255 char),
+    repository_id number(19,0),
+    version number(10,0) not null,
+    info_id number(19,0),
+    manifest_id number(19,0),
     primary key (id)
 );
 
 create table skipper_repository (
-    id bigint not null,
-    object_version bigint,
-    description varchar(255),
-    local smallint,
-    name varchar(255),
-    repo_order integer,
-    source_url varchar(255),
-    url varchar(255),
+    id number(19,0) not null,
+    object_version number(19,0),
+    description varchar2(255 char),
+    local number(1,0),
+    name varchar2(255 char),
+    repo_order number(10,0),
+    source_url varchar2(255 char),
+    url varchar2(255 char),
     primary key (id)
 );
 
 create table skipper_status (
-    id bigint not null,
-    platform_status clob(255),
-    status_code varchar(255),
+    id number(19,0) not null,
+    platform_status clob,
+    status_code varchar2(255 char),
     primary key (id)
+);
+
+create table state (
+    id number(19,0) not null,
+    initial_state number(1,0) not null,
+    kind number(10,0),
+    machine_id varchar2(255 char),
+    region varchar2(255 char),
+    state varchar2(255 char),
+    submachine_id varchar2(255 char),
+    initial_action_id number(19,0),
+    parent_state_id number(19,0),
+    primary key (id)
+);
+
+create table state_entry_actions (
+    jpa_repository_state_id number(19,0) not null,
+    entry_actions_id number(19,0) not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table state_exit_actions (
+    jpa_repository_state_id number(19,0) not null,
+    exit_actions_id number(19,0) not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table state_state_actions (
+    jpa_repository_state_id number(19,0) not null,
+    state_actions_id number(19,0) not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table state_machine (
+    machine_id varchar2(255 char) not null,
+    state varchar2(255 char),
+    state_machine_context blob,
+    primary key (machine_id)
+);
+
+create table transition (
+    id number(19,0) not null,
+    event varchar2(255 char),
+    kind number(10,0),
+    machine_id varchar2(255 char),
+    guard_id number(19,0),
+    source_id number(19,0),
+    target_id number(19,0),
+    primary key (id)
+);
+
+create table transition_actions (
+    jpa_repository_transition_id number(19,0) not null,
+    actions_id number(19,0) not null,
+    primary key (jpa_repository_transition_id, actions_id)
 );
 
 create index idx_pkg_name on skipper_package_metadata (name);
@@ -162,77 +169,13 @@ create index idx_rel_name on skipper_release (name);
 
 create index idx_repo_name on skipper_repository (name);
 
-create unique index uk_repository on skipper_repository (name);
+alter table skipper_repository
+    add constraint uk_repository unique (name);
 
-alter table jpa_repository_state
-    add constraint FKl7uw0stk3ta9k0i64ve8viv8b
-    foreign key (initial_action_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_state
-    add constraint FK85uu4no99eoivtd6elb2rp9dg
-    foreign key (parent_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_state_deferred_events
-    add constraint FKoodyqp0kxbmkjtmskj9m79h73
+alter table deferred_events
+    add constraint fk_state_deferred_events
     foreign key (jpa_repository_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_state_entry_actions
-    add constraint FKp9g3iq1ngku1imrsf5dnmmnww
-    foreign key (entry_actions_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_state_entry_actions
-    add constraint FKalgdctnelpb0xriggiufbfcd5
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_state_exit_actions
-    add constraint FKlhwv3oxyp5hprnlvs56gnyxdh
-    foreign key (exit_actions_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_state_exit_actions
-    add constraint FKnuahuplj5vp27hxqdult5y2su
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_state_state_actions
-    add constraint FK8wgwopqvhfnb1xe5sqf2213pw
-    foreign key (state_actions_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_state_state_actions
-    add constraint FKqqpkvnpqb8madraq2l57niagx
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_transition
-    add constraint FKrs9l0ayy1i7t5pjnixkohgrlm
-    foreign key (guard_id)
-    references jpa_repository_guard;
-
-alter table jpa_repository_transition
-    add constraint FK4dahkov2dttpljo5mfcid5gxh
-    foreign key (source_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_transition
-    add constraint FK6jymhcao9w1786ldrnbdlsacu
-    foreign key (target_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_transition_actions
-    add constraint FKhwdl9g5s5htj2jcb1xrkq6wpw
-    foreign key (actions_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_transition_actions
-    add constraint FK6287nce3o7soy1bjdyi04heih
-    foreign key (jpa_repository_transition_id)
-    references jpa_repository_transition;
+    references state;
 
 alter table skipper_info
     add constraint fk_info_status
@@ -248,3 +191,73 @@ alter table skipper_release
     add constraint fk_release_info
     foreign key (info_id)
     references skipper_info;
+
+alter table skipper_release
+    add constraint fk_release_manifest
+    foreign key (manifest_id)
+    references skipper_manifest;
+
+alter table state
+    add constraint fk_state_initial_action
+    foreign key (initial_action_id)
+    references action;
+
+alter table state
+    add constraint fk_state_parent_state
+    foreign key (parent_state_id)
+    references state;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_a
+    foreign key (entry_actions_id)
+    references action;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_a
+    foreign key (exit_actions_id)
+    references action;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_a
+    foreign key (state_actions_id)
+    references action;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_guard
+    foreign key (guard_id)
+    references guard;
+
+alter table transition
+    add constraint fk_transition_source
+    foreign key (source_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_target
+    foreign key (target_id)
+    references state;
+
+alter table transition_actions
+    add constraint fk_transition_actions_a
+    foreign key (actions_id)
+    references action;
+
+alter table transition_actions
+    add constraint fk_transition_actions_t
+    foreign key (jpa_repository_transition_id)
+    references transition;

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/postgresql/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/postgresql/V1__INITIAL_SETUP.sql
@@ -1,0 +1,255 @@
+create table hibernate_sequence (
+    next_val bigint
+);
+
+insert into hibernate_sequence values ( 1 );
+
+create table jpa_repository_action (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table jpa_repository_guard (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table jpa_repository_state (
+    id bigint not null,
+    initial bit not null,
+    kind integer,
+    machine_id varchar(255),
+    region varchar(255),
+    state varchar(255),
+    submachine_id varchar(255),
+    initial_action_id bigint,
+    parent_state_id bigint,
+    primary key (id)
+);
+
+create table jpa_repository_state_deferred_events (
+    jpa_repository_state_id bigint not null,
+    deferred_events varchar(255)
+);
+
+create table jpa_repository_state_entry_actions (
+    jpa_repository_state_id bigint not null,
+    entry_actions_id bigint not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table jpa_repository_state_exit_actions (
+    jpa_repository_state_id bigint not null,
+    exit_actions_id bigint not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table jpa_repository_state_state_actions (
+    jpa_repository_state_id bigint not null,
+    state_actions_id bigint not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table jpa_repository_state_machine (
+    machine_id varchar(255) not null,
+    state varchar(255),
+    state_machine_context longblob,
+    primary key (machine_id)
+);
+
+create table jpa_repository_transition (
+    id bigint not null,
+    event varchar(255),
+    kind integer,
+    machine_id varchar(255),
+    guard_id bigint,
+    source_id bigint,
+    target_id bigint,
+    primary key (id)
+);
+
+create table jpa_repository_transition_actions (
+    jpa_repository_transition_id bigint not null,
+    actions_id bigint not null,
+    primary key (jpa_repository_transition_id, actions_id)
+);
+
+create table skipper_app_deployer_data (
+    id bigint not null,
+    object_version bigint,
+    deployment_data longtext,
+    release_name varchar(255),
+    release_version integer,
+    primary key (id)
+);
+
+create table skipper_info (
+    id bigint not null,
+    object_version bigint,
+    deleted datetime,
+    description varchar(255),
+    first_deployed datetime,
+    last_deployed datetime,
+    status_id bigint,
+    primary key (id)
+);
+
+create table skipper_package_file (
+    id bigint not null,
+    package_bytes longblob,
+    primary key (id)
+);
+
+create table skipper_package_metadata (
+    id bigint not null,
+    object_version bigint,
+    api_version varchar(255),
+    description longtext,
+    display_name varchar(255),
+    icon_url longtext,
+    kind varchar(255),
+    maintainer varchar(255),
+    name varchar(255),
+    origin varchar(255),
+    package_home_url longtext,
+    package_source_url longtext,
+    repository_id bigint,
+    repository_name varchar(255),
+    sha256 varchar(255),
+    tags longtext,
+    version varchar(255),
+    packagefile_id bigint,
+    primary key (id)
+);
+
+create table skipper_release (
+    id bigint not null,
+    object_version bigint,
+    config_values_string longtext,
+    manifest longtext,
+    name varchar(255),
+    package_metadata_id bigint,
+    pkg_json_string longtext,
+    platform_name varchar(255),
+    repository_id bigint,
+    version integer not null,
+    info_id bigint,
+    primary key (id)
+);
+
+create table skipper_repository (
+    id bigint not null,
+    object_version bigint,
+    description varchar(255),
+    local bit,
+    name varchar(255),
+    repo_order integer,
+    source_url varchar(255),
+    url varchar(255),
+    primary key (id)
+);
+
+create table skipper_status (
+    id bigint not null,
+    platform_status longtext,
+    status_code varchar(255),
+    primary key (id)
+);
+
+create index idx_pkg_name on skipper_package_metadata (name);
+
+create index idx_rel_name on skipper_release (name);
+
+create index idx_repo_name on skipper_repository (name);
+
+alter table skipper_repository
+    add constraint uk_repository unique (name);
+
+alter table jpa_repository_state
+    add constraint FKl7uw0stk3ta9k0i64ve8viv8b
+    foreign key (initial_action_id)
+    references jpa_repository_action (id);
+
+alter table jpa_repository_state
+    add constraint FK85uu4no99eoivtd6elb2rp9dg
+    foreign key (parent_state_id)
+    references jpa_repository_state (id);
+
+alter table jpa_repository_state_deferred_events
+    add constraint FKoodyqp0kxbmkjtmskj9m79h73
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state (id);
+
+alter table jpa_repository_state_entry_actions
+    add constraint FKp9g3iq1ngku1imrsf5dnmmnww
+    foreign key (entry_actions_id)
+    references jpa_repository_action (id);
+
+alter table jpa_repository_state_entry_actions
+    add constraint FKalgdctnelpb0xriggiufbfcd5
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state (id);
+
+alter table jpa_repository_state_exit_actions
+    add constraint FKlhwv3oxyp5hprnlvs56gnyxdh
+    foreign key (exit_actions_id)
+    references jpa_repository_action (id);
+
+alter table jpa_repository_state_exit_actions
+    add constraint FKnuahuplj5vp27hxqdult5y2su
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state (id);
+
+alter table jpa_repository_state_state_actions
+    add constraint FK8wgwopqvhfnb1xe5sqf2213pw
+    foreign key (state_actions_id)
+    references jpa_repository_action (id);
+
+alter table jpa_repository_state_state_actions
+    add constraint FKqqpkvnpqb8madraq2l57niagx
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state (id);
+
+alter table jpa_repository_transition
+    add constraint FKrs9l0ayy1i7t5pjnixkohgrlm
+    foreign key (guard_id)
+    references jpa_repository_guard (id);
+
+alter table jpa_repository_transition
+    add constraint FK4dahkov2dttpljo5mfcid5gxh
+    foreign key (source_id)
+    references jpa_repository_state (id);
+
+alter table jpa_repository_transition
+    add constraint FK6jymhcao9w1786ldrnbdlsacu
+    foreign key (target_id)
+    references jpa_repository_state (id);
+
+alter table jpa_repository_transition_actions
+    add constraint FKhwdl9g5s5htj2jcb1xrkq6wpw
+    foreign key (actions_id)
+    references jpa_repository_action (id);
+
+alter table jpa_repository_transition_actions
+    add constraint FK6287nce3o7soy1bjdyi04heih
+    foreign key (jpa_repository_transition_id)
+    references jpa_repository_transition (id);
+
+alter table skipper_info
+    add constraint fk_info_status
+    foreign key (status_id)
+    references skipper_status (id);
+
+alter table skipper_package_metadata
+    add constraint FKq2maocius5sr76isk7xlhn7b4
+    foreign key (packagefile_id)
+    references skipper_package_file (id);
+
+alter table skipper_release
+    add constraint fk_release_info
+    foreign key (info_id)
+    references skipper_info (id);

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/postgresql/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/postgresql/V1__INITIAL_SETUP.sql
@@ -1,163 +1,166 @@
-create table hibernate_sequence (
-    next_val bigint
-);
+create sequence hibernate_sequence start 1 increment 1;
 
-insert into hibernate_sequence values ( 1 );
-
-create table jpa_repository_action (
-    id bigint not null,
+create table action (
+    id int8 not null,
     name varchar(255),
     spel varchar(255),
     primary key (id)
 );
 
-create table jpa_repository_guard (
-    id bigint not null,
-    name varchar(255),
-    spel varchar(255),
-    primary key (id)
-);
-
-create table jpa_repository_state (
-    id bigint not null,
-    initial bit not null,
-    kind integer,
-    machine_id varchar(255),
-    region varchar(255),
-    state varchar(255),
-    submachine_id varchar(255),
-    initial_action_id bigint,
-    parent_state_id bigint,
-    primary key (id)
-);
-
-create table jpa_repository_state_deferred_events (
-    jpa_repository_state_id bigint not null,
+create table deferred_events (
+    jpa_repository_state_id int8 not null,
     deferred_events varchar(255)
 );
 
-create table jpa_repository_state_entry_actions (
-    jpa_repository_state_id bigint not null,
-    entry_actions_id bigint not null,
-    primary key (jpa_repository_state_id, entry_actions_id)
-);
-
-create table jpa_repository_state_exit_actions (
-    jpa_repository_state_id bigint not null,
-    exit_actions_id bigint not null,
-    primary key (jpa_repository_state_id, exit_actions_id)
-);
-
-create table jpa_repository_state_state_actions (
-    jpa_repository_state_id bigint not null,
-    state_actions_id bigint not null,
-    primary key (jpa_repository_state_id, state_actions_id)
-);
-
-create table jpa_repository_state_machine (
-    machine_id varchar(255) not null,
-    state varchar(255),
-    state_machine_context longblob,
-    primary key (machine_id)
-);
-
-create table jpa_repository_transition (
-    id bigint not null,
-    event varchar(255),
-    kind integer,
-    machine_id varchar(255),
-    guard_id bigint,
-    source_id bigint,
-    target_id bigint,
+create table guard (
+    id int8 not null,
+    name varchar(255),
+    spel varchar(255),
     primary key (id)
 );
 
-create table jpa_repository_transition_actions (
-    jpa_repository_transition_id bigint not null,
-    actions_id bigint not null,
-    primary key (jpa_repository_transition_id, actions_id)
-);
-
 create table skipper_app_deployer_data (
-    id bigint not null,
-    object_version bigint,
-    deployment_data longtext,
+    id int8 not null,
+    object_version int8,
+    deployment_data text,
     release_name varchar(255),
-    release_version integer,
+    release_version int4,
     primary key (id)
 );
 
 create table skipper_info (
-    id bigint not null,
-    object_version bigint,
-    deleted datetime,
+    id int8 not null,
+    object_version int8,
+    deleted timestamp,
     description varchar(255),
-    first_deployed datetime,
-    last_deployed datetime,
-    status_id bigint,
+    first_deployed timestamp,
+    last_deployed timestamp,
+    status_id int8,
+    primary key (id)
+);
+
+create table skipper_manifest (
+    id int8 not null,
+    object_version int8,
+    data text,
     primary key (id)
 );
 
 create table skipper_package_file (
-    id bigint not null,
-    package_bytes longblob,
+    id int8 not null,
+    package_bytes oid,
     primary key (id)
 );
 
 create table skipper_package_metadata (
-    id bigint not null,
-    object_version bigint,
+    id int8 not null,
+    object_version int8,
     api_version varchar(255),
-    description longtext,
+    description text,
     display_name varchar(255),
-    icon_url longtext,
+    icon_url text,
     kind varchar(255),
     maintainer varchar(255),
     name varchar(255),
     origin varchar(255),
-    package_home_url longtext,
-    package_source_url longtext,
-    repository_id bigint,
+    package_home_url text,
+    package_source_url text,
+    repository_id int8,
     repository_name varchar(255),
     sha256 varchar(255),
-    tags longtext,
+    tags text,
     version varchar(255),
-    packagefile_id bigint,
+    packagefile_id int8,
     primary key (id)
 );
 
 create table skipper_release (
-    id bigint not null,
-    object_version bigint,
-    config_values_string longtext,
-    manifest longtext,
+    id int8 not null,
+    object_version int8,
+    config_values_string text,
     name varchar(255),
-    package_metadata_id bigint,
-    pkg_json_string longtext,
+    package_metadata_id int8,
+    pkg_json_string text,
     platform_name varchar(255),
-    repository_id bigint,
-    version integer not null,
-    info_id bigint,
+    repository_id int8,
+    version int4 not null,
+    info_id int8,
+    manifest_id int8,
     primary key (id)
 );
 
 create table skipper_repository (
-    id bigint not null,
-    object_version bigint,
+    id int8 not null,
+    object_version int8,
     description varchar(255),
-    local bit,
+    local boolean,
     name varchar(255),
-    repo_order integer,
+    repo_order int4,
     source_url varchar(255),
     url varchar(255),
     primary key (id)
 );
 
 create table skipper_status (
-    id bigint not null,
-    platform_status longtext,
+    id int8 not null,
+    platform_status text,
     status_code varchar(255),
     primary key (id)
+);
+
+create table state (
+    id int8 not null,
+    initial_state boolean not null,
+    kind int4,
+    machine_id varchar(255),
+    region varchar(255),
+    state varchar(255),
+    submachine_id varchar(255),
+    initial_action_id int8,
+    parent_state_id int8,
+    primary key (id)
+);
+
+create table state_entry_actions (
+    jpa_repository_state_id int8 not null,
+    entry_actions_id int8 not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table state_exit_actions (
+    jpa_repository_state_id int8 not null,
+    exit_actions_id int8 not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table state_state_actions (
+    jpa_repository_state_id int8 not null,
+    state_actions_id int8 not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table state_machine (
+    machine_id varchar(255) not null,
+    state varchar(255),
+    state_machine_context oid,
+    primary key (machine_id)
+);
+
+create table transition (
+    id int8 not null,
+    event varchar(255),
+    kind int4,
+    machine_id varchar(255),
+    guard_id int8,
+    source_id int8,
+    target_id int8,
+    primary key (id)
+);
+
+create table transition_actions (
+    jpa_repository_transition_id int8 not null,
+    actions_id int8 not null,
+    primary key (jpa_repository_transition_id, actions_id)
 );
 
 create index idx_pkg_name on skipper_package_metadata (name);
@@ -169,87 +172,92 @@ create index idx_repo_name on skipper_repository (name);
 alter table skipper_repository
     add constraint uk_repository unique (name);
 
-alter table jpa_repository_state
-    add constraint FKl7uw0stk3ta9k0i64ve8viv8b
-    foreign key (initial_action_id)
-    references jpa_repository_action (id);
-
-alter table jpa_repository_state
-    add constraint FK85uu4no99eoivtd6elb2rp9dg
-    foreign key (parent_state_id)
-    references jpa_repository_state (id);
-
-alter table jpa_repository_state_deferred_events
-    add constraint FKoodyqp0kxbmkjtmskj9m79h73
+alter table deferred_events
+    add constraint fk_state_deferred_events
     foreign key (jpa_repository_state_id)
-    references jpa_repository_state (id);
-
-alter table jpa_repository_state_entry_actions
-    add constraint FKp9g3iq1ngku1imrsf5dnmmnww
-    foreign key (entry_actions_id)
-    references jpa_repository_action (id);
-
-alter table jpa_repository_state_entry_actions
-    add constraint FKalgdctnelpb0xriggiufbfcd5
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state (id);
-
-alter table jpa_repository_state_exit_actions
-    add constraint FKlhwv3oxyp5hprnlvs56gnyxdh
-    foreign key (exit_actions_id)
-    references jpa_repository_action (id);
-
-alter table jpa_repository_state_exit_actions
-    add constraint FKnuahuplj5vp27hxqdult5y2su
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state (id);
-
-alter table jpa_repository_state_state_actions
-    add constraint FK8wgwopqvhfnb1xe5sqf2213pw
-    foreign key (state_actions_id)
-    references jpa_repository_action (id);
-
-alter table jpa_repository_state_state_actions
-    add constraint FKqqpkvnpqb8madraq2l57niagx
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state (id);
-
-alter table jpa_repository_transition
-    add constraint FKrs9l0ayy1i7t5pjnixkohgrlm
-    foreign key (guard_id)
-    references jpa_repository_guard (id);
-
-alter table jpa_repository_transition
-    add constraint FK4dahkov2dttpljo5mfcid5gxh
-    foreign key (source_id)
-    references jpa_repository_state (id);
-
-alter table jpa_repository_transition
-    add constraint FK6jymhcao9w1786ldrnbdlsacu
-    foreign key (target_id)
-    references jpa_repository_state (id);
-
-alter table jpa_repository_transition_actions
-    add constraint FKhwdl9g5s5htj2jcb1xrkq6wpw
-    foreign key (actions_id)
-    references jpa_repository_action (id);
-
-alter table jpa_repository_transition_actions
-    add constraint FK6287nce3o7soy1bjdyi04heih
-    foreign key (jpa_repository_transition_id)
-    references jpa_repository_transition (id);
+    references state;
 
 alter table skipper_info
     add constraint fk_info_status
     foreign key (status_id)
-    references skipper_status (id);
+    references skipper_status;
 
 alter table skipper_package_metadata
     add constraint FKq2maocius5sr76isk7xlhn7b4
     foreign key (packagefile_id)
-    references skipper_package_file (id);
+    references skipper_package_file;
 
 alter table skipper_release
     add constraint fk_release_info
     foreign key (info_id)
-    references skipper_info (id);
+    references skipper_info;
+
+alter table skipper_release
+    add constraint fk_release_manifest
+    foreign key (manifest_id)
+    references skipper_manifest;
+
+alter table state
+    add constraint fk_state_initial_action
+    foreign key (initial_action_id)
+    references action;
+
+alter table state
+    add constraint fk_state_parent_state
+    foreign key (parent_state_id)
+    references state;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_a
+    foreign key (entry_actions_id)
+    references action;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_a
+    foreign key (exit_actions_id)
+    references action;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_a
+    foreign key (state_actions_id)
+    references action;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_guard
+    foreign key (guard_id)
+    references guard;
+
+alter table transition
+    add constraint fk_transition_source
+    foreign key (source_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_target
+    foreign key (target_id)
+    references state;
+
+alter table transition_actions
+    add constraint fk_transition_actions_a
+    foreign key (actions_id)
+    references action;
+
+alter table transition_actions
+    add constraint fk_transition_actions_t
+    foreign key (jpa_repository_transition_id)
+    references transition;

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/sqlserver/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/sqlserver/V1__INITIAL_SETUP.sql
@@ -1,23 +1,121 @@
-create sequence hibernate_sequence start with 1 increment by 1;
+create table hibernate_sequence (
+    next_val bigint
+);
 
-create table jpa_repository_action (
+insert into hibernate_sequence values ( 1 );
+
+create table action (
     id bigint not null,
     name varchar(255),
     spel varchar(255),
     primary key (id)
 );
 
-create table jpa_repository_guard (
+create table deferred_events (
+    jpa_repository_state_id bigint not null,
+    deferred_events varchar(255)
+);
+
+create table guard (
     id bigint not null,
     name varchar(255),
     spel varchar(255),
     primary key (id)
 );
 
-create table jpa_repository_state (
+create table skipper_app_deployer_data (
     id bigint not null,
-    initial smallint not null,
-    kind integer,
+    object_version bigint,
+    deployment_data varchar(MAX),
+    release_name varchar(255),
+    release_version int,
+    primary key (id)
+);
+
+create table skipper_info (
+    id bigint not null,
+    object_version bigint,
+    deleted datetime2,
+    description varchar(255),
+    first_deployed datetime2,
+    last_deployed datetime2,
+    status_id bigint,
+    primary key (id)
+);
+
+create table skipper_manifest (
+    id bigint not null,
+    object_version bigint,
+    data varchar(MAX),
+    primary key (id)
+);
+
+create table skipper_package_file (
+    id bigint not null,
+    package_bytes varbinary(MAX),
+    primary key (id)
+);
+
+create table skipper_package_metadata (
+    id bigint not null,
+    object_version bigint,
+    api_version varchar(255),
+    description varchar(MAX),
+    display_name varchar(255),
+    icon_url varchar(MAX),
+    kind varchar(255),
+    maintainer varchar(255),
+    name varchar(255),
+    origin varchar(255),
+    package_home_url varchar(MAX),
+    package_source_url varchar(MAX),
+    repository_id bigint,
+    repository_name varchar(255),
+    sha256 varchar(255),
+    tags varchar(MAX),
+    version varchar(255),
+    packagefile_id bigint,
+    primary key (id)
+);
+
+create table skipper_release (
+    id bigint not null,
+    object_version bigint,
+    config_values_string varchar(MAX),
+    name varchar(255),
+    package_metadata_id bigint,
+    pkg_json_string varchar(MAX),
+    platform_name varchar(255),
+    repository_id bigint,
+    version int not null,
+    info_id bigint,
+    manifest_id bigint,
+    primary key (id)
+);
+
+create table skipper_repository (
+    id bigint not null,
+    object_version bigint,
+    description varchar(255),
+    local bit,
+    name varchar(255),
+    repo_order int,
+    source_url varchar(255),
+    url varchar(255),
+    primary key (id)
+);
+
+create table skipper_status (
+    id bigint not null,
+    platform_status varchar(MAX),
+    status_code varchar(255),
+    primary key (id)
+);
+
+create table state (
+    id bigint not null,
+    initial_state bit not null,
+    kind int,
     machine_id varchar(255),
     region varchar(255),
     state varchar(255),
@@ -27,40 +125,35 @@ create table jpa_repository_state (
     primary key (id)
 );
 
-create table jpa_repository_state_deferred_events (
-    jpa_repository_state_id bigint not null,
-    deferred_events varchar(255)
-);
-
-create table jpa_repository_state_entry_actions (
+create table state_entry_actions (
     jpa_repository_state_id bigint not null,
     entry_actions_id bigint not null,
     primary key (jpa_repository_state_id, entry_actions_id)
 );
 
-create table jpa_repository_state_exit_actions (
+create table state_exit_actions (
     jpa_repository_state_id bigint not null,
     exit_actions_id bigint not null,
     primary key (jpa_repository_state_id, exit_actions_id)
 );
 
-create table jpa_repository_state_state_actions (
+create table state_state_actions (
     jpa_repository_state_id bigint not null,
     state_actions_id bigint not null,
     primary key (jpa_repository_state_id, state_actions_id)
 );
 
-create table jpa_repository_state_machine (
+create table state_machine (
     machine_id varchar(255) not null,
     state varchar(255),
-    state_machine_context blob(255),
+    state_machine_context varbinary(MAX),
     primary key (machine_id)
 );
 
-create table jpa_repository_transition (
+create table transition (
     id bigint not null,
     event varchar(255),
-    kind integer,
+    kind int,
     machine_id varchar(255),
     guard_id bigint,
     source_id bigint,
@@ -68,92 +161,10 @@ create table jpa_repository_transition (
     primary key (id)
 );
 
-create table jpa_repository_transition_actions (
+create table transition_actions (
     jpa_repository_transition_id bigint not null,
     actions_id bigint not null,
     primary key (jpa_repository_transition_id, actions_id)
-);
-
-create table skipper_app_deployer_data (
-    id bigint not null,
-    object_version bigint,
-    deployment_data clob(255),
-    release_name varchar(255),
-    release_version integer,
-    primary key (id)
-);
-
-create table skipper_info (
-    id bigint not null,
-    object_version bigint,
-    deleted timestamp,
-    description varchar(255),
-    first_deployed timestamp,
-    last_deployed timestamp,
-    status_id bigint,
-    primary key (id)
-);
-
-create table skipper_package_file (
-    id bigint not null,
-    package_bytes blob(255),
-    primary key (id)
-);
-
-create table skipper_package_metadata (
-    id bigint not null,
-    object_version bigint,
-    api_version varchar(255),
-    description clob(255),
-    display_name varchar(255),
-    icon_url clob(255),
-    kind varchar(255),
-    maintainer varchar(255),
-    name varchar(255),
-    origin varchar(255),
-    package_home_url clob(255),
-    package_source_url clob(255),
-    repository_id bigint,
-    repository_name varchar(255),
-    sha256 varchar(255),
-    tags clob(255),
-    version varchar(255),
-    packagefile_id bigint,
-    primary key (id)
-);
-
-create table skipper_release (
-    id bigint not null,
-    object_version bigint,
-    config_values_string clob(255),
-    manifest clob(255),
-    name varchar(255),
-    package_metadata_id bigint,
-    pkg_json_string clob(255),
-    platform_name varchar(255),
-    repository_id bigint,
-    version integer not null,
-    info_id bigint,
-    primary key (id)
-);
-
-create table skipper_repository (
-    id bigint not null,
-    object_version bigint,
-    description varchar(255),
-    local smallint,
-    name varchar(255),
-    repo_order integer,
-    source_url varchar(255),
-    url varchar(255),
-    primary key (id)
-);
-
-create table skipper_status (
-    id bigint not null,
-    platform_status clob(255),
-    status_code varchar(255),
-    primary key (id)
 );
 
 create index idx_pkg_name on skipper_package_metadata (name);
@@ -162,77 +173,13 @@ create index idx_rel_name on skipper_release (name);
 
 create index idx_repo_name on skipper_repository (name);
 
-create unique index uk_repository on skipper_repository (name);
+alter table skipper_repository
+    add constraint uk_repository unique (name);
 
-alter table jpa_repository_state
-    add constraint FKl7uw0stk3ta9k0i64ve8viv8b
-    foreign key (initial_action_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_state
-    add constraint FK85uu4no99eoivtd6elb2rp9dg
-    foreign key (parent_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_state_deferred_events
-    add constraint FKoodyqp0kxbmkjtmskj9m79h73
+alter table deferred_events
+    add constraint fk_state_deferred_events
     foreign key (jpa_repository_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_state_entry_actions
-    add constraint FKp9g3iq1ngku1imrsf5dnmmnww
-    foreign key (entry_actions_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_state_entry_actions
-    add constraint FKalgdctnelpb0xriggiufbfcd5
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_state_exit_actions
-    add constraint FKlhwv3oxyp5hprnlvs56gnyxdh
-    foreign key (exit_actions_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_state_exit_actions
-    add constraint FKnuahuplj5vp27hxqdult5y2su
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_state_state_actions
-    add constraint FK8wgwopqvhfnb1xe5sqf2213pw
-    foreign key (state_actions_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_state_state_actions
-    add constraint FKqqpkvnpqb8madraq2l57niagx
-    foreign key (jpa_repository_state_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_transition
-    add constraint FKrs9l0ayy1i7t5pjnixkohgrlm
-    foreign key (guard_id)
-    references jpa_repository_guard;
-
-alter table jpa_repository_transition
-    add constraint FK4dahkov2dttpljo5mfcid5gxh
-    foreign key (source_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_transition
-    add constraint FK6jymhcao9w1786ldrnbdlsacu
-    foreign key (target_id)
-    references jpa_repository_state;
-
-alter table jpa_repository_transition_actions
-    add constraint FKhwdl9g5s5htj2jcb1xrkq6wpw
-    foreign key (actions_id)
-    references jpa_repository_action;
-
-alter table jpa_repository_transition_actions
-    add constraint FK6287nce3o7soy1bjdyi04heih
-    foreign key (jpa_repository_transition_id)
-    references jpa_repository_transition;
+    references state;
 
 alter table skipper_info
     add constraint fk_info_status
@@ -248,3 +195,75 @@ alter table skipper_release
     add constraint fk_release_info
     foreign key (info_id)
     references skipper_info;
+
+alter table skipper_release
+    add constraint fk_release_manifest
+    foreign key (manifest_id)
+    references skipper_manifest;
+
+alter table state
+    add constraint fk_state_initial_action
+    foreign key (initial_action_id)
+    references action;
+
+alter table state
+    add constraint fk_state_parent_state
+    foreign key (parent_state_id)
+    references state;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_a
+    foreign key (entry_actions_id)
+    references action;
+
+alter table state_entry_actions
+    add constraint fk_state_entry_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_a
+    foreign key (exit_actions_id)
+    references action;
+
+alter table state_exit_actions
+    add constraint fk_state_exit_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_a
+    foreign key (state_actions_id)
+    references action;
+
+alter table state_state_actions
+    add constraint fk_state_state_actions_s
+    foreign key (jpa_repository_state_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_guard
+    foreign key (guard_id)
+    references guard;
+
+alter table transition
+    add constraint fk_transition_source
+    foreign key (source_id)
+    references state;
+
+alter table transition
+    add constraint fk_transition_target
+    foreign key (target_id)
+    references state;
+
+alter table transition_actions
+    add constraint fk_transition_actions_a
+    foreign key (actions_id)
+    references action;
+
+alter table transition_actions
+    add constraint fk_transition_actions_t
+    foreign key (jpa_repository_transition_id)
+    references transition;
+
+

--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/sqlserver/V1__INITIAL_SETUP.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/sqlserver/V1__INITIAL_SETUP.sql
@@ -1,0 +1,250 @@
+create sequence hibernate_sequence start with 1 increment by 1;
+
+create table jpa_repository_action (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table jpa_repository_guard (
+    id bigint not null,
+    name varchar(255),
+    spel varchar(255),
+    primary key (id)
+);
+
+create table jpa_repository_state (
+    id bigint not null,
+    initial smallint not null,
+    kind integer,
+    machine_id varchar(255),
+    region varchar(255),
+    state varchar(255),
+    submachine_id varchar(255),
+    initial_action_id bigint,
+    parent_state_id bigint,
+    primary key (id)
+);
+
+create table jpa_repository_state_deferred_events (
+    jpa_repository_state_id bigint not null,
+    deferred_events varchar(255)
+);
+
+create table jpa_repository_state_entry_actions (
+    jpa_repository_state_id bigint not null,
+    entry_actions_id bigint not null,
+    primary key (jpa_repository_state_id, entry_actions_id)
+);
+
+create table jpa_repository_state_exit_actions (
+    jpa_repository_state_id bigint not null,
+    exit_actions_id bigint not null,
+    primary key (jpa_repository_state_id, exit_actions_id)
+);
+
+create table jpa_repository_state_state_actions (
+    jpa_repository_state_id bigint not null,
+    state_actions_id bigint not null,
+    primary key (jpa_repository_state_id, state_actions_id)
+);
+
+create table jpa_repository_state_machine (
+    machine_id varchar(255) not null,
+    state varchar(255),
+    state_machine_context blob(255),
+    primary key (machine_id)
+);
+
+create table jpa_repository_transition (
+    id bigint not null,
+    event varchar(255),
+    kind integer,
+    machine_id varchar(255),
+    guard_id bigint,
+    source_id bigint,
+    target_id bigint,
+    primary key (id)
+);
+
+create table jpa_repository_transition_actions (
+    jpa_repository_transition_id bigint not null,
+    actions_id bigint not null,
+    primary key (jpa_repository_transition_id, actions_id)
+);
+
+create table skipper_app_deployer_data (
+    id bigint not null,
+    object_version bigint,
+    deployment_data clob(255),
+    release_name varchar(255),
+    release_version integer,
+    primary key (id)
+);
+
+create table skipper_info (
+    id bigint not null,
+    object_version bigint,
+    deleted timestamp,
+    description varchar(255),
+    first_deployed timestamp,
+    last_deployed timestamp,
+    status_id bigint,
+    primary key (id)
+);
+
+create table skipper_package_file (
+    id bigint not null,
+    package_bytes blob(255),
+    primary key (id)
+);
+
+create table skipper_package_metadata (
+    id bigint not null,
+    object_version bigint,
+    api_version varchar(255),
+    description clob(255),
+    display_name varchar(255),
+    icon_url clob(255),
+    kind varchar(255),
+    maintainer varchar(255),
+    name varchar(255),
+    origin varchar(255),
+    package_home_url clob(255),
+    package_source_url clob(255),
+    repository_id bigint,
+    repository_name varchar(255),
+    sha256 varchar(255),
+    tags clob(255),
+    version varchar(255),
+    packagefile_id bigint,
+    primary key (id)
+);
+
+create table skipper_release (
+    id bigint not null,
+    object_version bigint,
+    config_values_string clob(255),
+    manifest clob(255),
+    name varchar(255),
+    package_metadata_id bigint,
+    pkg_json_string clob(255),
+    platform_name varchar(255),
+    repository_id bigint,
+    version integer not null,
+    info_id bigint,
+    primary key (id)
+);
+
+create table skipper_repository (
+    id bigint not null,
+    object_version bigint,
+    description varchar(255),
+    local smallint,
+    name varchar(255),
+    repo_order integer,
+    source_url varchar(255),
+    url varchar(255),
+    primary key (id)
+);
+
+create table skipper_status (
+    id bigint not null,
+    platform_status clob(255),
+    status_code varchar(255),
+    primary key (id)
+);
+
+create index idx_pkg_name on skipper_package_metadata (name);
+
+create index idx_rel_name on skipper_release (name);
+
+create index idx_repo_name on skipper_repository (name);
+
+create unique index uk_repository on skipper_repository (name);
+
+alter table jpa_repository_state
+    add constraint FKl7uw0stk3ta9k0i64ve8viv8b
+    foreign key (initial_action_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_state
+    add constraint FK85uu4no99eoivtd6elb2rp9dg
+    foreign key (parent_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_state_deferred_events
+    add constraint FKoodyqp0kxbmkjtmskj9m79h73
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_state_entry_actions
+    add constraint FKp9g3iq1ngku1imrsf5dnmmnww
+    foreign key (entry_actions_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_state_entry_actions
+    add constraint FKalgdctnelpb0xriggiufbfcd5
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_state_exit_actions
+    add constraint FKlhwv3oxyp5hprnlvs56gnyxdh
+    foreign key (exit_actions_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_state_exit_actions
+    add constraint FKnuahuplj5vp27hxqdult5y2su
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_state_state_actions
+    add constraint FK8wgwopqvhfnb1xe5sqf2213pw
+    foreign key (state_actions_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_state_state_actions
+    add constraint FKqqpkvnpqb8madraq2l57niagx
+    foreign key (jpa_repository_state_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_transition
+    add constraint FKrs9l0ayy1i7t5pjnixkohgrlm
+    foreign key (guard_id)
+    references jpa_repository_guard;
+
+alter table jpa_repository_transition
+    add constraint FK4dahkov2dttpljo5mfcid5gxh
+    foreign key (source_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_transition
+    add constraint FK6jymhcao9w1786ldrnbdlsacu
+    foreign key (target_id)
+    references jpa_repository_state;
+
+alter table jpa_repository_transition_actions
+    add constraint FKhwdl9g5s5htj2jcb1xrkq6wpw
+    foreign key (actions_id)
+    references jpa_repository_action;
+
+alter table jpa_repository_transition_actions
+    add constraint FK6287nce3o7soy1bjdyi04heih
+    foreign key (jpa_repository_transition_id)
+    references jpa_repository_transition;
+
+alter table skipper_info
+    add constraint fk_info_status
+    foreign key (status_id)
+    references skipper_status;
+
+alter table skipper_package_metadata
+    add constraint FKq2maocius5sr76isk7xlhn7b4
+    foreign key (packagefile_id)
+    references skipper_package_file;
+
+alter table skipper_release
+    add constraint fk_release_info
+    foreign key (info_id)
+    references skipper_info;


### PR DESCRIPTION
Moved scripts to db/migration/{vendor}
Tested on H2, HSQLDB, mysql, postgres, SQLServer
Oracle is having some issues when bootstraping flyway's schema_version table

Resolves spring-cloud/spring-cloud-skipper#471
Resolves spring-cloud/spring-cloud-skipper#461
Resolves spring-cloud/spring-cloud-skipper#433
Resolves spring-cloud/spring-cloud-skipper#432
