### PR TITLE
[DO NOT MERGE] Handle generic RuntimeException

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/PackageController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/PackageController.java
@@ -124,6 +124,12 @@ public class PackageController {
 		// needed for server not to log 500 errors
 	}
 
+	@ResponseStatus(value = HttpStatus.CONFLICT, reason = "Runtime server exception")
+	@ExceptionHandler(RuntimeException.class)
+	public void handleRuntimeException() {
+		// needed for server not to log 500 errors
+	}
+
 	public static class PackageControllerLinksResource extends ResourceSupport {
 
 		public PackageControllerLinksResource() {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -192,6 +192,12 @@ public class ReleaseController {
 		// needed for server not to log 500 errors
 	}
 
+	@ResponseStatus(value = HttpStatus.CONFLICT, reason = "Runtime server exception")
+	@ExceptionHandler(RuntimeException.class)
+	public void handleRuntimeException() {
+		// needed for server not to log 500 errors
+	}
+
 	/**
 	 * @author Mark Pollack
 	 */

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperErrorAttributes.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperErrorAttributes.java
@@ -56,6 +56,9 @@ public class SkipperErrorAttributes extends DefaultErrorAttributes {
 			else if (error instanceof SkipperException) {
 				errorAttributes.put("message", error.getMessage());
 			}
+			else if (error instanceof RuntimeException) {
+				errorAttributes.put("message", error.getMessage());
+			}
 		}
 		return errorAttributes;
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/SkipperStateMachineService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/SkipperStateMachineService.java
@@ -204,6 +204,8 @@ public class SkipperStateMachineService {
 				if (e.getCause() instanceof SkipperException) {
 					// throw as SkipperException
 					throw (SkipperException) e.getCause();
+				} else if (e.getCause() instanceof RuntimeException) {
+					throw (RuntimeException) e.getCause();
 				}
 				throw new SkipperException("Error waiting to get Release from a statemachine", e);
 			}


### PR DESCRIPTION
- In a same way than SkipperException add handling for generic
  RuntimeExcepion and propagate it via rest into a client. For example
  if service throws IllegalStateException it really is not handled at all.
  It is required as all asserts throw it or generally speaking,
  deployer may throw it as well.
- Fixes #370 

Currently if we somehow get `RuntimeException` or its sibling we don't handle, shell gets:
```
skipper:>some command to error
Error waiting to get Release from a statemachine
Details of the error have been omitted. You can use the stacktrace command to print the full stacktrace.
```

With this PR we get the message from exception:
```
skipper:>some command to error
hello from exception message
Details of the error have been omitted. You can use the stacktrace command to print the full stacktrace.
```
