### PR TITLE
Create k8s client from fabric8 config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
         release versions -->
         <spring-cloud.version>Dalston.SR5</spring-cloud.version>
         <spring-cloud-deployer.version>1.3.1.RELEASE</spring-cloud-deployer.version>
-        <spring-cloud-deployer-local.version>1.3.3.RELEASE</spring-cloud-deployer-local.version>
+        <spring-cloud-deployer-local.version>1.3.4.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
         <spring-cloud-deployer-cloudfoundry.version>1.3.1.RELEASE</spring-cloud-deployer-cloudfoundry.version>
-        <spring-cloud-deployer-kubernetes.version>1.3.2.RELEASE</spring-cloud-deployer-kubernetes.version>
+        <spring-cloud-deployer-kubernetes.version>1.3.3.BUILD-SNAPSHOT</spring-cloud-deployer-kubernetes.version>
 
         <dockerfile-maven-plugin.version>1.3.6</dockerfile-maven-plugin.version>
         <zeroturnaround.version>1.11</zeroturnaround.version>

--- a/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/KubernetesPlatformAutoConfiguration.java
+++ b/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/KubernetesPlatformAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +27,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.deployer.spi.kubernetes.ContainerFactory;
 import org.springframework.cloud.deployer.spi.kubernetes.DefaultContainerFactory;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesAppDeployer;
+import org.springframework.cloud.deployer.spi.kubernetes.KubernetesClientFactory;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesDeployerProperties;
 import org.springframework.cloud.skipper.deployer.kubernetes.KubernetesPlatformProperties;
 import org.springframework.cloud.skipper.domain.Deployer;
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * @author Donovan Muller
+ * @author Ilayaperumal Gopinathan
  */
 @Configuration
 @EnableConfigurationProperties(KubernetesPlatformProperties.class)
@@ -61,8 +62,7 @@ public class KubernetesPlatformAutoConfiguration {
 
 	protected Deployer createAndSaveKubernetesAppDeployers(String account,
 			KubernetesDeployerProperties kubernetesProperties) {
-		KubernetesClient kubernetesClient = new DefaultKubernetesClient()
-				.inNamespace(kubernetesProperties.getNamespace());
+		KubernetesClient kubernetesClient = KubernetesClientFactory.getKubernetesClient(kubernetesProperties);
 		ContainerFactory containerFactory = new DefaultContainerFactory(
 				kubernetesProperties);
 		KubernetesAppDeployer kubernetesAppDeployer = new KubernetesAppDeployer(

--- a/spring-cloud-skipper-platform-kubernetes/src/test/java/org/springframework/cloud/skipper/deployer/KubernetesPlatformPropertiesTest.java
+++ b/spring-cloud-skipper-platform-kubernetes/src/test/java/org/springframework/cloud/skipper/deployer/KubernetesPlatformPropertiesTest.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.skipper.deployer;
 
 import java.util.Map;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,6 +26,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.spi.kubernetes.EntryPointStyle;
 import org.springframework.cloud.deployer.spi.kubernetes.ImagePullPolicy;
+import org.springframework.cloud.deployer.spi.kubernetes.KubernetesClientFactory;
 import org.springframework.cloud.deployer.spi.kubernetes.KubernetesDeployerProperties;
 import org.springframework.cloud.skipper.deployer.kubernetes.KubernetesPlatformProperties;
 import org.springframework.context.annotation.Configuration;
@@ -47,9 +49,14 @@ public class KubernetesPlatformPropertiesTest {
 	@Test
 	public void deserializationTest() {
 		Map<String, KubernetesDeployerProperties> k8sAccounts = this.kubernetesPlatformProperties.getAccounts();
+		KubernetesClient devK8sClient = KubernetesClientFactory.getKubernetesClient(k8sAccounts.get("dev"));
+		KubernetesClient qaK8sClient = KubernetesClientFactory.getKubernetesClient(k8sAccounts.get("qa"));
 		assertThat(k8sAccounts).hasSize(2);
 		assertThat(k8sAccounts).containsKeys("dev", "qa");
-		assertThat(k8sAccounts.get("dev").getNamespace()).isEqualTo("devNamespace");
+		assertThat(devK8sClient.getNamespace()).isEqualTo("dev1");
+		assertThat(devK8sClient.getMasterUrl().toString()).isEqualTo("http://192.168.0.1:8443");
+		assertThat(qaK8sClient.getMasterUrl().toString()).isEqualTo("http://192.168.0.2:8443");
+		assertThat(qaK8sClient.getNamespace()).isEqualTo("qaNamespace");
 		assertThat(k8sAccounts.get("dev").getImagePullPolicy()).isEqualTo(ImagePullPolicy.Always);
 		assertThat(k8sAccounts.get("dev").getEntryPointStyle()).isEqualTo(EntryPointStyle.exec);
 		assertThat(k8sAccounts.get("dev").getLimits().getCpu()).isEqualTo("4");

--- a/spring-cloud-skipper-platform-kubernetes/src/test/resources/application-platform-properties.yml
+++ b/spring-cloud-skipper-platform-kubernetes/src/test/resources/application-platform-properties.yml
@@ -10,12 +10,17 @@ spring:
           kubernetes:
             accounts:
               dev:
+                fabric8:
+                  masterUrl: http://192.168.0.1:8443
+                  namespace: dev1
                 namespace: devNamespace
                 imagePullPolicy: Always
                 entryPointStyle: exec
                 limits:
                   cpu: 4
               qa:
+                fabric8:
+                  masterUrl: http://192.168.0.2:8443
                 namespace: qaNamespace
                 imagePullPolicy: IfNotPresent
                 entryPointStyle: boot


### PR DESCRIPTION
 - When creating the k8s client, use the fabric8 config set in the k8s deployer properties
   - Use the `KubernetesClientFactory` from spring-cloud-deployer-kubernetes to create the client
 - Add tests to verify the changes

Resolves #579