### PR TITLE
Make upgrade cancellable

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -26,8 +26,9 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.AboutResource;
+import org.springframework.cloud.skipper.domain.CancelRequest;
+import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -47,7 +48,6 @@ import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.client.Traverson;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
@@ -237,21 +237,12 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public void cancel(String releaseName) {
-		ParameterizedTypeReference<Void> typeReference = new ParameterizedTypeReference<Void>() {};
-		Map<String, String> uriVariables = new HashMap<String, String>();
-		uriVariables.put("releaseName", releaseName);
-		ResponseEntity<Void> responseEntity =
-				restTemplate.exchange(baseUri + "/release/cancel/{releaseName}",
-						HttpMethod.POST,
-						null,
-						typeReference,
-						uriVariables);
-		if (responseEntity.getStatusCode() != HttpStatus.ACCEPTED) {
-			throw new SkipperException("Cancel request for release " + releaseName + " not accepted");
-		}
-	}
-
+	public CancelResponse cancel(CancelRequest cancelRequest) {
+		String url = String.format("%s/%s/%s", baseUri, "release", "cancel");
+		log.debug("Posting CancelRequest to " + url + ". CancelRequest = " + cancelRequest);
+		return this.restTemplate.postForObject(url, cancelRequest, CancelResponse.class);
+	}	
+	
 	@Override
 	public Release rollback(RollbackRequest rollbackRequest) {
 		ParameterizedTypeReference<Resource<Release>> typeReference =

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
@@ -47,6 +47,7 @@ import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.client.Traverson;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
@@ -233,6 +234,22 @@ public class DefaultSkipperClient implements SkipperClient {
 			url = String.format("%s/%s/%s", baseUri, "release", releaseName);
 		}
 		this.restTemplate.delete(url, deletePackage);
+	}
+
+	@Override
+	public void cancel(String releaseName) {
+		ParameterizedTypeReference<Void> typeReference = new ParameterizedTypeReference<Void>() {};
+		Map<String, String> uriVariables = new HashMap<String, String>();
+		uriVariables.put("releaseName", releaseName);
+		ResponseEntity<Void> responseEntity =
+				restTemplate.exchange(baseUri + "/release/cancel/{releaseName}",
+						HttpMethod.POST,
+						null,
+						typeReference,
+						uriVariables);
+		if (responseEntity.getStatusCode() != HttpStatus.ACCEPTED) {
+			throw new SkipperException("Cancel request for release " + releaseName + " not accepted");
+		}
 	}
 
 	@Override

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -17,8 +17,9 @@ package org.springframework.cloud.skipper.client;
 
 import java.util.List;
 
-import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.AboutResource;
+import org.springframework.cloud.skipper.domain.CancelRequest;
+import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
@@ -119,12 +120,12 @@ public interface SkipperClient {
 	Release rollback(String releaseName, int releaseVersion);
 
 	/**
-	 * Sends a cancel request for current release operation. Throws
-	 * {@link SkipperException}} if cancel operation cannot be requested.
+	 * Sends a cancel request for current release operation
 	 * 
-	 * @param releaseName the release name
+	 * @param cancelRequest the cancel request
+	 * @return the cancel response
 	 */
-	void cancel(String releaseName);
+	CancelResponse cancel(CancelRequest cancelRequest);
 
 	/**
 	 * List the latest version of releases with status of deployed or failed.

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.skipper.client;
 
 import java.util.List;
 
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
@@ -116,6 +117,14 @@ public interface SkipperClient {
 	 */
 	@Deprecated
 	Release rollback(String releaseName, int releaseVersion);
+
+	/**
+	 * Sends a cancel request for current release operation. Throws
+	 * {@link SkipperException}} if cancel operation cannot be requested.
+	 * 
+	 * @param releaseName the release name
+	 */
+	void cancel(String releaseName);
 
 	/**
 	 * List the latest version of releases with status of deployed or failed.

--- a/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
@@ -666,3 +666,24 @@ include::{snippets}/delete-documentation/delete-release/http-response.adoc[]
 ====== Response fields
 
 include::{snippets}/delete-documentation/delete-release/response-fields.adoc[]
+
+[[resources-release-cancel]]
+==== Cancel
+
+===== Cancel a release
+
+You can use a `POST` request to cancel an existing release operation.
+
+====== Request structure
+
+include::{snippets}/cancel-documentation/cancel-release/http-request.adoc[]
+
+====== Example request
+
+include::{snippets}/cancel-documentation/cancel-release/curl-request.adoc[]
+
+====== Response structure
+
+include::{snippets}/cancel-documentation/cancel-release/http-response.adoc[]
+
+

--- a/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/api-guide.adoc
@@ -686,4 +686,7 @@ include::{snippets}/cancel-documentation/cancel-release/curl-request.adoc[]
 
 include::{snippets}/cancel-documentation/cancel-release/http-response.adoc[]
 
+====== Response fields
+
+include::{snippets}/cancel-documentation/cancel-release/response-fields.adoc[]
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -37,6 +37,7 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -167,6 +168,18 @@ public class ReleaseController {
 		deleteProperties.setDeletePackage(canDeletePackage);
 		Release release = this.skipperStateMachineService.deleteRelease(releaseName, deleteProperties);
 		return this.releaseResourceAssembler.toResource(release);
+	}
+
+	@RequestMapping(path = "/cancel/{name}", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<Void> cancel(@PathVariable("name") String releaseName) {
+		boolean accept = this.skipperStateMachineService.cancelRelease(releaseName);
+		if (accept) {
+			return new ResponseEntity<>(HttpStatus.ACCEPTED);
+		}
+		else {
+			return new ResponseEntity<>(HttpStatus.OK);
+		}
 	}
 
 	@RequestMapping(path = "/list", method = RequestMethod.GET)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.CancelRequest;
+import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.Manifest;
@@ -37,7 +39,6 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -170,18 +171,13 @@ public class ReleaseController {
 		return this.releaseResourceAssembler.toResource(release);
 	}
 
-	@RequestMapping(path = "/cancel/{name}", method = RequestMethod.POST)
+	@RequestMapping(path = "/cancel", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<Void> cancel(@PathVariable("name") String releaseName) {
-		boolean accept = this.skipperStateMachineService.cancelRelease(releaseName);
-		if (accept) {
-			return new ResponseEntity<>(HttpStatus.ACCEPTED);
-		}
-		else {
-			return new ResponseEntity<>(HttpStatus.OK);
-		}
+	public CancelResponse cancel(@RequestBody CancelRequest cancelRequest) {
+		boolean accepted = this.skipperStateMachineService.cancelRelease(cancelRequest.getReleaseName());
+		return new CancelResponse(accepted);
 	}
-
+	
 	@RequestMapping(path = "/list", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public Resources<Resource<Release>> list() {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractMockMvcTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractMockMvcTests.java
@@ -36,6 +36,7 @@ import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfigurat
 import org.springframework.boot.autoconfigure.web.ErrorMvcAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
@@ -122,6 +123,18 @@ public abstract class AbstractMockMvcTests extends AbstractAssertReleaseDeployed
 		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		try {
 			return objectMapper.readValue(json, new TypeReference<Release>() {
+			});
+		}
+		catch (IOException e) {
+			throw new IllegalArgumentException("Can't parse JSON for Release", e);
+		}
+	}
+
+	protected CancelResponse convertContentToCancelResponse(String json) {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		try {
+			return objectMapper.readValue(json, new TypeReference<CancelResponse>() {
 			});
 		}
 		catch (IOException e) {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/AbstractControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/AbstractControllerTests.java
@@ -21,6 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.skipper.domain.CancelRequest;
+import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
@@ -159,9 +161,11 @@ public abstract class AbstractControllerTests extends AbstractMockMvcTests {
 		return updatedRelease;
 	}
 
-	protected void cancel(String releaseName, int expectStatus) throws Exception {
-		mockMvc.perform(post("/api/release/cancel/" + releaseName)).andDo(print())
+	protected void cancel(String releaseName, int expectStatus, boolean accepted) throws Exception {
+		MvcResult result = mockMvc.perform(post("/api/release/cancel").content(convertObjectToJson(new CancelRequest(releaseName)))).andDo(print())
 				.andExpect(status().is(expectStatus)).andReturn();
+		CancelResponse response = convertContentToCancelResponse(result.getResponse().getContentAsString());
+		assertThat(response.getAccepted()).isEqualTo(accepted);
 	}
 
 	protected void commonReleaseAssertions(String releaseName, PackageMetadata packageMetadata,

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -188,7 +188,7 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 
 	@Test
 	public void cancelNonExistingRelease() throws Exception {
-		cancel("myLog2", HttpStatus.OK.value());
+		cancel("myLog2", HttpStatus.OK.value(), false);
 	}
 
 	@Test
@@ -202,9 +202,8 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 		assertThat(release.getVersion()).isEqualTo(2);
 
 		// Cancel
-		cancel(releaseName, HttpStatus.ACCEPTED.value());
+		cancel(releaseName, HttpStatus.OK.value(), true);
 	}
-
 
 	@Test
 	public void testStatusReportsErrorForMissingRelease() throws Exception {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Repository;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.repository.RepositoryRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -184,6 +185,26 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 
 		assertThat(release.getVersion()).isEqualTo(2);
 	}
+
+	@Test
+	public void cancelNonExistingRelease() throws Exception {
+		cancel("myLog2", HttpStatus.OK.value());
+	}
+
+	@Test
+	public void packageDeployAndUpgradeAndCancel() throws Exception {
+		String releaseName = "myTestapp";
+		Release release = install("testapp", "1.0.0", releaseName);
+		assertThat(release.getVersion()).isEqualTo(1);
+
+		// Upgrade
+		release = upgrade("testapp", "1.1.0", releaseName, false);
+		assertThat(release.getVersion()).isEqualTo(2);
+
+		// Cancel
+		cancel(releaseName, HttpStatus.ACCEPTED.value());
+	}
+
 
 	@Test
 	public void testStatusReportsErrorForMissingRelease() throws Exception {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/CancelDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/CancelDocumentation.java
@@ -17,10 +17,16 @@
 package org.springframework.cloud.skipper.server.controller.docs;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.nio.charset.Charset;
+
 import org.junit.Test;
+import org.springframework.cloud.skipper.domain.CancelRequest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
@@ -35,10 +41,16 @@ public class CancelDocumentation extends BaseDocumentation {
 		install("testapp", "1.0.0", releaseName);
 		upgrade("testapp", "1.1.0", releaseName, false);
 
+		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
+				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+		
 		this.mockMvc.perform(
-				post("/api/release/cancel/{releaseName}", releaseName)).andDo(print())
-				.andExpect(status().isAccepted())
+				post("/api/release/cancel").accept(MediaType.APPLICATION_JSON).contentType(contentType)
+				.content(convertObjectToJson(new CancelRequest(releaseName))))
+				.andDo(print())
+				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
+						responseFields(fieldWithPath("accepted").description("If cancel request was accepted"))
 						))
 				.andReturn();
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/CancelDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/CancelDocumentation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.server.controller.docs;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * @author Janne Valkealahti
+ */
+@ActiveProfiles("repo-test")
+public class CancelDocumentation extends BaseDocumentation {
+
+	@Test
+	public void cancelRelease() throws Exception {
+		final String releaseName = "myLogRelease";
+		install("testapp", "1.0.0", releaseName);
+		upgrade("testapp", "1.1.0", releaseName, false);
+
+		this.mockMvc.perform(
+				post("/api/release/cancel/{releaseName}", releaseName)).andDo(print())
+				.andExpect(status().isAccepted())
+				.andDo(this.documentationHandler.document(
+						))
+				.andReturn();
+	}
+}

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
@@ -30,7 +30,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.client.SkipperClient;
+import org.springframework.cloud.skipper.domain.CancelRequest;
+import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
@@ -218,8 +221,11 @@ public class ReleaseCommands extends AbstractSkipperCommand {
 	@ShellMethod(key = "release cancel", value = "Request a cancellation of current release operation.")
 	public String cancel(
 			@ShellOption(help = "the name of the release to cancel") String releaseName) {
-		this.skipperClient.cancel(releaseName);
-		return "Cancel request for release " + releaseName + " sent";
+		CancelResponse cancelResponse = this.skipperClient.cancel(new CancelRequest(releaseName));
+		if (cancelResponse != null && cancelResponse.getAccepted() != null && cancelResponse.getAccepted()) {
+			return "Cancel request for release " + releaseName + " sent";			
+		}
+		throw new SkipperException("Cancel request for release " + releaseName + " not accepted");
 	}
 
 	@ShellMethod(key = "release list", value = "List the latest version of releases with status of deployed or failed.")

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
@@ -215,6 +215,13 @@ public class ReleaseCommands extends AbstractSkipperCommand {
 		return sb.toString();
 	}
 
+	@ShellMethod(key = "release cancel", value = "Request a cancellation of current release operation.")
+	public String cancel(
+			@ShellOption(help = "the name of the release to cancel") String releaseName) {
+		this.skipperClient.cancel(releaseName);
+		return "Cancel request for release " + releaseName + " sent";
+	}
+
 	@ShellMethod(key = "release list", value = "List the latest version of releases with status of deployed or failed.")
 	public Table list(
 			@ShellOption(help = "wildcard expression to search by release name", defaultValue = NULL) String releaseName) {

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/CancelRequest.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/CancelRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+/**
+ * This contains all the request attributes for cancel operation.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class CancelRequest {
+
+	private String releaseName;
+
+	public CancelRequest() {
+	}
+	
+	public CancelRequest(String releaseName) {
+		this.releaseName = releaseName;
+	}
+
+	public String getReleaseName() {
+		return releaseName;
+	}
+
+	public void setReleaseName(String releaseName) {
+		this.releaseName = releaseName;
+	}
+	
+	@Override
+	public String toString() {
+		return "CancelRequest [releaseName=" + releaseName + "]";
+	}	
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/CancelResponse.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/CancelResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+/**
+ * This contains all the response attributes for cancel operation.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class CancelResponse {
+	
+	private Boolean accepted;
+
+	public CancelResponse() {
+	}
+
+	public CancelResponse(Boolean accepted) {
+		this.accepted = accepted;
+	}
+
+	public Boolean getAccepted() {
+		return accepted;
+	}
+
+	public void setAccepted(Boolean accepted) {
+		this.accepted = accepted;
+	}
+		
+	@Override
+	public String toString() {
+		return "CancelResponse [accepted=" + accepted + "]";
+	}	
+}


### PR DESCRIPTION
- Cancel funtionality is already in place in statemachine,
  this commit is focusing to expose that functionality
  to a user.
- Cancellation attempt is always done per release. We know
  if cancellation can be attempted, but the actual cancel
  operation is not quaranteed.
- Add cancel api's to ReleaseController and SkipperClient.
- For now we simply use HttpStatus.ACCEPTED to indicate cancel
  were accepted, and HttpStatus.OK indicating cancel attempt
  were not accepted.
- SkipperClient will differentiate from accepted, not accepted by
  throwing SkipperException if cancel were not accepted. We simply
  come up with a message in a shell or let it print out exception.
- Add some new tests and restdocs.
- Fixes #586 

Generic command flow is:
```
skipper:>package install --package-name testapp --package-version 1.0.0 --release-name mytestapp
Released mytestapp. Now at version v1.

skipper:>release status --release-name mytestapp
╔═══════════════╤═════════════════════════════════════════════════════════════════╗
║Last Deployed  │Tue May 08 19:57:54 BST 2018                                     ║
║Status         │DEPLOYED                                                         ║
║Platform Status│All applications have been successfully deployed.                ║
║               │[mytestapp.testapp-v1], State = [mytestapp.testapp-v1-0=deployed]║
╚═══════════════╧═════════════════════════════════════════════════════════════════╝

skipper:>release history --release-name mytestapp
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
║1      │Tue May 08 19:57:54 BST 2018│DEPLOYED│testapp     │1.0.0          │Install complete║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════╝

skipper:>release upgrade --package-name testapp --package-version 1.1.0 --release-name mytestapp
mytestapp has been upgraded.  Now at version v2.

skipper:>release history --release-name mytestapp
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│      Description       ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════════════╣
║2      │Tue May 08 19:58:17 BST 2018│UNKNOWN │testapp     │1.1.0          │Upgrade install underway║
║1      │Tue May 08 19:57:54 BST 2018│DEPLOYED│testapp     │1.0.0          │Install complete        ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════════════╝

skipper:>release status --release-name mytestapp
╔═══════════════╤═══════════════════════════════════════════════════════════════╗
║Last Deployed  │Tue May 08 19:58:17 BST 2018                                   ║
║Status         │UNKNOWN                                                        ║
║Platform Status│All apps have failed deployment.                               ║
║               │[mytestapp.testapp-v2], State = [mytestapp.testapp-v2-0=failed]║
╚═══════════════╧═══════════════════════════════════════════════════════════════╝

skipper:>release cancel --release-name mytestapp
Cancel request for release mytestapp sent

skipper:>release history --release-name mytestapp
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════════════════════════════════════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│                            Description                             ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════════════════════════════════════════════════════════╣
║2      │Tue May 08 19:58:17 BST 2018│FAILED  │testapp     │1.1.0          │Did not detect apps in replacing release as healthy after 300000 ms.║
║1      │Tue May 08 19:57:54 BST 2018│DEPLOYED│testapp     │1.0.0          │Install complete                                                    ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════════════════════════════════════════════════════════╝

skipper:>release cancel --release-name mytestapp
Cancel request for release mytestapp not accepted
Details of the error have been omitted. You can use the stacktrace command to print the full stacktrace.

skipper:>release delete --release-name mytestapp
mytestapp has been deleted.
```
