### PR TITLE
Fix for propagating PackageDeleteException to client

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientResponseErrorHandler.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientResponseErrorHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.http.client.ClientHttpResponse;
@@ -68,11 +69,15 @@ public class SkipperClientResponseErrorHandler extends DefaultResponseErrorHandl
 		if (ObjectUtils.nullSafeEquals(exceptionClazz, ReleaseNotFoundException.class.getName())) {
 			handleReleaseNotFoundException(map);
 		}
+		else if (ObjectUtils.nullSafeEquals(exceptionClazz, PackageDeleteException.class.getName())) {
+			handlePackageDeleteException(map);
+		}
 		else if (ObjectUtils.nullSafeEquals(exceptionClazz, SkipperException.class.getName())) {
 			handleSkipperException(map);
 		}
 		super.handleError(response);
 	}
+
 
 	private void handleReleaseNotFoundException(Map<String, String> map) {
 		String releaseName = map.get("releaseName");
@@ -92,6 +97,11 @@ public class SkipperClientResponseErrorHandler extends DefaultResponseErrorHandl
 				throw new ReleaseNotFoundException(releaseName);
 			}
 		}
+	}
+
+	private void handlePackageDeleteException(Map<String, String> map) {
+		String message = map.get("message");
+		throw new PackageDeleteException(StringUtils.hasText(message) ? message : "");
 	}
 
 	private void handleSkipperException(Map<String, String> map) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/PackageController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/PackageController.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.controller;
 
+import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
@@ -29,12 +30,17 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
@@ -100,6 +106,15 @@ public class PackageController {
 	@ResponseStatus(HttpStatus.OK)
 	public void packageDelete(@PathVariable("name") String name) {
 		this.packageMetadataService.deleteIfAllReleasesDeleted(name, PackageMetadataService.DEFAULT_RELEASE_ACTIVITY_CHECK);
+	}
+
+	@ExceptionHandler(PackageDeleteException.class)
+	public ResponseEntity<Map<String, String>> handlePackageDeleteException(PackageDeleteException error) {
+		// TODO investigate why SkipperErrorAttributes is not being invoked.
+		Map<String, String> map = new HashMap<>();
+		map.put("exception", error.getClass().getName());
+		map.put("message", error.getMessage());
+		return new ResponseEntity<Map<String, String>>(map, HttpStatus.CONFLICT);
 	}
 
 	public static class PackageControllerLinksResource extends ResourceSupport {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.cloud.skipper.server.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.PackageDeleteException;
@@ -179,6 +181,15 @@ public class ReleaseController {
 		// needed for server not to log 500 errors
 	}
 
+	@ExceptionHandler(PackageDeleteException.class)
+	public ResponseEntity<Map<String, String>> handlePackageDeleteException(PackageDeleteException error) {
+		// TODO investigate why SkipperErrorAttributes is not being invoked.
+		Map<String, String> map = new HashMap<>();
+		map.put("exception", error.getClass().getName());
+		map.put("message", error.getMessage());
+		return new ResponseEntity<Map<String, String>>(map, HttpStatus.CONFLICT);
+	}
+
 	/**
 	 * @author Mark Pollack
 	 */
@@ -186,10 +197,5 @@ public class ReleaseController {
 
 		public ReleaseControllerLinksResource() {
 		}
-	}
-
-	@ExceptionHandler(PackageDeleteException.class)
-	public ResponseEntity<String> handlePackageDeleteException(PackageDeleteException e) {
-		return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
 	}
 }

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/PackageCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/PackageCommands.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.InstallProperties;
@@ -155,7 +156,11 @@ public class PackageCommands extends AbstractSkipperCommand {
 
 	@ShellMethod(key = "package delete", value = "Delete a package.")
 	public String packageDelete(@ShellOption(help = "the package name to be deleted") String packageName) {
-		this.skipperClient.packageDelete(packageName);
+		try {
+			this.skipperClient.packageDelete(packageName);
+		} catch (PackageDeleteException e) {
+			return e.getMessage();
+		}
 		return String.format("Deleted Package '%s'", packageName);
 	}
 

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/PackageDeleteException.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/PackageDeleteException.java
@@ -30,16 +30,4 @@ public class PackageDeleteException extends SkipperException {
 		super(message, cause);
 	}
 
-//	public PackageDeleteException(String packageName, List<Release> releases) {
-//		super(getMessage(packageName, releases));
-//	}
-//
-//	public PackageDeleteException(String packageName, Release releases) {
-//		super(getMessage(packageName, Arrays.asList(releases)));
-//	}
-//
-//	private static String getMessage(String packageName, List<Release> releases) {
-//		return String.format("Can't delete package: [%s] because is used by deployed releases: %s",
-//				packageName, releases.stream().map(Release::getName).collect(Collectors.toList()));
-//	}
 }


### PR DESCRIPTION
 - Add logic to first check if package belongs to a remote repository, then check releases if necessary.
 - Partial fix - unclear why `SkipperErrorAttributes` is not being invoked when `PackageDeleteException` is thrown.
 - Not worth it to investigate the root cause now....nor refactor into `@ControllerAdvice`...

Fixes #486 
