### PR TITLE
Manage flyway version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <spring-statemachine.version>1.2.8.RC4</spring-statemachine.version>
         <jsonpath.version>2.2.0</jsonpath.version>
         <equalverifier.version>2.4.1</equalverifier.version>
+        <flyway.version>5.0.5</flyway.version>
 
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <surefire-maven-plugin.version>2.20</surefire-maven-plugin.version>
@@ -129,6 +130,11 @@
                 <groupId>org.zeroturnaround</groupId>
                 <artifactId>zt-zip</artifactId>
                 <version>1.11</version>
+            </dependency>
+            <dependency>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-core</artifactId>
+                <version>${flyway.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>5.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>


### PR DESCRIPTION
- Remove version from server pom and define it
  in dep management in parent pom. This makes jar
  to have 5.0.5 instead of 3.2.1 from boot.
- Fixes #510