### PR TITLE
Fix release description messages

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/SimpleRedBlackUpgradeStrategy.java
@@ -53,16 +53,16 @@ public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 
 	@Override
 	public void accept(Release existingRelease, Release replacingRelease,
-			ReleaseAnalysisReport releaseAnalysisReport) {
+			ReleaseAnalysisReport releaseAnalysisReport, boolean rollback) {
 		this.handleHealthCheckStep.handleHealthCheck(true, existingRelease,
-				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease, null);
+				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease, null, false, rollback);
 	}
 
 	@Override
 	public void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport,
-			Long timeout) {
+			Long timeout, boolean cancel, boolean rollback) {
 		this.handleHealthCheckStep.handleHealthCheck(false, existingRelease,
-				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease, timeout);
+				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease, timeout, cancel, rollback);
 	}
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
@@ -30,8 +30,10 @@ public interface UpgradeStrategy {
 
 	boolean checkStatus(Release replacingRelease);
 
-	void accept(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
+	void accept(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport,
+			boolean rollback);
 
-	void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport, Long timeout);
+	void cancel(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport,
+			Long timeout, boolean cancel, boolean rollback);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/AbstractUpgradeStartAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/AbstractUpgradeStartAction.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.statemachine;
 
+import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.service.ReleaseReportService;
@@ -51,9 +52,11 @@ public abstract class AbstractUpgradeStartAction extends AbstractAction {
 	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
 		UpgradeRequest upgradeRequest = context.getExtendedState().get(SkipperEventHeaders.UPGRADE_REQUEST,
 				UpgradeRequest.class);
+		RollbackRequest rollbackRequest = context.getExtendedState().get(SkipperEventHeaders.ROLLBACK_REQUEST,
+				RollbackRequest.class);
 		Assert.notNull(upgradeRequest, "'upgradeRequest' not known to the system in extended state");
 		ReleaseAnalysisReport releaseAnalysisReport = this.getReleaseReportService().createReport(upgradeRequest,
-				handlesInitialReport());
+				rollbackRequest, handlesInitialReport());
 		context.getExtendedState().getVariables().put(SkipperVariables.RELEASE_ANALYSIS_REPORT, releaseAnalysisReport);
 	}
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeleteSourceAppsAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeDeleteSourceAppsAction.java
@@ -15,9 +15,11 @@
  */
 package org.springframework.cloud.skipper.server.statemachine;
 
+import org.springframework.cloud.skipper.domain.RollbackRequest;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
 import org.springframework.cloud.skipper.server.service.ReleaseReportService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
 import org.springframework.statemachine.StateContext;
@@ -48,7 +50,11 @@ public class UpgradeDeleteSourceAppsAction extends AbstractUpgradeStartAction {
 	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
 		super.executeInternal(context);
 		ReleaseAnalysisReport releaseAnalysisReport = getReleaseAnalysisReport(context);
+		
+		// check if we're doing rollback and pass flag to strategy
+		RollbackRequest rollbackRequest = context.getExtendedState().get(SkipperEventHeaders.ROLLBACK_REQUEST,
+				RollbackRequest.class);
 		upgradeStrategy.accept(releaseAnalysisReport.getExistingRelease(), releaseAnalysisReport.getReplacingRelease(),
-				releaseAnalysisReport);
+				releaseAnalysisReport, rollbackRequest != null);
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
@@ -212,7 +212,7 @@ public class StateMachineTests {
 
 	@Test
 	public void testRestoreFromUpgradeUsingUpgradeRequest() throws Exception {
-		Mockito.when(releaseReportService.createReport(any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
 				new ReleaseDifference(), new Release(), new Release()));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(true);
@@ -274,7 +274,7 @@ public class StateMachineTests {
 
 	@Test
 	public void testSimpleUpgradeShouldNotError() throws Exception {
-		Mockito.when(releaseReportService.createReport(any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
 				new ReleaseDifference(), new Release(), new Release()));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(true);
@@ -310,7 +310,7 @@ public class StateMachineTests {
 
 	@Test
 	public void testUpgradeFailsNewAppFailToDeploy() throws Exception {
-		Mockito.when(releaseReportService.createReport(any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
 				new ReleaseDifference(), new Release(), new Release()));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);
@@ -358,7 +358,7 @@ public class StateMachineTests {
 
 	@Test
 	public void testUpgradeCancelWhileCheckingApps() throws Exception {
-		Mockito.when(releaseReportService.createReport(any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
 				new ReleaseDifference(), new Release(), new Release()));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);
@@ -552,7 +552,7 @@ public class StateMachineTests {
 
 	@Test
 	public void testInstallDeniedWhileUpgrading() throws Exception {
-		Mockito.when(releaseReportService.createReport(any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
 				new ReleaseDifference(), new Release(), new Release()));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);


### PR DESCRIPTION
- Previous refactoring work for timeouts and cancellation
  broke some of the functionality for meaninful descriptions.
  We missed missed a message that we're doing a rollback, timouts
  were wrong if we cancelled a release operation, etc. Also originally
  when rollback were finished, description said `Upgrade complete`.
- Until we get to do better refactoring in a whole flow, for now
  just pass on more information to strategy and healthcheck classes
  so that we can accurately update descriptions.
- Fixes #609 

Here's a command flow showing relevant changes for cancel/timeout, upgrade .vs rollback:

# Better messages for cancel

```
skipper:>package install --package-name testapp --package-version 1.0.0 --release-name mytestapp
Released mytestapp. Now at version v1.

skipper:>release upgrade --package-name testapp --package-version 1.1.0 --release-name mytestapp
mytestapp has been upgraded.  Now at version v2.

skipper:>release history --release-name mytestapp
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│      Description       ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════════════╣
║2      │Wed May 16 08:22:47 BST 2018│UNKNOWN │testapp     │1.1.0          │Upgrade install underway║
║1      │Wed May 16 08:22:08 BST 2018│DEPLOYED│testapp     │1.0.0          │Install complete        ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════════════╝

skipper:>release cancel --release-name mytestapp
Cancel request for release mytestapp sent

# We get better message that user cancelled and after what time

skipper:>release history --release-name mytestapp
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤═════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│       Description       ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪═════════════════════════╣
║2      │Wed May 16 08:22:47 BST 2018│FAILED  │testapp     │1.1.0          │Cancelled after 19524 ms.║ << we now see if user cancelled
║1      │Wed May 16 08:22:08 BST 2018│DEPLOYED│testapp     │1.0.0          │Install complete         ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧═════════════════════════╝

skipper:>release upgrade --package-name testapp --package-version 1.1.0 --release-name mytestapp --timeout-expression 15s
mytestapp has been upgraded.  Now at version v3.

skipper:>release history --release-name mytestapp
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤═════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│       Description       ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪═════════════════════════╣
║3      │Wed May 16 08:24:03 BST 2018│UNKNOWN │testapp     │1.1.0          │Upgrade install underway ║
║2      │Wed May 16 08:22:47 BST 2018│FAILED  │testapp     │1.1.0          │Cancelled after 19524 ms.║ << just said Did not detect apps in...
║1      │Wed May 16 08:22:08 BST 2018│DEPLOYED│testapp     │1.0.0          │Install complete         ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧═════════════════════════╝

# No cancel, let it timeout and we get normal message

skipper:>release history --release-name mytestapp
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤═══════════════════════════════════════════════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│                            Description                            ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪═══════════════════════════════════════════════════════════════════╣
║3      │Wed May 16 08:24:03 BST 2018│FAILED  │testapp     │1.1.0          │Did not detect apps in replacing release as healthy after 15000 ms.║
║2      │Wed May 16 08:22:47 BST 2018│FAILED  │testapp     │1.1.0          │Cancelled after 19524 ms.                                          ║
║1      │Wed May 16 08:22:08 BST 2018│DEPLOYED│testapp     │1.0.0          │Install complete                                                   ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧═══════════════════════════════════════════════════════════════════╝
```


# Better messages for upgrade vs. rollback


```
skipper:>package install --package-name log --package-version 1.0.0 --release-name mylog
Released mylog. Now at version v1.

skipper:>release history --release-name mylog
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
║1      │Wed May 16 08:42:25 BST 2018│DEPLOYED│log         │1.0.0          │Install complete║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════╝

skipper:>release upgrade --package-name log --package-version 1.1.0 --release-name mylog
mylog has been upgraded.  Now at version v2.

skipper:>release history --release-name mylog
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│      Description       ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════════════╣
║2      │Wed May 16 08:42:34 BST 2018│UNKNOWN │log         │1.1.0          │Upgrade install underway║
║1      │Wed May 16 08:42:25 BST 2018│DEPLOYED│log         │1.0.0          │Install complete        ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════════════╝

skipper:>release history --release-name mylog
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
║2      │Wed May 16 08:42:34 BST 2018│DEPLOYED│log         │1.1.0          │Upgrade complete║
║1      │Wed May 16 08:42:25 BST 2018│DELETED │log         │1.0.0          │Delete complete ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════╝

skipper:>release rollback --release-name mylog
mylog has been rolled back.  Now at version v3.

skipper:>release history --release-name mylog
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤═════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│       Description       ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪═════════════════════════╣
║3      │Wed May 16 08:42:52 BST 2018│UNKNOWN │log         │1.0.0          │Rollback install underway║ << used to say Upgrade install underway
║2      │Wed May 16 08:42:34 BST 2018│DEPLOYED│log         │1.1.0          │Upgrade complete         ║
║1      │Wed May 16 08:42:25 BST 2018│DELETED │log         │1.0.0          │Delete complete          ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧═════════════════════════╝

skipper:>release history --release-name mylog
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤═════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│   Description   ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪═════════════════╣
║3      │Wed May 16 08:42:52 BST 2018│DEPLOYED│log         │1.0.0          │Rollback complete║ << used to say Upgrade complete
║2      │Wed May 16 08:42:34 BST 2018│DELETED │log         │1.1.0          │Delete complete  ║
║1      │Wed May 16 08:42:25 BST 2018│DELETED │log         │1.0.0          │Delete complete  ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧═════════════════╝
```
