### PR TITLE
Remove use of printStackTrace()

### DIFF
--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/DifferenceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/DifferenceTests.java
@@ -20,7 +20,7 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import org.junit.Test;
-
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifest;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.cloud.skipper.domain.deployer.ApplicationManifestDifference;
@@ -132,7 +132,7 @@ public class DifferenceTests {
 					Charset.defaultCharset());
 		}
 		catch (IOException e) {
-			e.printStackTrace();
+			throw new SkipperException("Error copying manifest", e);
 		}
 		return this.applicationManifestReader.read(manifest);
 	}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.util.StringUtils;
 
 /**
@@ -123,7 +124,7 @@ public class Release extends AbstractEntity {
 			this.pkgJsonString = mapper.writeValueAsString(pkg);
 		}
 		catch (JsonProcessingException e) {
-			e.printStackTrace();
+			throw new SkipperException("Error processing pkg json string", e);
 		}
 	}
 
@@ -187,7 +188,7 @@ public class Release extends AbstractEntity {
 			}
 		}
 		catch (IOException e) {
-			e.printStackTrace();
+			throw new SkipperException("Error processing config values", e);
 		}
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/io/DefaultPackageReader.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/io/DefaultPackageReader.java
@@ -29,7 +29,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
 import org.zeroturnaround.zip.commons.FileUtils;
-
+import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
@@ -146,7 +146,7 @@ public class DefaultPackageReader implements PackageReader {
 			fileContents = FileUtils.readFileToString(file);
 		}
 		catch (IOException e) {
-			e.printStackTrace();
+			throw new SkipperException("Error reading yaml file", e);
 		}
 		PackageMetadata pkgMetadata = (PackageMetadata) yaml.load(fileContents);
 		return pkgMetadata;


### PR DESCRIPTION
- Simply replace printStackTrace() with throwing
  SkipperException.
- Fixes #614