### PR TITLE
Switch local and k8s deployer versions to 1.3.1.BS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
 
         <spring-cloud.version>Dalston.RELEASE</spring-cloud.version>
         <spring-cloud-deployer.version>1.3.0.RELEASE</spring-cloud-deployer.version>
-        <spring-cloud-deployer-local.version>1.3.0.RELEASE</spring-cloud-deployer-local.version>
+        <spring-cloud-deployer-local.version>1.3.1.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
         <spring-cloud-deployer-cloudfoundry.version>1.3.0.RELEASE</spring-cloud-deployer-cloudfoundry.version>
-        <spring-cloud-deployer-kubernetes.version>1.3.0.RELEASE</spring-cloud-deployer-kubernetes.version>
+        <spring-cloud-deployer-kubernetes.version>1.3.1.BUILD-SNAPSHOT</spring-cloud-deployer-kubernetes.version>
 
         <dockerfile-maven-plugin.version>1.3.6</dockerfile-maven-plugin.version>
         <zeroturnaround.version>1.11</zeroturnaround.version>


### PR DESCRIPTION
Currently, K8S ATs are failing on 1.9.x because the deployer fixes for 1.9 compatibility is in 1.3.1.BS. While I was at it, I also switched the local-deployer, but that doesn't really do anything for K8S ATs.

The local build with tests ran successfully. 