### PR TITLE
Fix CF app name prefix setting

### DIFF
--- a/spring-cloud-skipper-platform-cloudfoundry/src/test/java/org/springframework/cloud/skipper/deployer/CloudFoundryPlatformPropertiesTest.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/test/java/org/springframework/cloud/skipper/deployer/CloudFoundryPlatformPropertiesTest.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Donovan Muller
+ * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = CloudFoundryPlatformPropertiesTest.TestConfig.class)
@@ -52,11 +53,14 @@ public class CloudFoundryPlatformPropertiesTest {
 		assertThat(cfAccounts.get("dev").getDeployment().getMemory()).isEqualTo("512m");
 		assertThat(cfAccounts.get("dev").getDeployment().getDisk()).isEqualTo("2048m");
 		assertThat(cfAccounts.get("dev").getDeployment().getInstances()).isEqualTo(4);
+		assertThat(cfAccounts.get("dev").getDeployment().getAppNamePrefix().equals("dev1"));
 		assertThat(cfAccounts.get("dev").getDeployment().getServices())
 				.containsExactly("rabbit", "mysql");
+
 		assertThat(cfAccounts.get("qa").getDeployment().getMemory()).isEqualTo("756m");
 		assertThat(cfAccounts.get("qa").getDeployment().getDisk()).isEqualTo("724m");
 		assertThat(cfAccounts.get("qa").getDeployment().getInstances()).isEqualTo(2);
+		assertThat(cfAccounts.get("qa").getDeployment().getAppNamePrefix().equals("qa1"));
 		assertThat(cfAccounts.get("qa").getDeployment().getServices())
 				.containsExactly("rabbitQA", "mysqlQA");
 	}

--- a/spring-cloud-skipper-platform-cloudfoundry/src/test/resources/application-platform-properties.yml
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/test/resources/application-platform-properties.yml
@@ -23,6 +23,7 @@ spring:
                   disk: 2048m
                   instances: 4
                   services: rabbit,mysql
+                  appNamePrefix: dev1
               qa:
                 connection:
                   url: https://api.run.pivotal.io
@@ -37,3 +38,4 @@ spring:
                   disk: 724m
                   instances: 2
                   services: rabbitQA,mysqlQA
+                  appNamePrefix: qa1

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/AppDeployerReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/AppDeployerReleaseManager.java
@@ -237,7 +237,8 @@ public class AppDeployerReleaseManager implements ReleaseManager {
 			for (String deploymentId : deploymentIds) {
 				AppStatus appStatus = appDeployer.status(deploymentId);
 
-				if (appStatus.getState().equals(DeploymentState.failed)) {
+				if (appStatus.getState().equals(DeploymentState.failed) ||
+						appStatus.getState().equals(DeploymentState.error)) {
 					// check if we have 'early' status computed via multiStateAppDeployer
 					if (deploymentStateMap.containsKey(deploymentId)) {
 						appStatus = AppStatus.of(deploymentId).generalState(deploymentStateMap.get(deploymentId))


### PR DESCRIPTION
 - Initialize the `appNamePrefix` configuration in CFAppNameGenerator
 - Update test

Fix status calcuation when MultistateDeployer has state

 - If the app status has `error`, still check if MultiStateDeployer has valid status and consider it

Resolves #619
Resolves #620