### PR TITLE
Handle package config value YAML loading

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/util/YamlEscapeUtility.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/util/YamlEscapeUtility.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.server.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * @author Christian Tzolov
+ */
+public class YamlEscapeUtility {
+
+	private List<String> filterKeywords;
+
+	public YamlEscapeUtility() {
+		this.filterKeywords = new ArrayList<>();
+		this.filterKeywords.add("expression");
+	}
+
+	public YamlEscapeUtility(List<String> filterKeywords) {
+		this.filterKeywords = filterKeywords;
+	}
+
+	/**
+	 * In Java '\\\\' sands for escaped backslash. E.g. it corresponds to '\\' in regular expression.
+	 *
+	 * (?<!\\) - (negative lookbehind) - the previous character is not a backslash.
+	 * (\\)    - (non-capturing group) - current character is a backslash
+	 * (?![\\0abtnvfreN_LP\s"]) - (negative lookforward) - next character is neither of \, 0, a, b, t, n, v, f, r, e, N, _, L, P, ,\s, "
+	 */
+	private static final Pattern SINGLE_BACKSLASH = Pattern.compile("(?<!\\\\)(\\\\)(?![\\\\0abtnvfreN_LP\\s\"])");
+
+	public Map escapeSingleBackslashInProperties(Map<String, String> properties) {
+		return properties.entrySet().stream()
+				.collect(Collectors.toMap(
+						e -> e.getKey(),
+						e -> this.isEscapeCandidate(e.getKey()) ? backslashEscape(e.getValue()) : e.getValue()));
+	}
+
+	private boolean isEscapeCandidate(String text) {
+		return this.filterKeywords.stream().filter(v -> text.contains(v)).findFirst().isPresent();
+	}
+
+	public String backslashEscape(String text) {
+		return SINGLE_BACKSLASH.matcher(text).replaceAll("\\\\\\\\");
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/util/ManifestUtilsTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/util/ManifestUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.server.util;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.cloud.skipper.domain.Package;
+import org.springframework.cloud.skipper.io.DefaultPackageReader;
+import org.springframework.cloud.skipper.io.PackageReader;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Christian Tzolov
+ */
+public class ManifestUtilsTest {
+
+	@Test
+	public void testCreateManifest() throws IOException {
+		Resource resource = new ClassPathResource("/repositories/sources/test/ticktock/ticktock-1.0.1");
+		PackageReader packageReader = new DefaultPackageReader();
+
+		Package pkg = packageReader.read(resource.getFile());
+		assertThat(pkg).isNotNull();
+
+		Map<String, Object> log = new HashMap<>();
+		log.put("version", "666");
+		log.put("adate", new Date(666));
+		log.put("bool", true);
+		log.put("array", "[a, b, c]");
+
+		Map<String, String> time = new HashMap<>();
+		time.put("version", "666");
+
+		Map<String, Object> map = new HashMap<>();
+		map.put("log", log);
+		map.put("time", time);
+
+		String manifest = ManifestUtils.createManifest(pkg, map);
+
+		assertTrue("Handle Integer", manifest.contains("\"version\": \"666\""));
+		assertTrue("Handle Boolean", manifest.contains("\"bool\": \"true\""));
+		assertTrue("Handle Date", manifest.contains("\"adate\": \"Thu Jan 01 01:00:00 CET 1970\""));
+		assertTrue("Handle Array", manifest.contains("\"array\":\n  - \"a\"\n  - \"b\"\n  - \"c\""));
+		assertTrue("Handle Null", manifest.contains("\"applicationProperties\": !!null \"null\""));
+//		CCCCassertFalse("Handle Empty Value", manifest.contains("null"));
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/package.yml
@@ -1,0 +1,9 @@
+apiVersion: skipper.spring.io/v1
+kind: SkipperPackageMetadata
+name: ticktock
+version: 1.0.0
+packageSourceUrl: https://example.com/dataflow/ticktock
+packageHomeUrl: http://example.com/dataflow/ticktock
+tags: stream, time, log
+maintainer: https://github.com/markpollack
+description: The ticktock stream sends a time stamp and logs the value.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/log/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/log/package.yml
@@ -1,0 +1,9 @@
+apiVersion: skipper.spring.io/v1
+kind: SkipperPackageMetadata
+name: log
+version: 2.0.0
+packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
+packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+tags: logging, sink
+maintainer: https://github.com/sobychacko
+description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/log/templates/log.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/log/templates/log.yml
@@ -1,0 +1,20 @@
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: log
+  type: sink
+spec:
+  resource: maven://org.springframework.cloud.stream.app:log-sink-rabbit
+  resourceMetadata: maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:{{version}}
+  version: {{version}}
+  bool: {{bool}}
+  adate: {{adate}}
+  array: {{array}}
+  applicationProperties:
+    {{#spec.applicationProperties.entrySet}}
+    {{key}}: {{value}}
+    {{/spec.applicationProperties.entrySet}}
+  deploymentProperties:
+    {{#spec.deploymentProperties.entrySet}}
+    {{key}}: {{value}}
+    {{/spec.deploymentProperties.entrySet}}

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/log/values.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/log/values.yml
@@ -1,0 +1,13 @@
+# Default values for {{name}}
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates
+version: 1.1.0.RELEASE
+spec:
+  applicationProperties:
+    log.level: DEBUG
+  deploymentProperties:
+    memory: 1024m
+
+
+
+

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/time/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/time/package.yml
@@ -1,0 +1,9 @@
+apiVersion: skipper.spring.io/v1
+kind: SkipperPackageMetadata
+name: time
+version: 2.0.0
+packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE
+packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+tags: time, source
+maintainer: https://github.com/sobychacko
+description: The time source periodically emits a timestamp string.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/time/templates/time.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/time/templates/time.yml
@@ -1,0 +1,17 @@
+apiVersion: skipper.spring.io/v1
+kind: SpringCloudDeployerApplication
+metadata:
+  name: time
+  type: source
+spec:
+  resource: maven://org.springframework.cloud.stream.app:time-source-rabbit
+  resourceMetadata: maven://org.springframework.cloud.stream.app:time-source-rabbit:jar:metadata:{{version}}
+  version: {{version}}
+  applicationProperties:
+    {{#spec.applicationProperties.entrySet}}
+    {{key}}: {{value}}
+    {{/spec.applicationProperties.entrySet}}
+  deploymentProperties:
+    {{#spec.deploymentProperties.entrySet}}
+    {{key}}: {{value}}
+    {{/spec.deploymentProperties.entrySet}}

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/time/values.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/time/values.yml
@@ -1,0 +1,12 @@
+# Default values for {{name}}
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates
+version: 1.2.0.RELEASE
+spec:
+  applicationProperties:
+    log.level: DEBUG
+  deploymentProperties:
+    memory: 1024m
+
+
+

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/values.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/values.yml
@@ -1,0 +1,7 @@
+# Default values for {{name}}
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates
+
+
+# No values to override
+

--- a/spring-cloud-skipper/src/main/resources/org/springframework/cloud/skipper/io/generic-template.yml
+++ b/spring-cloud-skipper/src/main/resources/org/springframework/cloud/skipper/io/generic-template.yml
@@ -2,7 +2,7 @@ apiVersion: skipper.spring.io/v1
 kind: SpringCloudDeployerApplication
 metadata:
   {{#metadata.entrySet}}
-  "{{{key}}}": "{{{value}}}"
+  "{{{key}}}": {{{value}}}
   {{/metadata.entrySet}}
 spec:
   resource: "{{{spec.resource}}}"
@@ -10,10 +10,9 @@ spec:
   version: "{{{spec.version}}}"
   applicationProperties:
     {{#spec.applicationProperties.entrySet}}
-    "{{{key}}}": "{{{value}}}"
+    "{{{key}}}": {{{value}}}
     {{/spec.applicationProperties.entrySet}}
   deploymentProperties:
     {{#spec.deploymentProperties.entrySet}}
-    "{{{key}}}": "{{{value}}}"
-    {{/spec.deploymentProperties.entrySet}}
-  cfManifest: "{{{spec.cfManifest}}}"
+    "{{{key}}}": {{{value}}}
+    {{/spec.deploymentProperties.entrySet}}  cfManifest: "{{{spec.cfManifest}}}"

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifestReaderTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifestReaderTests.java
@@ -110,7 +110,7 @@ public class SpringCloudDeployerApplicationManifestReaderTests {
 				.isEqualTo("maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:1.2.0.RELEASE");
 		assertThat(spec.getApplicationProperties()).hasSize(2);
 		assertThat(spec.getApplicationProperties()).containsEntry("log.level", "INFO");
-		assertThat(spec.getApplicationProperties()).containsEntry("log.expression", "hellobaby");
+		assertThat(spec.getApplicationProperties()).containsEntry("log.expression", "hello baby");
 
 		assertThat(spec.getDeploymentProperties()).hasSize(2);
 		assertThat(spec.getDeploymentProperties()).containsEntry("memory", "1024");

--- a/spring-cloud-skipper/src/test/resources/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifestReaderTests-manifest.yml
+++ b/spring-cloud-skipper/src/test/resources/org/springframework/cloud/skipper/domain/SpringCloudDeployerApplicationManifestReaderTests-manifest.yml
@@ -10,7 +10,7 @@ spec:
   resourceMetadata: maven://org.springframework.cloud.stream.app:log-sink-rabbit:jar:metadata:1.2.0.RELEASE
   applicationProperties:
     log.level: INFO
-    log.expression: hellobaby
+    log.expression: "hello baby"
   deploymentProperties:
     memory: 1024
     disk: 2


### PR DESCRIPTION
- Remove double quotes in generic template for the property values
 - Perform Yaml dump on merged config values with the YAML dumping option set to DumperOptions.ScalarStyle.DOUBLE_QUOTED for the default scalar style
 - Load this yaml data when setting the release manifest
 - Handle dumped value types
 - Add Yaml dump logic test

Resolves #642