### PR TITLE
Use matching cloud versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <spring-shell.version>2.0.0.RELEASE</spring-shell.version>
         <spring-statemachine.version>1.2.8.RELEASE</spring-statemachine.version>
 
-        <spring-cloud.version>Dalston.RELEASE</spring-cloud.version>
+        <spring-cloud.version>Dalston.SR5</spring-cloud.version>
         <spring-cloud-deployer.version>1.3.1.RELEASE</spring-cloud-deployer.version>
         <spring-cloud-deployer-local.version>1.3.3.RELEASE</spring-cloud-deployer-local.version>
         <spring-cloud-deployer-cloudfoundry.version>1.3.1.RELEASE</spring-cloud-deployer-cloudfoundry.version>


### PR DESCRIPTION
- Match parent pom version with the one
  used in spring-cloud-dependencies import.
- Dalston.SR5 is 1.3.7.RELEASE while Dalston.RELEASE is 1.3.1.RELEASE
- Fixes #565 

Here's a diff from fatjar before and after:
```
$ diff /tmp/skipper-dalston-release.out /tmp/skipper-dalston-sr5.out 
59c59
< BOOT-INF/lib/logging-interceptor-3.6.0.jar
---
> BOOT-INF/lib/logging-interceptor-3.8.1.jar
79,80c79,80
< BOOT-INF/lib/okhttp-3.6.0.jar
< BOOT-INF/lib/okio-1.11.0.jar
---
> BOOT-INF/lib/okhttp-3.8.1.jar
> BOOT-INF/lib/okio-1.13.0.jar
110c110
< BOOT-INF/lib/spring-cloud-commons-1.2.0.RELEASE.jar
---
> BOOT-INF/lib/spring-cloud-commons-1.2.5.RELEASE.jar
112,113c112,113
< BOOT-INF/lib/spring-cloud-config-client-1.3.0.RELEASE.jar
< BOOT-INF/lib/spring-cloud-context-1.2.0.RELEASE.jar
---
> BOOT-INF/lib/spring-cloud-config-client-1.3.4.RELEASE.jar
> BOOT-INF/lib/spring-cloud-context-1.2.5.RELEASE.jar
125,126c125,126
< BOOT-INF/lib/spring-cloud-starter-1.2.0.RELEASE.jar
< BOOT-INF/lib/spring-cloud-starter-config-1.3.0.RELEASE.jar
---
> BOOT-INF/lib/spring-cloud-starter-1.2.5.RELEASE.jar
> BOOT-INF/lib/spring-cloud-starter-config-1.3.4.RELEASE.jar
```

Still we get downgrade from fabric8. 

```
+- io.fabric8:kubernetes-client:jar:3.1.5:compile
|  +- io.fabric8:kubernetes-model:jar:2.0.4:compile
|  |  +- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.8.10:compile (version managed from 2.7.5)
|  |  |  +- (com.fasterxml.jackson.core:jackson-core:jar:2.8.10:compile - version managed from 2.8.3; omitted for duplicate)
|  |  |  +- (com.fasterxml.jackson.core:jackson-annotations:jar:2.8.0:compile - version managed from 2.8.10; omitted for duplicate)
|  |  |  \- (com.fasterxml.jackson.core:jackson-databind:jar:2.8.10:compile - version managed from 2.8.3; omitted for duplicate)
|  |  \- (javax.validation:validation-api:jar:1.1.0.Final:compile - omitted for duplicate)
|  +- com.squareup.okhttp3:okhttp:jar:3.8.1:compile (version managed from 3.9.0)
|  |  \- com.squareup.okio:okio:jar:1.13.0:compile
|  +- com.squareup.okhttp3:logging-interceptor:jar:3.8.1:compile (version managed from 3.9.0)
|  |  \- (com.squareup.okhttp3:okhttp:jar:3.8.1:compile - version managed from 3.9.0; omitted for duplicate)
```
