### PR TITLE
Changes to the manifest were not additive

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseReportService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseReportService.java
@@ -17,6 +17,11 @@ package org.springframework.cloud.skipper.server.service;
 
 import java.util.Map;
 
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.Manifest;
 import org.springframework.cloud.skipper.domain.Package;
@@ -34,6 +39,7 @@ import org.springframework.cloud.skipper.server.util.ConfigValueUtils;
 import org.springframework.cloud.skipper.server.util.ManifestUtils;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Mark Pollack
@@ -85,23 +91,56 @@ public class ReleaseReportService {
 
 		// if we're about to save new release during this report, create
 		// or restore replacing one.
-		Release replacingRelease = null;
+		Release tempReplacingRelease = null;
 		if (initial) {
-			replacingRelease = createReleaseForUpgrade(packageMetadata, latestRelease.getVersion() + 1,
+			tempReplacingRelease = createReleaseForUpgrade(packageMetadata, latestRelease.getVersion() + 1,
 					upgradeProperties, existingRelease.getPlatformName(), rollbackRequest);
 		}
 		else {
-			replacingRelease = this.releaseRepository.findByNameAndVersion(
+			tempReplacingRelease = this.releaseRepository.findByNameAndVersion(
 					upgradeRequest.getUpgradeProperties().getReleaseName(), latestRelease.getVersion());
 		}
+		// Carry over customized config values from replacing release so updates are additive with property changes.
+		Release replacingRelease = updateReplacingReleaseConfigValues(latestRelease, tempReplacingRelease);
 
-		Map<String, Object> model = ConfigValueUtils.mergeConfigValues(replacingRelease.getPkg(),
+		Map<String, Object> mergedReplacingReleaseModel = ConfigValueUtils.mergeConfigValues(replacingRelease.getPkg(),
 				replacingRelease.getConfigValues());
-		String manifestData = ManifestUtils.createManifest(replacingRelease.getPkg(), model);
+
+		String manifestData = ManifestUtils.createManifest(replacingRelease.getPkg(), mergedReplacingReleaseModel);
 		Manifest manifest = new Manifest();
 		manifest.setData(manifestData);
 		replacingRelease.setManifest(manifest);
 		return this.releaseManager.createReport(existingRelease, replacingRelease, initial);
+	}
+
+	private Release updateReplacingReleaseConfigValues(Release targetRelease, Release replacingRelease) {
+		Map<String, Object> targetConfigValueMap = getConfigValuesAsMap(targetRelease.getConfigValues());
+		Map<String, Object> replacingRelaseConfigValueMap = getConfigValuesAsMap(replacingRelease.getConfigValues());
+		if (targetConfigValueMap !=null && replacingRelaseConfigValueMap !=null) {
+			ConfigValueUtils.merge(targetConfigValueMap, replacingRelaseConfigValueMap);
+			DumperOptions dumperOptions = new DumperOptions();
+			dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+			dumperOptions.setPrettyFlow(true);
+			Yaml yaml = new Yaml(dumperOptions);
+			ConfigValues mergedConfigValues = new ConfigValues();
+			mergedConfigValues.setRaw(yaml.dump(targetConfigValueMap));
+			replacingRelease.setConfigValues(mergedConfigValues);
+		}
+		return replacingRelease;
+	}
+
+	private Map<String,Object> getConfigValuesAsMap(ConfigValues configValues) {
+		Yaml yaml = new Yaml();
+		if (StringUtils.hasText(configValues.getRaw())) {
+			Object data = yaml.load(configValues.getRaw());
+			if (data instanceof Map) {
+				return (Map<String, Object>) yaml.load(configValues.getRaw());
+			}	else {
+				throw new SkipperException("Was expecting override values to produce a Map, instead got class = " +
+						data.getClass() + "overrideValues.getRaw() = " + configValues.getRaw());
+			}
+		}
+		return null;
 	}
 
 	private Release createReleaseForUpgrade(PackageMetadata packageMetadata, Integer newVersion,

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/util/ConfigValueUtils.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/util/ConfigValueUtils.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.springframework.util.Assert;
 import org.yaml.snakeyaml.Yaml;
 
 import org.springframework.cloud.skipper.SkipperException;
@@ -176,6 +177,8 @@ public class ConfigValueUtils {
 	 * @param map2 The map of values to override those of the first map argument.
 	 */
 	public static void merge(Map<String, Object> map1, Map<String, Object> map2) {
+		Assert.notNull(map1, "Base map to merge value onto must not be null.");
+		Assert.notNull(map2, "Map with values to override must not be null.");
 		for (String key : map2.keySet()) {
 			Object value2 = map2.get(key);
 			if (map1.containsKey(key)) {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -445,7 +445,7 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		Release upgradedRelease = upgrade(upgradeRequest);
 
 		assertThat(upgradedRelease.getVersion()).isEqualTo(2);
-		assertThat(upgradedRelease.getConfigValues()).isEqualTo(upgradeRequest.getUpgradeProperties().getConfigValues());
+		assertThat(upgradedRelease.getConfigValues().getRaw()).isEqualTo(upgradeRequest.getUpgradeProperties().getConfigValues().getRaw());
 		this.appDeployerDataRepository.findByReleaseNameAndReleaseVersionRequired(releaseName, 2);
 
 		// Delete


### PR DESCRIPTION
Noticed when updating different values over versions

Fixes #645 

Tested with Data Flow
```dataflow:>stream create --name ticktock --definition "time | log --name=mylogger"
Created new stream 'ticktock'
dataflow:>stream deploy --name ticktock
Deployment request has been sent for stream 'ticktock'
dataflow:>stream list
╔═══════════╤══════════════════════════════╤═════════════════════════════╗
║Stream Name│      Stream Definition       │           Status            ║
╠═══════════╪══════════════════════════════╪═════════════════════════════╣
║ticktock   │time | log --log.name=mylogger│The stream is being deployed.║
╚═══════════╧══════════════════════════════╧═════════════════════════════╝

dataflow:>stream update --name ticktock --properties app.log.foo2=bar2
Update request has been sent for the stream 'ticktock'
dataflow:>stream list
╔═══════════╤══════════════════════════════════════════╤═════════════════════════════════════════╗
║Stream Name│            Stream Definition             │                 Status                  ║
╠═══════════╪══════════════════════════════════════════╪═════════════════════════════════════════╣
║ticktock   │time | log --log.name=mylogger --foo2=bar2│The stream has been successfully deployed║
╚═══════════╧══════════════════════════════════════════╧═════════════════════════════════════════╝

dataflow:>stream update --name ticktock --properties app.log.foo3=bar3
Update request has been sent for the stream 'ticktock'
dataflow:>stream list
╔═══════════╤══════════════════════════════════════════════════════╤═════════════════════════════════════════╗
║Stream Name│                  Stream Definition                   │                 Status                  ║
╠═══════════╪══════════════════════════════════════════════════════╪═════════════════════════════════════════╣
║ticktock   │time | log --log.name=mylogger --foo2=bar2 --foo3=bar3│The stream has been successfully deployed║
╚═══════════╧══════════════════════════════════════════════════════╧═════════════════════════════════════════╝
```