### PR TITLE
Fix various issues around state handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring-shell.version>2.0.0.RELEASE</spring-shell.version>
-        <spring-statemachine.version>1.2.10.RELEASE</spring-statemachine.version>
+        <spring-statemachine.version>1.2.11.BUILD-SNAPSHOT</spring-statemachine.version>
 
         <!-- NOTE: Make sure to update `spring-cloud-build` version and `spring-cloud-dependencies` version (spring-cloud.version)
         are in sync with the https://github.com/spring-cloud/spring-cloud-release/blob/master/pom.xml updates for the respective

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -41,9 +41,10 @@ public interface ReleaseManager {
 	 * @param existingRelease the existing release that is deployed
 	 * @param replacingRelease the release that is to be deployed in place of the existing
 	 * release
+	 * @param initial the flag indicating this is initial report creation
 	 * @return a report describing the actions to take to update
 	 */
-	ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease);
+	ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease, boolean initial);
 
 	/**
 	 * Delete the release

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HandleHealthCheckStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HandleHealthCheckStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,9 +105,11 @@ public class HandleHealthCheckStep {
 			this.releaseRepository.save(replacingRelease);
 		}
 		catch (DataAccessException e) {
+			logger.debug("Error1 deleteReplacingRelease {}", e);
 			throw e;
 		}
 		catch (Exception e) {
+			logger.debug("Error2 deleteReplacingRelease {}", e);
 			// Update Status in DB
 			Status status = new Status();
 			status.setStatusCode(StatusCode.FAILED);
@@ -131,9 +133,11 @@ public class HandleHealthCheckStep {
 			this.deleteStep.delete(existingRelease, existingAppDeployerData, applicationNamesToUpgrade);
 		}
 		catch (DataAccessException e) {
+			logger.debug("Error1 deleteExistingRelease {}", e);
 			throw e;
 		}
 		catch (Exception e) {
+			logger.debug("Error2 deleteExistingRelease {}", e);
 			// Update Status in DB
 			Status status = new Status();
 			status.setStatusCode(StatusCode.FAILED);

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -304,7 +304,7 @@ public class ReleaseService {
 
 	@Transactional
 	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease) {
-		return this.releaseManager.createReport(existingRelease, replacingRelease);
+		return this.releaseManager.createReport(existingRelease, replacingRelease, true);
 	}
 
 	protected Release createInitialRelease(InstallProperties installProperties, Package packageToInstall,

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/AbstractUpgradeStartAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/AbstractUpgradeStartAction.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.springframework.cloud.skipper.domain.UpgradeRequest;
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.service.ReleaseReportService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+import org.springframework.util.Assert;
+
+/**
+ * Base class for upgrade related {@link Action}s wanting some shared functionality.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractUpgradeStartAction extends AbstractAction {
+
+	private final ReleaseReportService releaseReportService;
+
+	/**
+	 * Instantiates a new abstract upgrade start action.
+	 *
+	 * @param releaseReportService the release report service
+	 */
+	public AbstractUpgradeStartAction(ReleaseReportService releaseReportService) {
+		super();
+		Assert.notNull(releaseReportService, "'releaseReportService' must be set");
+		this.releaseReportService = releaseReportService;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		UpgradeRequest upgradeRequest = context.getExtendedState().get(SkipperEventHeaders.UPGRADE_REQUEST,
+				UpgradeRequest.class);
+		Assert.notNull(upgradeRequest, "'upgradeRequest' not known to the system in extended state");
+		ReleaseAnalysisReport releaseAnalysisReport = this.getReleaseReportService().createReport(upgradeRequest,
+				handlesInitialReport());
+		context.getExtendedState().getVariables().put(SkipperVariables.RELEASE_ANALYSIS_REPORT, releaseAnalysisReport);
+	}
+
+	protected ReleaseAnalysisReport getReleaseAnalysisReport(
+			StateContext<SkipperStates, SkipperEvents> context) {
+		ReleaseAnalysisReport releaseAnalysisReport = context.getExtendedState()
+				.get(SkipperVariables.RELEASE_ANALYSIS_REPORT, ReleaseAnalysisReport.class);
+		Assert.notNull(releaseAnalysisReport, "'releaseAnalysisReport' not known to the system in extended state");
+		return releaseAnalysisReport;
+	}
+
+	protected boolean handlesInitialReport() {
+		return false;
+	}
+
+	protected ReleaseReportService getReleaseReportService() {
+		return releaseReportService;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/DeleteDeleteAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/DeleteDeleteAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,9 @@ public class DeleteDeleteAction extends AbstractAction {
 		log.debug("Starting action " + context);
 		String releaseName = context.getMessageHeaders().get(SkipperEventHeaders.RELEASE_NAME, String.class);
 		log.info("About to delete {}", releaseName);
-		DeleteProperties deleteProperties = context.getMessageHeaders()
+		DeleteProperties deleteProperties = context.getExtendedState()
 				.get(SkipperEventHeaders.RELEASE_DELETE_PROPERTIES, DeleteProperties.class);
+		Assert.notNull(deleteProperties, "'deleteProperties' not known to the system in extended state");
 		Release release = this.releaseService.delete(releaseName, deleteProperties.isDeletePackage());
 		context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, release);
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ResetVariablesAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ResetVariablesAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,11 @@
  */
 package org.springframework.cloud.skipper.server.statemachine;
 
+import org.springframework.cloud.skipper.domain.DeleteProperties;
+import org.springframework.cloud.skipper.domain.InstallProperties;
+import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.UpgradeRequest;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
 import org.springframework.statemachine.StateContext;
@@ -31,5 +36,54 @@ public class ResetVariablesAction implements Action<SkipperStates, SkipperEvents
 	@Override
 	public void execute(StateContext<SkipperStates, SkipperEvents> context) {
 		context.getExtendedState().getVariables().clear();
+
+		// storing various requests into context so that those get persisted
+		// when machine goes to any parent states (rollback, upgrade, install,
+		// delete)
+
+		// for install
+		InstallRequest installRequest = context.getMessageHeaders().get(SkipperEventHeaders.INSTALL_REQUEST,
+				InstallRequest.class);
+		if (installRequest != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.INSTALL_REQUEST, installRequest);
+		}
+
+		InstallProperties installProperties = context.getMessageHeaders().get(SkipperEventHeaders.INSTALL_PROPERTIES,
+				InstallProperties.class);
+		if (installProperties != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.INSTALL_PROPERTIES, installProperties);
+		}
+
+		// for rollback and delete
+		String releaseName = context.getMessageHeaders().get(SkipperEventHeaders.RELEASE_NAME, String.class);
+		if (releaseName != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.RELEASE_NAME, releaseName);
+		}
+
+		// for rollback
+		Integer rollbackVersion = context.getMessageHeaders().get(SkipperEventHeaders.ROLLBACK_VERSION, Integer.class);
+		if (rollbackVersion != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.ROLLBACK_VERSION, rollbackVersion);
+		}
+
+		// for upgrade
+		UpgradeRequest upgradeRequest = context.getMessageHeaders().get(SkipperEventHeaders.UPGRADE_REQUEST,
+				UpgradeRequest.class);
+		if (upgradeRequest != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.UPGRADE_REQUEST, upgradeRequest);
+		}
+
+		Long upgradeTimeout = context.getMessageHeaders().get(SkipperEventHeaders.UPGRADE_TIMEOUT, Long.class);
+		if (upgradeTimeout != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.UPGRADE_TIMEOUT, upgradeTimeout);
+		}
+
+		// for delete
+		DeleteProperties deleteProperties = context.getMessageHeaders()
+				.get(SkipperEventHeaders.RELEASE_DELETE_PROPERTIES, DeleteProperties.class);
+		if (deleteProperties != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.RELEASE_DELETE_PROPERTIES,
+					deleteProperties);
+		}
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/RollbackStartAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/RollbackStartAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,18 @@ package org.springframework.cloud.skipper.server.statemachine;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.InstallProperties;
+import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.domain.UpgradeProperties;
+import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
-import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 import org.springframework.util.Assert;
@@ -54,9 +56,17 @@ public class RollbackStartAction  extends AbstractAction {
 
 	@Override
 	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		log.debug("Starting to execute action");
+		// get from event headers and fall back checking if it's in context
+		// in case machine died and we restored
 		String releaseName = context.getMessageHeaders().get(SkipperEventHeaders.RELEASE_NAME, String.class);
 		Integer rollbackVersion = context.getMessageHeaders().get(SkipperEventHeaders.ROLLBACK_VERSION, Integer.class);
-
+		if (releaseName == null) {
+			releaseName = context.getExtendedState().get(SkipperEventHeaders.RELEASE_NAME, String.class);
+		}
+		if (rollbackVersion == null) {
+			rollbackVersion = context.getExtendedState().get(SkipperEventHeaders.ROLLBACK_VERSION, Integer.class);
+		}
 
 		Assert.notNull(releaseName, "Release name must not be null");
 		Assert.isTrue(rollbackVersion >= 0,
@@ -84,20 +94,39 @@ public class RollbackStartAction  extends AbstractAction {
 		log.info("Rolling back releaseName={}.  Current version={}, Target version={}", releaseName,
 				currentRelease.getVersion(), rollbackVersionToUse);
 
-		Release newRollbackRelease = new Release();
-		newRollbackRelease.setName(releaseName);
-		newRollbackRelease.setPkg(releaseToRollback.getPkg());
-		newRollbackRelease.setManifest(releaseToRollback.getManifest());
-		newRollbackRelease.setVersion(currentRelease.getVersion() + 1);
-		newRollbackRelease.setPlatformName(releaseToRollback.getPlatformName());
-		newRollbackRelease.setConfigValues(releaseToRollback.getConfigValues());
-		newRollbackRelease.setInfo(Info.createNewInfo("Rollback underway"));
+		// rollback a release will dispatch to either install or upgrade,
+		// thus create install or update request conditionally. we have
+		// same package identifier for both.
 
-		context.getExtendedState().getVariables().put(SkipperVariables.TARGET_RELEASE, newRollbackRelease);
+		PackageIdentifier packageIdentifier = new PackageIdentifier();
+		packageIdentifier.setPackageName(releaseToRollback.getPkg().getMetadata().getName());
+		packageIdentifier.setPackageVersion(releaseToRollback.getPkg().getMetadata().getVersion());
+		packageIdentifier.setRepositoryName(releaseToRollback.getPkg().getMetadata().getRepositoryName());
 
-		if (!currentRelease.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
-			context.getExtendedState().getVariables().put(SkipperVariables.SOURCE_RELEASE, currentRelease);
+		if (currentRelease.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
+			InstallRequest installRequest = new InstallRequest();
+			InstallProperties installProperties = new InstallProperties();
+			installProperties.setConfigValues(releaseToRollback.getConfigValues());
+			installProperties.setPlatformName(releaseToRollback.getPlatformName());
+			installProperties.setReleaseName(releaseName);
+			installRequest.setInstallProperties(installProperties);
+			installRequest.setPackageIdentifier(packageIdentifier);
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.INSTALL_REQUEST, installRequest);
 		}
+		else {
+			UpgradeRequest upgradeRequest = new UpgradeRequest();
+			UpgradeProperties upgradeProperties = new UpgradeProperties();
+			upgradeProperties.setReleaseName(releaseName);
+			upgradeProperties.setConfigValues(releaseToRollback.getConfigValues());
+			upgradeRequest.setUpgradeProperties(upgradeProperties);
+			upgradeRequest.setPackageIdentifier(packageIdentifier);
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.UPGRADE_REQUEST, upgradeRequest);
+		}
+		// TODO: originally we had
+		//       newRollbackRelease.setInfo(Info.createNewInfo("Rollback underway"));
+		//       should think how we pass this on. it feels a bit off that we do either
+		//       install or upgrade and status should reflect that. either we should
+		//       pass some extra msg fields with install/upgrade requests or fully
+		//       separate rollback into its own flow.
 	}
-
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/SkipperStateMachineService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/SkipperStateMachineService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCancelAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCancelAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package org.springframework.cloud.skipper.server.statemachine;
 
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.service.ReleaseReportService;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
-import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
@@ -29,24 +29,25 @@ import org.springframework.statemachine.action.Action;
  * @author Janne Valkealahti
  *
  */
-public class UpgradeCancelAction extends AbstractAction {
+public class UpgradeCancelAction extends AbstractUpgradeStartAction {
 
 	private final UpgradeStrategy upgradeStrategy;
 
 	/**
 	 * Instantiates a new upgrade cancel action.
 	 *
+	 * @param releaseReportService the release report service
 	 * @param upgradeStrategy the upgrade strategy
 	 */
-	public UpgradeCancelAction(UpgradeStrategy upgradeStrategy) {
-		super();
+	public UpgradeCancelAction(ReleaseReportService releaseReportService, UpgradeStrategy upgradeStrategy) {
+		super(releaseReportService);
 		this.upgradeStrategy = upgradeStrategy;
 	}
 
 	@Override
 	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
-		ReleaseAnalysisReport releaseAnalysisReport = context.getExtendedState().get(SkipperVariables.RELEASE_ANALYSIS_REPORT,
-				ReleaseAnalysisReport.class);
+		super.executeInternal(context);
+		ReleaseAnalysisReport releaseAnalysisReport = getReleaseAnalysisReport(context);
 		upgradeStrategy.cancel(releaseAnalysisReport.getExistingRelease(), releaseAnalysisReport.getReplacingRelease(),
 				releaseAnalysisReport);
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeleteSourceAppsAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeleteSourceAppsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package org.springframework.cloud.skipper.server.statemachine;
 
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.service.ReleaseReportService;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
-import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
@@ -29,24 +29,25 @@ import org.springframework.statemachine.action.Action;
  * @author Janne Valkealahti
  *
  */
-public class UpgradeDeleteSourceAppsAction extends AbstractAction {
+public class UpgradeDeleteSourceAppsAction extends AbstractUpgradeStartAction {
 
 	private final UpgradeStrategy upgradeStrategy;
 
 	/**
 	 * Instantiates a new upgrade delete source apps action.
 	 *
+	 * @param releaseReportService the release report service
 	 * @param upgradeStrategy the upgrade strategy
 	 */
-	public UpgradeDeleteSourceAppsAction(UpgradeStrategy upgradeStrategy) {
-		super();
+	public UpgradeDeleteSourceAppsAction(ReleaseReportService releaseReportService, UpgradeStrategy upgradeStrategy) {
+		super(releaseReportService);
 		this.upgradeStrategy = upgradeStrategy;
 	}
 
 	@Override
 	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
-		ReleaseAnalysisReport releaseAnalysisReport = context.getExtendedState().get(SkipperVariables.RELEASE_ANALYSIS_REPORT,
-				ReleaseAnalysisReport.class);
+		super.executeInternal(context);
+		ReleaseAnalysisReport releaseAnalysisReport = getReleaseAnalysisReport(context);
 		upgradeStrategy.accept(releaseAnalysisReport.getExistingRelease(), releaseAnalysisReport.getReplacingRelease(),
 				releaseAnalysisReport);
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeployTargetAppsAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeployTargetAppsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package org.springframework.cloud.skipper.server.statemachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.service.ReleaseReportService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
@@ -33,32 +34,42 @@ import org.springframework.statemachine.action.Action;
  * @author Janne Valkealahti
  *
  */
-public class UpgradeDeployTargetAppsAction extends AbstractAction {
+public class UpgradeDeployTargetAppsAction extends AbstractUpgradeStartAction {
 
 	private static final Logger log = LoggerFactory.getLogger(UpgradeDeployTargetAppsAction.class);
+	private static final long DEFAULT_UPGRADE_TIMEOUT = 300000L;
 	private final UpgradeStrategy upgradeStrategy;
 
 	/**
 	 * Instantiates a new upgrade deploy target apps action.
 	 *
+	 * @param releaseReportService the release report service
 	 * @param upgradeStrategy the upgrade strategy
 	 */
-	public UpgradeDeployTargetAppsAction(UpgradeStrategy upgradeStrategy) {
-		super();
+	public UpgradeDeployTargetAppsAction(ReleaseReportService releaseReportService, UpgradeStrategy upgradeStrategy) {
+		super(releaseReportService);
 		this.upgradeStrategy = upgradeStrategy;
 	}
 
 	@Override
 	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		super.executeInternal(context);
+		ReleaseAnalysisReport releaseAnalysisReport = getReleaseAnalysisReport(context);
 		log.info("Using UpgradeStrategy {}", upgradeStrategy);
-		ReleaseAnalysisReport releaseAnalysisReport = context.getExtendedState().get(SkipperVariables.RELEASE_ANALYSIS_REPORT,
-				ReleaseAnalysisReport.class);
-		log.info("releaseAnalysisReport {}", releaseAnalysisReport);
-		if (releaseAnalysisReport == null) {
-			throw new SkipperException("ReleaseAnalysis report is null");
-		}
+		setUpgradeCutOffTime(context);
 		this.upgradeStrategy.deployApps(releaseAnalysisReport.getExistingRelease(),
 				releaseAnalysisReport.getReplacingRelease(), releaseAnalysisReport);
 		context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, releaseAnalysisReport.getReplacingRelease());
+	}
+
+	private void setUpgradeCutOffTime(StateContext<SkipperStates, SkipperEvents> context) {
+		Long upgradeTimeout = context.getExtendedState().get(SkipperEventHeaders.UPGRADE_TIMEOUT, Long.class);
+		if (upgradeTimeout == null) {
+			upgradeTimeout = DEFAULT_UPGRADE_TIMEOUT;
+		}
+		long cutOffTime = System.currentTimeMillis() + upgradeTimeout;
+		context.getExtendedState().getVariables().put(SkipperVariables.UPGRADE_CUTOFF_TIME,
+				cutOffTime);
+		log.debug("Set cutoff time as {}", cutOffTime);
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ConfigValues.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ConfigValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.cloud.skipper.domain;
  * Configuration values for the deployment.
  *
  * @author Mark Pollack
+ * @author Janne Valkealahti
+ *
  */
 public class ConfigValues {
 
@@ -36,4 +38,28 @@ public class ConfigValues {
 		this.raw = raw;
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((raw == null) ? 0 : raw.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ConfigValues other = (ConfigValues) obj;
+		if (raw == null) {
+			if (other.raw != null)
+				return false;
+		} else if (!raw.equals(other.raw))
+			return false;
+		return true;
+	}
 }


### PR DESCRIPTION
- Effectively remove most of the release related object
  from machine context persistance layer to overcome
  kryo issues.
- Remove hard requirement passing Release pojo around
  and try to recreate it and report from request pojos
  used with install and upgrade.
- Rewrite most of the machine action classes to be better
  with serialised context when machine is restored.
- Add equals/hash to ConfigValues as tests expect equal on
  a object level, not just checking if it's a same instance.
- Some things are left to other PR's such as, 1. have proper
  release status when upgrading, 2. auto start machines for
  releases which are supposed to be in a state other than
  INITIAL, 3 need to add support for installing a release when
  upgrade fully failed where v1 ended into DELETED and v2 into FAILED.
- Fixes #574
- Fixes #575