### PR TITLE
Fix typo in persist skip function

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachinePersistConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachinePersistConfiguration.java
@@ -56,7 +56,7 @@ public class StateMachinePersistConfiguration {
 		return interceptor;
 	}
 
-	private static class SkipUnwantedVariablesFunction
+	static class SkipUnwantedVariablesFunction
 			implements Function<StateMachine<SkipperStates, SkipperEvents>, Map<Object, Object>> {
 
 		@Override
@@ -65,8 +65,8 @@ public class StateMachinePersistConfiguration {
 				return !(ObjectUtils.nullSafeEquals(e.getKey(), SkipperVariables.SOURCE_RELEASE)
 						|| ObjectUtils.nullSafeEquals(e.getKey(), SkipperVariables.TARGET_RELEASE)
 						|| ObjectUtils.nullSafeEquals(e.getKey(), SkipperVariables.RELEASE)
-						|| ObjectUtils.nullSafeEquals(e.getKey(), SkipperVariables.RELEASE_ANALYSIS_REPORT))
-						|| ObjectUtils.nullSafeEquals(e.getKey(), SkipperVariables.ERROR);
+						|| ObjectUtils.nullSafeEquals(e.getKey(), SkipperVariables.RELEASE_ANALYSIS_REPORT)
+						|| ObjectUtils.nullSafeEquals(e.getKey(), SkipperVariables.ERROR));
 			}).collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 		}
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachinePersistConfigurationTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachinePersistConfigurationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.cloud.skipper.server.statemachine.StateMachinePersistConfiguration.SkipUnwantedVariablesFunction;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.support.DefaultExtendedState;
+
+/**
+ * Tests for persist skip function.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class StateMachinePersistConfigurationTests {
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testSkipFunction() {
+		SkipUnwantedVariablesFunction f = new SkipUnwantedVariablesFunction();
+
+		DefaultExtendedState extendedState = new DefaultExtendedState();
+		extendedState.getVariables().put(SkipperVariables.SOURCE_RELEASE, new Object());
+		extendedState.getVariables().put(SkipperVariables.TARGET_RELEASE, new Object());
+		extendedState.getVariables().put(SkipperVariables.RELEASE, new Object());
+		extendedState.getVariables().put(SkipperVariables.RELEASE_ANALYSIS_REPORT, new Object());
+		extendedState.getVariables().put(SkipperVariables.ERROR, new Object());
+		extendedState.getVariables().put(SkipperVariables.UPGRADE_CUTOFF_TIME, new Object());
+		extendedState.getVariables().put(SkipperVariables.UPGRADE_STATUS, new Object());
+
+		StateMachine<SkipperStates, SkipperEvents> stateMachine = Mockito.mock(StateMachine.class);
+		Mockito.when(stateMachine.getExtendedState()).thenReturn(extendedState);
+
+		// test that others gets filtered out
+		Map<Object, Object> map = f.apply(stateMachine);
+		assertThat(map).isNotNull();
+		assertThat(map).containsOnlyKeys(SkipperVariables.UPGRADE_CUTOFF_TIME, SkipperVariables.UPGRADE_STATUS);
+	}
+}


### PR DESCRIPTION
- Expose SkipUnwantedVariablesFunction to package level
  to test it.
- Fix typo in apply function which caused wrong check
  for SkipperVariables.ERROR.
- Fixes #658