### PR TITLE
Handle package config value YAML loading

### DIFF
--- a/spring-cloud-skipper/src/main/resources/org/springframework/cloud/skipper/io/generic-template.yml
+++ b/spring-cloud-skipper/src/main/resources/org/springframework/cloud/skipper/io/generic-template.yml
@@ -2,7 +2,7 @@ apiVersion: skipper.spring.io/v1
 kind: SpringCloudDeployerApplication
 metadata:
   {{#metadata.entrySet}}
-  "{{{key}}}": "{{{value}}}"
+  "{{{key}}}": {{{value}}}
   {{/metadata.entrySet}}
 spec:
   resource: "{{{spec.resource}}}"
@@ -10,10 +10,9 @@ spec:
   version: "{{{spec.version}}}"
   applicationProperties:
     {{#spec.applicationProperties.entrySet}}
-    "{{{key}}}": "{{{value}}}"
+    "{{{key}}}": {{{value}}}
     {{/spec.applicationProperties.entrySet}}
   deploymentProperties:
     {{#spec.deploymentProperties.entrySet}}
-    "{{{key}}}": "{{{value}}}"
-    {{/spec.deploymentProperties.entrySet}}
-  cfManifest: "{{{spec.cfManifest}}}"
+    "{{{key}}}": {{{value}}}
+    {{/spec.deploymentProperties.entrySet}}  cfManifest: "{{{spec.cfManifest}}}"

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifestReaderTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifestReaderTests.java
@@ -110,7 +110,7 @@ public class SpringCloudDeployerApplicationManifestReaderTests {
 				.isEqualTo("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:1.2.0.RELEASE");
 		assertThat(spec.getApplicationProperties()).hasSize(2);
 		assertThat(spec.getApplicationProperties()).containsEntry("log.level", "INFO");
-		assertThat(spec.getApplicationProperties()).containsEntry("log.expression", "hellobaby");
+		assertThat(spec.getApplicationProperties()).containsEntry("log.expression", "hello baby");
 
 		assertThat(spec.getDeploymentProperties()).hasSize(2);
 		assertThat(spec.getDeploymentProperties()).containsEntry("memory", "1024");

--- a/spring-cloud-skipper/src/test/resources/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifestReaderTests-manifest.yml
+++ b/spring-cloud-skipper/src/test/resources/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifestReaderTests-manifest.yml
@@ -10,7 +10,7 @@ spec:
   resourceMetadata: maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:1.2.0.RELEASE
   applicationProperties:
     log.level: INFO
-    log.expression: hellobaby
+    log.expression: "hello baby"
   deploymentProperties:
     memory: 1024
     disk: 2


### PR DESCRIPTION
 - Remove double quotes in generic template for the property values
 - Perform Yaml dump on merged config values with the YAML dumping option set to DumperOptions.ScalarStyle.DOUBLE_QUOTED for the default scalar style
 - Load this yaml data when setting the release manifest

Resolves #624