### PR TITLE
Polish controller error handling

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/PackageController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/PackageController.java
@@ -16,6 +16,8 @@
 package org.springframework.cloud.skipper.server.controller;
 
 import org.springframework.cloud.skipper.PackageDeleteException;
+import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
@@ -30,7 +32,6 @@ import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,9 +39,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
@@ -108,13 +106,22 @@ public class PackageController {
 		this.packageMetadataService.deleteIfAllReleasesDeleted(name, PackageMetadataService.DEFAULT_RELEASE_ACTIVITY_CHECK);
 	}
 
+	@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Release not found")
+	@ExceptionHandler(ReleaseNotFoundException.class)
+	public void handleReleaseNotFoundException() {
+		// needed for server not to log 500 errors
+	}
+
+	@ResponseStatus(value = HttpStatus.PRECONDITION_FAILED, reason = "Package deletion error")
 	@ExceptionHandler(PackageDeleteException.class)
-	public ResponseEntity<Map<String, String>> handlePackageDeleteException(PackageDeleteException error) {
-		// TODO investigate why SkipperErrorAttributes is not being invoked.
-		Map<String, String> map = new HashMap<>();
-		map.put("exception", error.getClass().getName());
-		map.put("message", error.getMessage());
-		return new ResponseEntity<Map<String, String>>(map, HttpStatus.CONFLICT);
+	public void handlePackageDeleteException() {
+		// needed for server not to log 500 errors
+	}
+
+	@ResponseStatus(value = HttpStatus.CONFLICT, reason = "Skipper server exception")
+	@ExceptionHandler(SkipperException.class)
+	public void handleSkipperException() {
+		// needed for server not to log 500 errors
 	}
 
 	public static class PackageControllerLinksResource extends ResourceSupport {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,12 @@
  */
 package org.springframework.cloud.skipper.server.controller;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.Manifest;
@@ -37,7 +36,6 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -181,13 +179,16 @@ public class ReleaseController {
 		// needed for server not to log 500 errors
 	}
 
+	@ResponseStatus(value = HttpStatus.PRECONDITION_FAILED, reason = "Package deletion error")
 	@ExceptionHandler(PackageDeleteException.class)
-	public ResponseEntity<Map<String, String>> handlePackageDeleteException(PackageDeleteException error) {
-		// TODO investigate why SkipperErrorAttributes is not being invoked.
-		Map<String, String> map = new HashMap<>();
-		map.put("exception", error.getClass().getName());
-		map.put("message", error.getMessage());
-		return new ResponseEntity<Map<String, String>>(map, HttpStatus.CONFLICT);
+	public void handlePackageDeleteException() {
+		// needed for server not to log 500 errors
+	}
+
+	@ResponseStatus(value = HttpStatus.CONFLICT, reason = "Skipper server exception")
+	@ExceptionHandler(SkipperException.class)
+	public void handleSkipperException() {
+		// needed for server not to log 500 errors
 	}
 
 	/**

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperErrorAttributes.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperErrorAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ import java.util.Map;
 
 import org.springframework.boot.autoconfigure.web.DefaultErrorAttributes;
 import org.springframework.boot.autoconfigure.web.ErrorAttributes;
+import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.web.context.request.RequestAttributes;
 
 /**
@@ -34,6 +36,8 @@ public class SkipperErrorAttributes extends DefaultErrorAttributes {
 	public Map<String, Object> getErrorAttributes(RequestAttributes requestAttributes, boolean includeStackTrace) {
 		Map<String, Object> errorAttributes = super.getErrorAttributes(requestAttributes, includeStackTrace);
 		Throwable error = getError(requestAttributes);
+		// if we're in our skipper related exceptions, reset message as available from there
+		// as otherwise super method above will resolve message as one possibly set from exception handler
 		if (error != null) {
 			// pass in name and version if ReleaseNotFoundException
 			if (error instanceof ReleaseNotFoundException) {
@@ -44,6 +48,13 @@ public class SkipperErrorAttributes extends DefaultErrorAttributes {
 				if (e.getReleaseVersion() != null) {
 					errorAttributes.put("version", e.getReleaseVersion());
 				}
+				errorAttributes.put("message", error.getMessage());
+			}
+			else if (error instanceof PackageDeleteException) {
+				errorAttributes.put("message", error.getMessage());
+			}
+			else if (error instanceof SkipperException) {
+				errorAttributes.put("message", error.getMessage());
 			}
 		}
 		return errorAttributes;

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,9 +111,9 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 		boolean deletePackage = true;
 
 		MvcResult result = mockMvc.perform(delete("/api/release/" + releaseNameOne + "/" + deletePackage))
-				.andDo(print()).andExpect(status().isConflict()).andReturn();
+				.andDo(print()).andExpect(status().isPreconditionFailed()).andReturn();
 
-		assertThat(result.getResponse().getContentAsString())
+		assertThat(result.getResolvedException().getMessage())
 				.contains("Can not delete Package Metadata [log:1.0.0] in Repository [test]. Not all releases of " +
 						"this package have the status DELETED. Active Releases [test2]");
 


### PR DESCRIPTION
- Instead of introducing global error handling, in PackageController
  and ReleaseController explicitely handle all skipper related
  exceptions so that we don't get 500's and SkipperErrorAttributes
  gets a change to kick in.
- As long as we throw ReleaseNotFoundException, PackageDeleteException or
  generic SkipperException, we don't get 500's and map to more meaninful
  code and reason.
- In SkipperErrorAttributes, override message set by boot's
  DefaultErrorAttributes to have one in our own skipper related exceptions.
  Otherwise we get message set in @ResponseStatus with @ExceptionHandler.
- Fixes #490