### PR TITLE
Enhance timeout handling with rollback and upgrade

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.skipper.domain.Manifest;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
@@ -235,9 +236,20 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
+	public Release rollback(RollbackRequest rollbackRequest) {
+		ParameterizedTypeReference<Resource<Release>> typeReference =
+				new ParameterizedTypeReference<Resource<Release>>() { };
+		String url = String.format("%s/%s/%s", baseUri, "release", "rollback");
+
+		HttpEntity<RollbackRequest> httpEntity = new HttpEntity<>(rollbackRequest);
+		ResponseEntity<Resource<Release>> resourceResponseEntity =
+				restTemplate.exchange(url, HttpMethod.POST, httpEntity,	typeReference);
+		return resourceResponseEntity.getBody().getContent();
+	}
+
+	@Override
 	public Release rollback(String releaseName, int releaseVersion) {
-		String url = String.format("%s/%s/%s/%s/%s", baseUri, "release", "rollback", releaseName, releaseVersion);
-		return this.restTemplate.postForObject(url, null, Release.class);
+		return rollback(new RollbackRequest(releaseName, releaseVersion));
 	}
 
 	@Override

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Repository;
+import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
@@ -34,6 +35,7 @@ import org.springframework.hateoas.Resources;
  *
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
 public interface SkipperClient {
 
@@ -98,10 +100,21 @@ public interface SkipperClient {
 	/**
 	 * Rollback a specific release.
 	 *
+	 * @param rollbackRequest the rollback request
+	 * @return the rolled back {@link Release}
+	 */
+	Release rollback(RollbackRequest rollbackRequest);
+
+	/**
+	 * Rollback a specific release.
+	 *
 	 * @param releaseName the release name
 	 * @param releaseVersion the release version
 	 * @return the rolled back {@link Release}
+	 * @see #rollback(RollbackRequest)
+	 * @deprecated use rollback method taking a rollback request
 	 */
+	@Deprecated
 	Release rollback(String releaseName, int releaseVersion);
 
 	/**

--- a/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
@@ -540,9 +540,15 @@ include::{snippets}/upgrade-documentation/upgrade-release/response-fields.adoc[]
 [[resources-release-rollback]]
 ==== Rollback
 
-===== Rollback release
+===== Rollback release using uri variables
 
 The rollback link rolls back the release to a previous or a specific release.
+
+[NOTE]
+====
+This part of the api is deprecated, please use
+<<resources-release-rollback-request>>.
+====
 
 ====== Request structure
 
@@ -560,6 +566,26 @@ include::{snippets}/rollback-documentation/rollback-release/http-response.adoc[]
 
 include::{snippets}/rollback-documentation/rollback-release/response-fields.adoc[]
 
+[[resources-release-rollback-request]]
+===== Rollback release using request object
+
+The rollback link rolls back the release to a previous or a specific release.
+
+====== Request structure
+
+include::{snippets}/rollback-documentation/rollback-release-request/http-request.adoc[]
+
+====== Example request
+
+include::{snippets}/rollback-documentation/rollback-release-request/curl-request.adoc[]
+
+====== Response structure
+
+include::{snippets}/rollback-documentation/rollback-release-request/http-response.adoc[]
+
+====== Response fields
+
+include::{snippets}/rollback-documentation/rollback-release-request/response-fields.adoc[]
 
 [[resources-release-manifest]]
 ==== Manifest

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -278,12 +278,10 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 	@Bean
 	public HandleHealthCheckStep healthCheckAndDeleteStep(ReleaseRepository releaseRepository,
 			AppDeployerDataRepository appDeployerDataRepository,
-			DeleteStep deleteStep,
-			HealthCheckProperties healthCheckProperties) {
+			DeleteStep deleteStep) {
 		return new HandleHealthCheckStep(releaseRepository,
 				appDeployerDataRepository,
-				deleteStep,
-				healthCheckProperties);
+				deleteStep);
 	}
 
 	@Bean(name = SKIPPER_EXECUTOR)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
@@ -55,13 +55,14 @@ public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 	public void accept(Release existingRelease, Release replacingRelease,
 			ReleaseAnalysisReport releaseAnalysisReport) {
 		this.handleHealthCheckStep.handleHealthCheck(true, existingRelease,
-				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease);
+				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease, null);
 	}
 
 	@Override
-	public void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport) {
+	public void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport,
+			Long timeout) {
 		this.handleHealthCheckStep.handleHealthCheck(false, existingRelease,
-				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease);
+				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease, timeout);
 	}
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
@@ -32,6 +32,6 @@ public interface UpgradeStrategy {
 
 	void accept(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
 
-	void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
+	void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport, Long timeout);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ResetVariablesAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ResetVariablesAction.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.statemachine;
 import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
@@ -64,6 +65,11 @@ public class ResetVariablesAction implements Action<SkipperStates, SkipperEvents
 		Integer rollbackVersion = context.getMessageHeaders().get(SkipperEventHeaders.ROLLBACK_VERSION, Integer.class);
 		if (rollbackVersion != null) {
 			context.getExtendedState().getVariables().put(SkipperEventHeaders.ROLLBACK_VERSION, rollbackVersion);
+		}
+		RollbackRequest rollbackRequest = context.getMessageHeaders().get(SkipperEventHeaders.ROLLBACK_REQUEST,
+				RollbackRequest.class);
+		if (rollbackRequest != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.ROLLBACK_REQUEST, rollbackRequest);
 		}
 
 		// for upgrade

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/RollbackStartAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/RollbackStartAction.java
@@ -22,6 +22,7 @@ import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
@@ -120,6 +121,11 @@ public class RollbackStartAction  extends AbstractAction {
 			upgradeProperties.setConfigValues(releaseToRollback.getConfigValues());
 			upgradeRequest.setUpgradeProperties(upgradeProperties);
 			upgradeRequest.setPackageIdentifier(packageIdentifier);
+			RollbackRequest rollbackRequest = context.getExtendedState().get(SkipperEventHeaders.ROLLBACK_REQUEST,
+					RollbackRequest.class);
+			if (rollbackRequest != null) {
+				upgradeRequest.setTimeout(rollbackRequest.getTimeout());
+			}
 			context.getExtendedState().getVariables().put(SkipperEventHeaders.UPGRADE_REQUEST, upgradeRequest);
 		}
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineConfiguration.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckProperties;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 import org.springframework.cloud.skipper.server.service.ReleaseReportService;
@@ -77,6 +78,9 @@ public class StateMachineConfiguration {
 
 		@Autowired
 		private UpgradeStrategy upgradeStrategy;
+
+		@Autowired
+		private HealthCheckProperties healthCheckProperties;
 
 		@Autowired
 		private StateMachineRuntimePersister<SkipperStates, SkipperEvents, String> stateMachineRuntimePersister;
@@ -317,7 +321,7 @@ public class StateMachineConfiguration {
 
 		@Bean
 		public UpgradeDeployTargetAppsAction upgradeDeployTargetAppsAction() {
-			return new UpgradeDeployTargetAppsAction(releaseReportService, upgradeStrategy);
+			return new UpgradeDeployTargetAppsAction(releaseReportService, upgradeStrategy, healthCheckProperties);
 		}
 
 		@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCancelAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCancelAction.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.statemachine;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
 import org.springframework.cloud.skipper.server.service.ReleaseReportService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
 import org.springframework.statemachine.StateContext;
@@ -48,7 +49,8 @@ public class UpgradeCancelAction extends AbstractUpgradeStartAction {
 	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
 		super.executeInternal(context);
 		ReleaseAnalysisReport releaseAnalysisReport = getReleaseAnalysisReport(context);
+		Long upgradeTimeout = context.getExtendedState().get(SkipperEventHeaders.UPGRADE_TIMEOUT, Long.class);
 		upgradeStrategy.cancel(releaseAnalysisReport.getExistingRelease(), releaseAnalysisReport.getReplacingRelease(),
-				releaseAnalysisReport);
+				releaseAnalysisReport, upgradeTimeout);
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
@@ -36,6 +36,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
@@ -162,7 +163,7 @@ public abstract class AbstractIntegrationTest extends AbstractAssertReleaseDeplo
 	}
 
 	protected Release rollback(String releaseName, int releaseVersion) throws InterruptedException {
-		Release release = skipperStateMachineService.rollbackRelease(releaseName, releaseVersion);
+		Release release = skipperStateMachineService.rollbackRelease(new RollbackRequest(releaseName, releaseVersion));
 		// Need to use the value of version passed back from calling rollback,
 		// since 0 implies most recent deleted release
 		assertReleaseIsDeployedSuccessfully(release.getName(), release.getVersion());

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
@@ -21,7 +21,9 @@ import org.junit.Test;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.StringUtils;
@@ -32,6 +34,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.Charset;
 
 /**
  * @author Gunnar Hillert
@@ -59,6 +63,88 @@ public class RollbackDocumentation extends BaseDocumentation {
 				.andDo(this.documentationHandler.document(
 						responseFields(
 								subsectionWithPath("_links").ignored(),
+								fieldWithPath("name").description("Name of the release"),
+								fieldWithPath("version").description("Version of the release"),
+								fieldWithPath("info.status.statusCode").description(
+										String.format("StatusCode of the release's status (%s)",
+												StringUtils.arrayToCommaDelimitedString(StatusCode.values()))),
+								fieldWithPath("info.status.platformStatus")
+										.description("Status from the underlying platform"),
+								fieldWithPath("info.firstDeployed").description("Date/Time of first deployment"),
+								fieldWithPath("info.lastDeployed").description("Date/Time of last deployment"),
+								fieldWithPath("info.deleted").description("Date/Time of when the release was deleted"),
+								fieldWithPath("info.description")
+										.description("Human-friendly 'log entry' about this release"),
+								fieldWithPath("pkg.metadata.apiVersion")
+										.description("The Package Index spec version this file is based on"),
+								fieldWithPath("pkg.metadata.origin")
+										.description("Indicates the origin of the repository (free form text)"),
+								fieldWithPath("pkg.metadata.repositoryId")
+										.description("The repository ID this Package belongs to."),
+								fieldWithPath("pkg.metadata.repositoryName")
+										.description("The repository name this Package belongs to."),
+								fieldWithPath("pkg.metadata.kind")
+										.description("What type of package system is being used"),
+								fieldWithPath("pkg.metadata.name").description("The name of the package"),
+								fieldWithPath("pkg.metadata.displayName").description("Display name of the release"),
+								fieldWithPath("pkg.metadata.version").description("The version of the package"),
+								fieldWithPath("pkg.metadata.packageSourceUrl")
+										.description("Location to source code for this package"),
+								fieldWithPath("pkg.metadata.packageHomeUrl")
+										.description("The home page of the package"),
+								fieldWithPath("pkg.metadata.tags")
+										.description("A comma separated list of tags to use for searching"),
+								fieldWithPath("pkg.metadata.maintainer").description("Who is maintaining this package"),
+								fieldWithPath("pkg.metadata.description")
+										.description("Brief description of the package"),
+								fieldWithPath("pkg.metadata.sha256").description(
+										"Hash of package binary that will be downloaded using SHA256 hash algorithm"),
+								fieldWithPath("pkg.metadata.iconUrl").description("Url location of a icon"),
+								fieldWithPath("pkg.templates[].name")
+										.description("Name is the path-like name of the template"),
+								fieldWithPath("pkg.templates[].data")
+										.description("Data is the template as string data"),
+								fieldWithPath("pkg.dependencies")
+										.description("The packages that this package depends upon"),
+								fieldWithPath("pkg.configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("pkg.fileHolders")
+										.description("Miscellaneous files in a package, e.g. README, LICENSE, etc."),
+								fieldWithPath("configValues.raw")
+										.description("The raw YAML string of configuration values"),
+								fieldWithPath("manifest.data").description("The manifest of the release"),
+								fieldWithPath("platformName").description("Platform name of the release"))))
+				.andReturn();
+		Release release = convertContentToRelease(result.getResponse().getContentAsString());
+		assertReleaseIsDeployedSuccessfully(releaseName, release.getVersion());
+	}
+
+	@Test
+	public void rollbackReleaseRequest() throws Exception {
+		final String releaseName = "myLogRelease2";
+		final InstallRequest installRequest = new InstallRequest();
+		final PackageIdentifier packageIdentifier = new PackageIdentifier();
+		packageIdentifier.setPackageName("log");
+		packageIdentifier.setPackageVersion("1.0.0");
+		packageIdentifier.setRepositoryName("notused");
+		installRequest.setPackageIdentifier(packageIdentifier);
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
+
+		installPackage(installRequest);
+		upgrade("log", "1.1.0", releaseName);
+
+		final RollbackRequest rollbackRequest = new RollbackRequest(releaseName, 1, 60000l);
+		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
+				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+
+		MvcResult result = this.mockMvc.perform(
+				post("/api/release/rollback").accept(MediaType.APPLICATION_JSON).contentType(contentType)
+				.content(convertObjectToJson(rollbackRequest)))
+				.andDo(print())
+				.andExpect(status().isCreated())
+				.andDo(this.documentationHandler.document(
+						responseFields(
+								subsectionWithPath("links").ignored(),
 								fieldWithPath("name").description("Name of the release"),
 								fieldWithPath("version").description("Version of the release"),
 								fieldWithPath("info.status.statusCode").description(

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
@@ -41,6 +41,7 @@ import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
 import org.springframework.cloud.skipper.server.deployer.strategies.DeployAppStep;
 import org.springframework.cloud.skipper.server.deployer.strategies.HandleHealthCheckStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckProperties;
 import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckStep;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
@@ -123,6 +124,9 @@ public class StateMachineTests {
 
 	@MockBean
 	private ReleaseRepository releaseRepository;
+
+	@MockBean
+	private HealthCheckProperties healthCheckProperties;
 
 	@SpyBean
 	private UpgradeCancelAction upgradeCancelAction;

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/RollbackRequest.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/RollbackRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+/**
+ * This contains all the request attributes for rollback operation.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class RollbackRequest {
+
+	private String releaseName;
+	private Integer version;
+	private Long timeout;
+
+	public RollbackRequest() {
+	}
+
+	public RollbackRequest(String releaseName, Integer version) {
+		this(releaseName, version, null);
+	}
+
+	public RollbackRequest(String releaseName, Integer version, Long timeout) {
+		this.releaseName = releaseName;
+		this.version = version;
+		this.timeout = timeout;
+	}
+
+	public String getReleaseName() {
+		return releaseName;
+	}
+
+	public void setReleaseName(String releaseName) {
+		this.releaseName = releaseName;
+	}
+
+	public Integer getVersion() {
+		return version;
+	}
+
+	public void setVersion(Integer version) {
+		this.version = version;
+	}
+
+	public Long getTimeout() {
+		return timeout;
+	}
+
+	public void setTimeout(Long timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
+	public String toString() {
+		return "RollbackRequest [releaseName=" + releaseName + ", version=" + version + ", timeout=" + timeout + "]";
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/UpgradeRequest.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/UpgradeRequest.java
@@ -23,8 +23,8 @@ package org.springframework.cloud.skipper.domain;
 public class UpgradeRequest {
 
 	private PackageIdentifier packageIdentifier;
-
 	private UpgradeProperties upgradeProperties;
+	private Long timeout;
 
 	public PackageIdentifier getPackageIdentifier() {
 		return packageIdentifier;
@@ -42,12 +42,17 @@ public class UpgradeRequest {
 		this.upgradeProperties = upgradeProperties;
 	}
 
+	public Long getTimeout() {
+		return timeout;
+	}
+
+	public void setTimeout(Long timeout) {
+		this.timeout = timeout;
+	}
+
 	@Override
 	public String toString() {
-		final StringBuffer sb = new StringBuffer("UpgradeRequest{");
-		sb.append("packageIdentifier=").append(packageIdentifier);
-		sb.append(", upgradeProperties=").append(upgradeProperties);
-		sb.append('}');
-		return sb.toString();
+		return "UpgradeRequest [packageIdentifier=" + packageIdentifier + ", upgradeProperties=" + upgradeProperties
+				+ ", timeout=" + timeout + "]";
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/DurationStyle.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/DurationStyle.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.support;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Copy from a Boot 2.x to support duration style formats
+ * while being on Boot 1.x.
+ *
+ * @author Phillip Webb
+ * @author Janne Valkealahti
+ *
+ */
+public enum DurationStyle {
+
+	/**
+	 * Simple formatting, for example '1s'.
+	 */
+	SIMPLE("^([\\+\\-]?\\d+)([a-zA-Z]{0,2})$") {
+
+		@Override
+		public Duration parse(String value, ChronoUnit unit) {
+			try {
+				Matcher matcher = matcher(value);
+				Assert.state(matcher.matches(), "Does not match simple duration pattern");
+				String suffix = matcher.group(2);
+				return (StringUtils.hasLength(suffix) ? Unit.fromSuffix(suffix)
+						: Unit.fromChronoUnit(unit)).parse(matcher.group(1));
+			}
+			catch (Exception ex) {
+				throw new IllegalArgumentException(
+						"'" + value + "' is not a valid simple duration", ex);
+			}
+		}
+
+		@Override
+		public String print(Duration value, ChronoUnit unit) {
+			return Unit.fromChronoUnit(unit).print(value);
+		}
+
+	},
+
+	/**
+	 * ISO-8601 formatting.
+	 */
+	ISO8601("^[\\+\\-]?P.*$") {
+
+		@Override
+		public Duration parse(String value, ChronoUnit unit) {
+			try {
+				return Duration.parse(value);
+			}
+			catch (Exception ex) {
+				throw new IllegalArgumentException(
+						"'" + value + "' is not a valid ISO-8601 duration", ex);
+			}
+		}
+
+		@Override
+		public String print(Duration value, ChronoUnit unit) {
+			return value.toString();
+		}
+
+	};
+
+	private final Pattern pattern;
+
+	DurationStyle(String pattern) {
+		this.pattern = Pattern.compile(pattern);
+	}
+
+	protected final boolean matches(String value) {
+		return this.pattern.matcher(value).matches();
+	}
+
+	protected final Matcher matcher(String value) {
+		return this.pattern.matcher(value);
+	}
+
+	/**
+	 * Parse the given value to a duration.
+	 * @param value the value to parse
+	 * @return a duration
+	 */
+	public Duration parse(String value) {
+		return parse(value, null);
+	}
+
+	/**
+	 * Parse the given value to a duration.
+	 * @param value the value to parse
+	 * @param unit the duration unit to use if the value doesn't specify one ({@code null}
+	 * will default to ms)
+	 * @return a duration
+	 */
+	public abstract Duration parse(String value, ChronoUnit unit);
+
+	/**
+	 * Print the specified duration.
+	 * @param value the value to print
+	 * @return the printed result
+	 */
+	public String print(Duration value) {
+		return print(value, null);
+	}
+
+	/**
+	 * Print the specified duration using the given unit.
+	 * @param value the value to print
+	 * @param unit the value to use for printing
+	 * @return the printed result
+	 */
+	public abstract String print(Duration value, ChronoUnit unit);
+
+	/**
+	 * Detect the style then parse the value to return a duration.
+	 * @param value the value to parse
+	 * @return the parsed duration
+	 * @throws IllegalStateException if the value is not a known style or cannot be parsed
+	 */
+	public static Duration detectAndParse(String value) {
+		return detectAndParse(value, null);
+	}
+
+	/**
+	 * Detect the style then parse the value to return a duration.
+	 * @param value the value to parse
+	 * @param unit the duration unit to use if the value doesn't specify one ({@code null}
+	 * will default to ms)
+	 * @return the parsed duration
+	 * @throws IllegalStateException if the value is not a known style or cannot be parsed
+	 */
+	public static Duration detectAndParse(String value, ChronoUnit unit) {
+		return detect(value).parse(value, unit);
+	}
+
+	/**
+	 * Detect the style from the given source value.
+	 * @param value the source value
+	 * @return the duration style
+	 * @throws IllegalStateException if the value is not a known style
+	 */
+	public static DurationStyle detect(String value) {
+		Assert.notNull(value, "Value must not be null");
+		for (DurationStyle candidate : values()) {
+			if (candidate.matches(value)) {
+				return candidate;
+			}
+		}
+		throw new IllegalArgumentException("'" + value + "' is not a valid duration");
+	}
+
+	/**
+	 * Units that we support.
+	 */
+	enum Unit {
+
+		/**
+		 * Nanoseconds.
+		 */
+		NANOS(ChronoUnit.NANOS, "ns", Duration::toNanos),
+
+		/**
+		 * Milliseconds.
+		 */
+		MILLIS(ChronoUnit.MILLIS, "ms", Duration::toMillis),
+
+		/**
+		 * Seconds.
+		 */
+		SECONDS(ChronoUnit.SECONDS, "s", Duration::getSeconds),
+
+		/**
+		 * Minutes.
+		 */
+		MINUTES(ChronoUnit.MINUTES, "m", Duration::toMinutes),
+
+		/**
+		 * Hours.
+		 */
+		HOURS(ChronoUnit.HOURS, "h", Duration::toHours),
+
+		/**
+		 * Days.
+		 */
+		DAYS(ChronoUnit.DAYS, "d", Duration::toDays);
+
+		private final ChronoUnit chronoUnit;
+
+		private final String suffix;
+
+		private Function<Duration, Long> longValue;
+
+		Unit(ChronoUnit chronoUnit, String suffix, Function<Duration, Long> toUnit) {
+			this.chronoUnit = chronoUnit;
+			this.suffix = suffix;
+			this.longValue = toUnit;
+		}
+
+		public Duration parse(String value) {
+			return Duration.of(Long.valueOf(value), this.chronoUnit);
+		}
+
+		public String print(Duration value) {
+			return longValue(value) + this.suffix;
+		}
+
+		public long longValue(Duration value) {
+			return this.longValue.apply(value);
+		}
+
+		public static Unit fromChronoUnit(ChronoUnit chronoUnit) {
+			if (chronoUnit == null) {
+				return Unit.MILLIS;
+			}
+			for (Unit candidate : values()) {
+				if (candidate.chronoUnit == chronoUnit) {
+					return candidate;
+				}
+			}
+			throw new IllegalArgumentException("Unknown unit " + chronoUnit);
+		}
+
+		public static Unit fromSuffix(String suffix) {
+			for (Unit candidate : values()) {
+				if (candidate.suffix.equalsIgnoreCase(suffix)) {
+					return candidate;
+				}
+			}
+			throw new IllegalArgumentException("Unknown unit '" + suffix + "'");
+		}
+
+	}
+
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/DurationUtils.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/support/DurationUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.support;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * {@code DurationUtils} together with {@link DurationStyle} is to support Boot
+ * 2.x style expressions while we're still staying on Boot 1.x. This is meant to
+ * provide smooth upgrade path by not breaking expression formats exposed to
+ * user.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public final class DurationUtils {
+
+	/**
+	 * Converts a duration expression into {@link Duration}.
+	 *
+	 * @param expression the duration expression
+	 * @return the parsed duration
+	 */
+	public static Duration convert(String expression) {
+		return convert(expression, null);
+	}
+
+	/**
+	 * Converts a duration expression into {@link Duration} with a given
+	 * {@link ChronoUnit}.
+	 *
+	 * @param expression the duration expression
+	 * @param unit the chrono unit
+	 * @return the parsed duration
+	 */
+	public static Duration convert(String expression, ChronoUnit unit) {
+		if (!StringUtils.hasText(expression)) {
+			return null;
+		}
+		return DurationStyle.detect(expression).parse(expression, unit);
+	}
+}

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/support/DurationUtilsTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/support/DurationUtilsTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.support;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DurationUtilsTests {
+
+	@Test
+	public void convertWhenIso8601ShouldReturnDuration() {
+		assertThat(convert("PT20.345S")).isEqualTo(Duration.parse("PT20.345S"));
+		assertThat(convert("PT15M")).isEqualTo(Duration.parse("PT15M"));
+		assertThat(convert("+PT15M")).isEqualTo(Duration.parse("PT15M"));
+		assertThat(convert("PT10H")).isEqualTo(Duration.parse("PT10H"));
+		assertThat(convert("P2D")).isEqualTo(Duration.parse("P2D"));
+		assertThat(convert("P2DT3H4M")).isEqualTo(Duration.parse("P2DT3H4M"));
+		assertThat(convert("-PT6H3M")).isEqualTo(Duration.parse("-PT6H3M"));
+		assertThat(convert("-PT-6H+3M")).isEqualTo(Duration.parse("-PT-6H+3M"));
+	}
+
+	@Test
+	public void convertWhenSimpleNanosShouldReturnDuration() {
+		assertThat(convert("10ns")).isEqualTo(Duration.ofNanos(10));
+		assertThat(convert("10NS")).isEqualTo(Duration.ofNanos(10));
+		assertThat(convert("+10ns")).isEqualTo(Duration.ofNanos(10));
+		assertThat(convert("-10ns")).isEqualTo(Duration.ofNanos(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleMillisShouldReturnDuration() {
+		assertThat(convert("10ms")).isEqualTo(Duration.ofMillis(10));
+		assertThat(convert("10MS")).isEqualTo(Duration.ofMillis(10));
+		assertThat(convert("+10ms")).isEqualTo(Duration.ofMillis(10));
+		assertThat(convert("-10ms")).isEqualTo(Duration.ofMillis(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleSecondsShouldReturnDuration() {
+		assertThat(convert("10s")).isEqualTo(Duration.ofSeconds(10));
+		assertThat(convert("10S")).isEqualTo(Duration.ofSeconds(10));
+		assertThat(convert("+10s")).isEqualTo(Duration.ofSeconds(10));
+		assertThat(convert("-10s")).isEqualTo(Duration.ofSeconds(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleMinutesShouldReturnDuration() {
+		assertThat(convert("10m")).isEqualTo(Duration.ofMinutes(10));
+		assertThat(convert("10M")).isEqualTo(Duration.ofMinutes(10));
+		assertThat(convert("+10m")).isEqualTo(Duration.ofMinutes(10));
+		assertThat(convert("-10m")).isEqualTo(Duration.ofMinutes(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleHoursShouldReturnDuration() {
+		assertThat(convert("10h")).isEqualTo(Duration.ofHours(10));
+		assertThat(convert("10H")).isEqualTo(Duration.ofHours(10));
+		assertThat(convert("+10h")).isEqualTo(Duration.ofHours(10));
+		assertThat(convert("-10h")).isEqualTo(Duration.ofHours(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleDaysShouldReturnDuration() {
+		assertThat(convert("10d")).isEqualTo(Duration.ofDays(10));
+		assertThat(convert("10D")).isEqualTo(Duration.ofDays(10));
+		assertThat(convert("+10d")).isEqualTo(Duration.ofDays(10));
+		assertThat(convert("-10d")).isEqualTo(Duration.ofDays(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleWithoutSuffixShouldReturnDuration() {
+		assertThat(convert("10")).isEqualTo(Duration.ofMillis(10));
+		assertThat(convert("+10")).isEqualTo(Duration.ofMillis(10));
+		assertThat(convert("-10")).isEqualTo(Duration.ofMillis(-10));
+	}
+
+	@Test
+	public void convertWhenSimpleWithoutSuffixButWithAnnotationShouldReturnDuration() {
+		assertThat(convert("10", ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(10));
+		assertThat(convert("+10", ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(10));
+		assertThat(convert("-10", ChronoUnit.SECONDS)).isEqualTo(Duration.ofSeconds(-10));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void convertWhenBadFormatShouldThrowException() {
+		convert("10foo");
+	}
+
+	@Test
+	public void convertWhenEmptyShouldReturnNull() {
+		assertThat(convert("")).isNull();
+	}
+
+	private static Duration convert(String expression) {
+		return convert(expression, null);
+	}
+
+	private static Duration convert(String expression, ChronoUnit unit) {
+		return DurationUtils.convert(expression, unit);
+	}
+}


### PR DESCRIPTION
- This commit focus to add better functionality to
  handle timeouts during upgrade and rollback.
- We start by adding `timeout-expression` option to both
  `release upgrade` and `release rollback`. This expression
  is backed by a feature copy of `DurationUtils` and `DurationStyle`
  from boot2, which gives nice upgrade path if that time comes.
  Behind a scenes these expressions are translated to millis.
- New duration expression takes all sort of strings like, `60s`,
  `PT1H`, etc.
- As we need to pass timout with rollback, introduce `RollbackRequest`
  and deprecate previous endpoint which only took `releaseName`
  and `version`.
- `ReleaseController` now uses `/rollback` to get `RollbackRequest`,
   while `/rollback/{name}/{version}` is the old deprecated endpoint.
- Add some new tests to statemachine. Core timeout functionality
  were actually already in place, just not exposed to user.
- Modify `UpgradeStrategy.cancel` to pass timeout value so that
  we can report it back to status as timeout can come from user request.
- Fix bug where timeout from `HealthCheckProperties` were not
  actually used as a global setting. We previously had hard coded
  value in a statemachine. Now order is, shell/rest timeout value ->
  HealthCheckProperties -> default value in statemachine.
- Add new rest docs for new api and add note for deprecation.
- Some status fields don't exactly represent correct operation now,
  something we need to fix in other commits. We used to manually change
  status from rollback to indicate rollback even if we're dispatching to
  install or upgrade. This is a bit broader topic we need to address as
  we can't just manually change things outside of the flow.
- Fixes #587
- Fixes #598
- Fixes #601