### PR TITLE
Refactor to support multiple release managers

### DIFF
--- a/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/CloudFoundryPlatformAutoConfiguration.java
+++ b/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/CloudFoundryPlatformAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.github.zafarkhaja.semver.Version;
+
 import org.cloudfoundry.client.CloudFoundryClient;
 import org.cloudfoundry.client.v2.info.GetInfoRequest;
 import org.cloudfoundry.operations.CloudFoundryOperations;
@@ -29,9 +30,10 @@ import org.cloudfoundry.reactor.DefaultConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
 import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryAppDeployer;
@@ -42,17 +44,23 @@ import org.springframework.cloud.deployer.spi.core.RuntimeEnvironmentInfo;
 import org.springframework.cloud.deployer.spi.util.RuntimeVersionUtils;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.deployer.cloudfoundry.CloudFoundryPlatformProperties;
+import org.springframework.cloud.skipper.deployer.cloudfoundry.CloudFoundrySkipperServerConfiguration;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Platform;
+import org.springframework.cloud.skipper.server.config.EnableSkipperServerConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author Donovan Muller
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
 @Configuration
+@ConditionalOnBean(EnableSkipperServerConfiguration.Marker.class)
 @EnableConfigurationProperties(CloudFoundryPlatformProperties.class)
+@Import(CloudFoundrySkipperServerConfiguration.class)
 public class CloudFoundryPlatformAutoConfiguration {
 
 	private static final Logger logger = LoggerFactory

--- a/spring-cloud-skipper-platform-cloudfoundry/pom.xml
+++ b/spring-cloud-skipper-platform-cloudfoundry/pom.xml
@@ -17,6 +17,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-skipper-server-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-deployer-cloudfoundry</artifactId>
         </dependency>
         <dependency>

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CFApplicationManifestUtils.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CFApplicationManifestUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.deployer;
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
 
 import java.io.File;
 import java.io.IOException;

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CFManifestApplicationDeployer.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CFManifestApplicationDeployer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.deployer;
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
 
 import java.time.Duration;
 import java.util.List;
@@ -35,7 +35,6 @@ import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoa
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundryAppInstanceStatus;
-import org.springframework.cloud.skipper.deployer.cloudfoundry.PlatformCloudFoundryOperations;
 import org.springframework.cloud.skipper.domain.CFApplicationManifestReader;
 import org.springframework.cloud.skipper.domain.CFApplicationSkipperManifest;
 import org.springframework.cloud.skipper.domain.CFApplicationSpec;
@@ -43,6 +42,7 @@ import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Status;
 import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryDeleteStep.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryDeleteStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.deployer.strategies;
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
 
 import java.util.List;
-import java.util.Map;
 
+import org.cloudfoundry.operations.applications.ApplicationManifest;
+import org.cloudfoundry.operations.applications.DeleteApplicationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.cloud.deployer.spi.app.AppDeployer;
-import org.springframework.cloud.deployer.spi.app.AppStatus;
-import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Status;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.domain.AppDeployerData;
-import org.springframework.cloud.skipper.server.repository.DeployerRepository;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 
 /**
@@ -36,38 +33,30 @@ import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
  * the release.
  * @author Mark Pollack
  */
-public class DeleteStep {
+public class CloudFoundryDeleteStep {
 
-	private final Logger logger = LoggerFactory.getLogger(DeleteStep.class);
+	private final Logger logger = LoggerFactory.getLogger(CloudFoundryDeleteStep.class);
 
 	private final ReleaseRepository releaseRepository;
 
-	private final DeployerRepository deployerRepository;
+	private final PlatformCloudFoundryOperations platformCloudFoundryOperations;
 
-	public DeleteStep(ReleaseRepository releaseRepository, DeployerRepository deployerRepository) {
+	public CloudFoundryDeleteStep(ReleaseRepository releaseRepository,
+			PlatformCloudFoundryOperations platformCloudFoundryOperations) {
 		this.releaseRepository = releaseRepository;
-		this.deployerRepository = deployerRepository;
+		this.platformCloudFoundryOperations = platformCloudFoundryOperations;
 	}
 
 	public Release delete(Release release, AppDeployerData existingAppDeployerData,
 			List<String> applicationNamesToDelete) {
-		AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
-				.getAppDeployer();
-
-		Map<String, String> appNamesAndDeploymentIds = existingAppDeployerData.getDeploymentDataAsMap();
-
-		for (Map.Entry<String, String> appNameAndDeploymentId : appNamesAndDeploymentIds.entrySet()) {
-			if (applicationNamesToDelete.contains(appNameAndDeploymentId.getKey())) {
-				AppStatus appStatus = appDeployer.status(appNameAndDeploymentId.getValue());
-				if (appStatus.getState().equals(DeploymentState.deployed)) {
-					appDeployer.undeploy(appNameAndDeploymentId.getValue());
-				}
-				else {
-					logger.warn("For Release name {}, did not undeploy existing app {} as its status is not "
-							+ "'deployed'.", release.getName(), appNameAndDeploymentId.getKey());
-				}
-			}
-		}
+		ApplicationManifest applicationManifest = CFApplicationManifestUtils.updateApplicationName(release);
+		String applicationName = applicationManifest.getName();
+		DeleteApplicationRequest deleteApplicationRequest = DeleteApplicationRequest.builder().name(applicationName)
+				.build();
+		this.platformCloudFoundryOperations.getCloudFoundryOperations(release.getPlatformName()).applications()
+				.delete(deleteApplicationRequest)
+				.doOnSuccess(v -> logger.info("Successfully undeployed app {}", applicationName))
+				.doOnError(e -> logger.error("Failed to undeploy app %s", applicationName)).block();
 
 		Status deletedStatus = new Status();
 		deletedStatus.setStatusCode(StatusCode.DELETED);

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryDeployAppStep.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryDeployAppStep.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
+
+import static org.springframework.cloud.skipper.deployer.cloudfoundry.CFManifestApplicationDeployer.isNotFoundError;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.cloudfoundry.operations.applications.ApplicationManifest;
+import org.cloudfoundry.operations.applications.PushApplicationManifestRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.cloud.skipper.server.util.ArgumentSanitizer;
+import org.springframework.dao.DataAccessException;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Responsible for taking the ReleaseAnalysisReport and deploying the apps in the
+ * replacing release. Step operates in it's own transaction, catches all exceptions so
+ * always commits.
+ * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
+ */
+public class CloudFoundryDeployAppStep {
+
+	private static final Logger logger = LoggerFactory.getLogger(CloudFoundryDeployAppStep.class);
+
+	private final AppDeployerDataRepository appDeployerDataRepository;
+
+	private final ReleaseRepository releaseRepository;
+
+	private final PlatformCloudFoundryOperations platformCloudFoundryOperations;
+
+	private final CFManifestApplicationDeployer cfManifestApplicationDeployer;
+
+	public CloudFoundryDeployAppStep(AppDeployerDataRepository appDeployerDataRepository,
+			ReleaseRepository releaseRepository, PlatformCloudFoundryOperations platformCloudFoundryOperations,
+			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+		this.appDeployerDataRepository = appDeployerDataRepository;
+		this.releaseRepository = releaseRepository;
+		this.platformCloudFoundryOperations = platformCloudFoundryOperations;
+		this.cfManifestApplicationDeployer = cfManifestApplicationDeployer;
+	}
+
+	@Transactional
+	public List<String> deployApps(Release existingRelease, Release replacingRelease,
+			ReleaseAnalysisReport releaseAnalysisReport) {
+		List<String> applicationNamesToUpgrade = new ArrayList<>();
+		try {
+			applicationNamesToUpgrade = releaseAnalysisReport.getApplicationNamesToUpgrade();
+			deployCFApp(replacingRelease);
+		}
+		catch (DataAccessException e) {
+			throw e;
+		}
+		catch (Exception e) {
+			Status status = new Status();
+			status.setStatusCode(StatusCode.FAILED);
+			replacingRelease.getInfo().setStatus(status);
+			replacingRelease.getInfo().setStatus(status);
+			replacingRelease.getInfo().setDescription("Could not deploy app.");
+			this.releaseRepository.save(replacingRelease);
+		}
+		return applicationNamesToUpgrade;
+	}
+
+	private void deployCFApp(Release replacingRelease) {
+		ApplicationManifest applicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(replacingRelease);
+		logger.debug("Manifest = " + ArgumentSanitizer.sanitizeYml(replacingRelease.getManifest().getData()));
+		// Deploy the application
+		String applicationName = applicationManifest.getName();
+		Map<String, String> appDeploymentData = new HashMap<>();
+		appDeploymentData.put(applicationManifest.getName(), applicationManifest.toString());
+		this.platformCloudFoundryOperations.getCloudFoundryOperations(replacingRelease.getPlatformName())
+				.applications().pushManifest(
+				PushApplicationManifestRequest.builder()
+						.manifest(applicationManifest)
+						.stagingTimeout(CFManifestApplicationDeployer.STAGING_TIMEOUT)
+						.startupTimeout(CFManifestApplicationDeployer.STARTUP_TIMEOUT)
+						.build())
+				.doOnSuccess(v -> logger.info("Done uploading bits for {}", applicationName))
+				.doOnError(e -> logger.error(
+						String.format("Error creating app %s.  Exception Message %s", applicationName,
+								e.getMessage())))
+				.timeout(CFManifestApplicationDeployer.PUSH_REQUEST_TIMEOUT)
+				.doOnSuccess(item -> {
+					logger.info("Successfully deployed {}", applicationName);
+					AppDeployerData appDeployerData = new AppDeployerData();
+					appDeployerData.setReleaseName(replacingRelease.getName());
+					appDeployerData.setReleaseVersion(replacingRelease.getVersion());
+					appDeployerData.setDeploymentDataUsingMap(appDeploymentData);
+					this.appDeployerDataRepository.save(appDeployerData);
+				})
+				.doOnError(error -> {
+					if (isNotFoundError().test(error)) {
+						logger.warn("Unable to deploy application. It may have been destroyed before start completed: " + error.getMessage());
+					}
+					else {
+						logger.error(String.format("Failed to deploy %s", applicationName));
+					}
+				})
+				.block();
+	}
+}

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryHandleHealthCheckStep.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryHandleHealthCheckStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.deployer.strategies;
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
 
 import java.util.List;
 
@@ -35,26 +35,26 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Responsible for taking action based on the health of the latest deployed release. If
  * healthy, then delete applications from the previous release. Otherwise delete the
- * latest deployed release. Delegates to {@link DeleteStep}.
+ * latest deployed release. Delegates to {@link CloudFoundryDeleteStep}.
  *
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  */
-public class HandleHealthCheckStep {
+public class CloudFoundryHandleHealthCheckStep {
 
-	private final Logger logger = LoggerFactory.getLogger(HandleHealthCheckStep.class);
+	private final Logger logger = LoggerFactory.getLogger(CloudFoundryHandleHealthCheckStep.class);
 
 	private final ReleaseRepository releaseRepository;
 
 	private final AppDeployerDataRepository appDeployerDataRepository;
 
-	private final DeleteStep deleteStep;
+	private final CloudFoundryDeleteStep deleteStep;
 
 	private final ReleaseManagerFactory releaseManagerFactory;
 
-	public HandleHealthCheckStep(ReleaseRepository releaseRepository,
+	public CloudFoundryHandleHealthCheckStep(ReleaseRepository releaseRepository,
 			AppDeployerDataRepository appDeployerDataRepository,
-			DeleteStep deleteStep,
+			CloudFoundryDeleteStep deleteStep,
 			ReleaseManagerFactory releaseManagerFactory) {
 		this.releaseRepository = releaseRepository;
 		this.appDeployerDataRepository = appDeployerDataRepository;
@@ -95,7 +95,7 @@ public class HandleHealthCheckStep {
 						+ " milliseconds.  " + "Keeping existing release, and Deleting apps of replacing release");				
 			}
 			String kind = ManifestUtils.resolveKind(replacingRelease.getManifest().getData());
-			ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);
+			ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);			
 			releaseManager.delete(replacingRelease);
 			Status status = new Status();
 			status.setStatusCode(StatusCode.FAILED);

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryHealthCheckStep.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryHealthCheckStep.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
+
+import org.springframework.cloud.deployer.spi.app.AppStatus;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.skipper.domain.Release;
+
+/**
+ * Checks if the apps in the Replacing release are healthy. Health polling values are set
+ * using {@link HealthCheckProperties}
+ * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
+ */
+public class CloudFoundryHealthCheckStep {
+
+	private final CFManifestApplicationDeployer cfManifestApplicationDeployer;
+
+	public CloudFoundryHealthCheckStep(CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+		this.cfManifestApplicationDeployer = cfManifestApplicationDeployer;
+	}
+
+	public boolean isHealthy(Release replacingRelease) {
+		AppStatus appStatus = cfManifestApplicationDeployer.status(replacingRelease);
+		if (appStatus.getState() == DeploymentState.deployed) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseAnalyzer.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseAnalyzer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.cloudfoundry.operations.applications.ApplicationManifest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.deployer.ApplicationManifestDifference;
+import org.springframework.cloud.skipper.domain.deployer.ReleaseDifference;
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.support.PropertiesDiff;
+import org.springframework.util.StringUtils;
+
+/**
+ * Analyze the new release manifest and the previous one to determine the minimum number
+ * of releases to install and delete when upgrading. This implementation currently only
+ * supports detecting changes between the two packages that either a) both have a single
+ * top level package template b) both have the same number of dependent packages and no
+ * top level package template
+ *
+ * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
+ */
+public class CloudFoundryReleaseAnalyzer {
+
+	private final Logger logger = LoggerFactory.getLogger(CloudFoundryReleaseAnalyzer.class);
+
+	private final CFManifestApplicationDeployer cfManifestApplicationDeployer;
+
+	public CloudFoundryReleaseAnalyzer(CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+		this.cfManifestApplicationDeployer = cfManifestApplicationDeployer;
+	}
+
+	/**
+	 * Analyze the existing release and the replacing release to determine the minimal number
+	 * of changes that need to be made.
+	 * @param existingRelease the release that is currently deployed
+	 * @param replacingRelease the proposed release to be deployed that will replace the
+	 * existing release.
+	 * @return an analysis report describing the changes to make, if any.
+	 */
+	public ReleaseAnalysisReport analyze(Release existingRelease, Release replacingRelease) {
+		List<ApplicationManifestDifference> applicationManifestDifferences = new ArrayList<>();
+		ApplicationManifest existingApplicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(existingRelease);
+		ApplicationManifest replacingApplicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(replacingRelease);
+		if (!existingApplicationManifest.equals(replacingApplicationManifest)) {
+			Map<String, String> existingMap = CFApplicationManifestUtils.getCFManifestMap(existingApplicationManifest);
+			Map<String, String> replacingMap = CFApplicationManifestUtils.getCFManifestMap(replacingApplicationManifest);
+			PropertiesDiff emptyPropertiesDiff = PropertiesDiff.builder().build();
+			PropertiesDiff propertiesDiff = PropertiesDiff.builder().left(existingMap).right(replacingMap).build();
+			ApplicationManifestDifference applicationManifestDifference = new ApplicationManifestDifference(existingApplicationManifest.getName(),
+					emptyPropertiesDiff, emptyPropertiesDiff, emptyPropertiesDiff, propertiesDiff, emptyPropertiesDiff);
+			applicationManifestDifferences.add(applicationManifestDifference);
+		}
+		return createReleaseAnalysisReport(existingRelease, replacingRelease, applicationManifestDifferences);
+	}
+
+	private ReleaseAnalysisReport createReleaseAnalysisReport(Release existingRelease,
+			Release replacingRelease,
+			List<ApplicationManifestDifference> applicationManifestDifferences) {
+		List<String> appsToUpgrade = new ArrayList<>();
+		ReleaseDifference releaseDifference = new ReleaseDifference();
+		releaseDifference.setDifferences(applicationManifestDifferences);
+		if (!releaseDifference.areEqual()) {
+			logger.info("Differences detected between existing and replacing application manifests."
+					+ "Upgrading applications = [" +
+					StringUtils.collectionToCommaDelimitedString(releaseDifference.getChangedApplicationNames()) + "]");
+			appsToUpgrade.addAll(releaseDifference.getChangedApplicationNames());
+		}
+		return new ReleaseAnalysisReport(appsToUpgrade, releaseDifference, existingRelease, replacingRelease);
+	}
+}

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
+
+import static org.springframework.cloud.skipper.deployer.cloudfoundry.CFManifestApplicationDeployer.PUSH_REQUEST_TIMEOUT;
+import static org.springframework.cloud.skipper.deployer.cloudfoundry.CFManifestApplicationDeployer.STAGING_TIMEOUT;
+import static org.springframework.cloud.skipper.deployer.cloudfoundry.CFManifestApplicationDeployer.STARTUP_TIMEOUT;
+import static org.springframework.cloud.skipper.deployer.cloudfoundry.CFManifestApplicationDeployer.isNotFoundError;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.cloudfoundry.operations.applications.ApplicationManifest;
+import org.cloudfoundry.operations.applications.PushApplicationManifestRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.domain.Manifest;
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.SkipperManifestKind;
+import org.springframework.cloud.skipper.domain.Status;
+import org.springframework.cloud.skipper.domain.StatusCode;
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
+import org.springframework.cloud.skipper.server.domain.AppDeployerData;
+import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.cloud.skipper.server.util.ArgumentSanitizer;
+import org.springframework.cloud.skipper.server.util.ManifestUtils;
+import org.springframework.util.Assert;
+
+/**
+ * A ReleaseManager implementation that uses an CF manifest based deployer.
+ *
+ * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
+ */
+public class CloudFoundryReleaseManager implements ReleaseManager {
+
+	public static final String SPRING_CLOUD_DEPLOYER_COUNT = "spring.cloud.deployer.count";
+
+	private static final Logger logger = LoggerFactory.getLogger(CloudFoundryReleaseManager.class);
+
+	private final ReleaseRepository releaseRepository;
+
+	private final AppDeployerDataRepository appDeployerDataRepository;
+
+	private final CloudFoundryReleaseAnalyzer cloudFoundryReleaseAnalyzer;
+
+	private final PlatformCloudFoundryOperations platformCloudFoundryOperations;
+
+	private final CFManifestApplicationDeployer cfManifestApplicationDeployer;
+
+	public CloudFoundryReleaseManager(ReleaseRepository releaseRepository,
+			AppDeployerDataRepository appDeployerDataRepository,
+			CloudFoundryReleaseAnalyzer cloudFoundryReleaseAnalyzer,
+			PlatformCloudFoundryOperations platformCloudFoundryOperations,
+			CFManifestApplicationDeployer cfManifestApplicationDeployer
+			) {
+		this.releaseRepository = releaseRepository;
+		this.appDeployerDataRepository = appDeployerDataRepository;
+		this.cloudFoundryReleaseAnalyzer = cloudFoundryReleaseAnalyzer;
+		this.platformCloudFoundryOperations = platformCloudFoundryOperations;
+		this.cfManifestApplicationDeployer = cfManifestApplicationDeployer;
+	}
+
+	@Override
+	public Collection<String> getSupportedKinds() {
+		return Arrays.asList(SkipperManifestKind.CFApplication.name());
+	}
+	
+	public Release install(Release newRelease) {
+		Release release = this.releaseRepository.save(newRelease);
+		ApplicationManifest applicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(release);
+		Assert.isTrue(applicationManifest != null, "CF Application Manifest must be set");
+		logger.debug("Manifest = " + ArgumentSanitizer.sanitizeYml(newRelease.getManifest().getData()));
+		// Deploy the application
+		String applicationName = applicationManifest.getName();
+		Map<String, String> appDeploymentData = new HashMap<>();
+		appDeploymentData.put(applicationManifest.getName(), applicationManifest.toString());
+		this.platformCloudFoundryOperations.getCloudFoundryOperations(newRelease.getPlatformName())
+				.applications().pushManifest(
+				PushApplicationManifestRequest.builder()
+						.manifest(applicationManifest)
+						.stagingTimeout(STAGING_TIMEOUT)
+						.startupTimeout(STARTUP_TIMEOUT)
+						.build())
+				.doOnSuccess(v -> logger.info("Done uploading bits for {}", applicationName))
+				.doOnError(e -> logger.error(
+						String.format("Error creating app %s.  Exception Message %s", applicationName,
+								e.getMessage())))
+				.timeout(PUSH_REQUEST_TIMEOUT)
+				.doOnSuccess(item -> {
+					logger.info("Successfully deployed {}", applicationName);
+					saveAppDeployerData(release, appDeploymentData);
+
+					// Update Status in DB
+					updateInstallComplete(release);
+				})
+				.doOnError(error -> {
+					if (isNotFoundError().test(error)) {
+						logger.warn("Unable to deploy application. It may have been destroyed before start completed: " + error.getMessage());
+					}
+					else {
+						logger.error(String.format("Failed to deploy %s", applicationName));
+					}
+				})
+				.block();
+		// Store updated state in in DB and compute status
+		return status(this.releaseRepository.save(release));
+	}
+
+	private void updateInstallComplete(Release release) {
+		Status status = new Status();
+		status.setStatusCode(StatusCode.DEPLOYED);
+		release.getInfo().setStatus(status);
+		release.getInfo().setDescription("Install complete");
+	}
+
+	private void saveAppDeployerData(Release release, Map<String, String> appNameDeploymentIdMap) {
+		AppDeployerData appDeployerData = new AppDeployerData();
+		appDeployerData.setReleaseName(release.getName());
+		appDeployerData.setReleaseVersion(release.getVersion());
+		appDeployerData.setDeploymentDataUsingMap(appNameDeploymentIdMap);
+		this.appDeployerDataRepository.save(appDeployerData);
+	}
+
+	@Override
+	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease, boolean initial) {
+		ReleaseAnalysisReport releaseAnalysisReport = this.cloudFoundryReleaseAnalyzer
+				.analyze(existingRelease, replacingRelease);
+		ApplicationManifest applicationManifest = this.cfManifestApplicationDeployer
+				.getCFApplicationManifest(replacingRelease);
+		Map<String, ?> configValues = CFApplicationManifestUtils.getCFManifestMap(applicationManifest);
+		String manifestData = ManifestUtils.createManifest(replacingRelease.getPkg(), configValues);
+		logger.debug("Replacing Release Manifest = " + ArgumentSanitizer.sanitizeYml(manifestData));
+		Manifest manifest = new Manifest();
+		manifest.setData(manifestData);
+		replacingRelease.setManifest(manifest);
+		if (initial) {
+			this.releaseRepository.save(replacingRelease);
+		}
+		return new ReleaseAnalysisReport(releaseAnalysisReport.getApplicationNamesToUpgrade(),
+				releaseAnalysisReport.getReleaseDifference(), existingRelease, replacingRelease);
+	}
+
+	public Release status(Release release) {
+			release.getInfo().getStatus().setPlatformStatusAsAppStatusList(
+					Collections.singletonList(this.cfManifestApplicationDeployer.status(release)));
+		return release;
+	}
+
+	public Release delete(Release release) {
+		this.releaseRepository.save(this.cfManifestApplicationDeployer.delete(release));
+		return release;
+	}
+
+}

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundrySimpleRedBlackUpgradeStrategy.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundrySimpleRedBlackUpgradeStrategy.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.skipper.server.deployer.strategies;
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -21,36 +21,40 @@ import java.util.Collection;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.SkipperManifestKind;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
 
 /**
- * A simple approach to deploying a new application. All the new apps are deployed and a
- * health check is done to on the new apps. If they are healthy, the old apps are deleted.
- * Executes on it's own thread since it is a long lived operation. Delegates to
- * {@link DeployAppStep}, {@link HealthCheckStep} and {@link HandleHealthCheckStep}
+ * A simple approach to deploying a new application. All the new apps are
+ * deployed and a health check is done to on the new apps. If they are healthy,
+ * the old apps are deleted. Executes on it's own thread since it is a long
+ * lived operation. Delegates to {@link CloudFoundryDeployAppStep},
+ * {@link CloudFoundryHealthCheckStep} and
+ * {@link CloudFoundryHandleHealthCheckStep}
+ * 
  * @author Mark Pollack
+ * @author Janne Valkealahti
  */
-public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
+public class CloudFoundrySimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 
-	private final HealthCheckStep healthCheckStep;
+	private final CloudFoundryHealthCheckStep healthCheckStep;
 
-	private final HandleHealthCheckStep handleHealthCheckStep;
+	private final CloudFoundryHandleHealthCheckStep handleHealthCheckStep;
 
-	private final DeployAppStep deployAppStep;
+	private final CloudFoundryDeployAppStep deployAppStep;
 
-	public SimpleRedBlackUpgradeStrategy(HealthCheckStep healthCheckStep,
-			HandleHealthCheckStep handleHealthCheckStep,
-			DeployAppStep deployAppStep) {
+	public CloudFoundrySimpleRedBlackUpgradeStrategy(CloudFoundryHealthCheckStep healthCheckStep,
+			CloudFoundryHandleHealthCheckStep handleHealthCheckStep,
+			CloudFoundryDeployAppStep deployAppStep) {
 		this.healthCheckStep = healthCheckStep;
 		this.handleHealthCheckStep = handleHealthCheckStep;
 		this.deployAppStep = deployAppStep;
 	}
-	
+
 	@Override
 	public Collection<String> getSupportedKinds() {
-		return Arrays.asList(SkipperManifestKind.SpringBootApp.name(),
-				SkipperManifestKind.SpringCloudDeployerApplication.name());
+		return Arrays.asList(SkipperManifestKind.CFApplication.name());
 	}
-
+	
 	@Override
 	public void deployApps(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport) {
 		this.deployAppStep.deployApps(existingRelease, replacingRelease, releaseAnalysisReport);
@@ -74,5 +78,4 @@ public class SimpleRedBlackUpgradeStrategy implements UpgradeStrategy {
 		this.handleHealthCheckStep.handleHealthCheck(false, existingRelease,
 				releaseAnalysisReport.getApplicationNamesToUpgrade(), replacingRelease, timeout, cancel, rollback);
 	}
-
 }

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundrySkipperServerConfiguration.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundrySkipperServerConfiguration.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.deployer.cloudfoundry;
+
+import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
+import org.springframework.cloud.skipper.domain.CFApplicationManifestReader;
+import org.springframework.cloud.skipper.server.deployer.ReleaseManagerFactory;
+import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for CF related server features for CF manifest support.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+public class CloudFoundrySkipperServerConfiguration {
+
+	@Bean
+	public CloudFoundryReleaseManager cloudFoundryReleaseManager(ReleaseRepository releaseRepository,
+			AppDeployerDataRepository appDeployerDataRepository,
+			CloudFoundryReleaseAnalyzer cloudFoundryReleaseAnalyzer,
+			PlatformCloudFoundryOperations platformCloudFoundryOperations,
+			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+		return new CloudFoundryReleaseManager(releaseRepository, appDeployerDataRepository, cloudFoundryReleaseAnalyzer,
+				platformCloudFoundryOperations, cfManifestApplicationDeployer);
+	}
+
+	@Bean
+	public CFApplicationManifestReader cfApplicationManifestReader() {
+		return new CFApplicationManifestReader();
+	}
+
+	@Bean
+	public CloudFoundryHandleHealthCheckStep cloudFoundryHandleHealthCheckStep(ReleaseRepository releaseRepository,
+			AppDeployerDataRepository appDeployerDataRepository, CloudFoundryDeleteStep deleteStep,
+			ReleaseManagerFactory releaseManagerFactory) {
+		return new CloudFoundryHandleHealthCheckStep(releaseRepository, appDeployerDataRepository, deleteStep,
+				releaseManagerFactory);
+	}
+
+	@Bean
+	public CloudFoundrySimpleRedBlackUpgradeStrategy cloudFoundrySimpleRedBlackUpgradeStrategy(
+			CloudFoundryHealthCheckStep healthCheckStep, CloudFoundryHandleHealthCheckStep handleHealthCheckStep,
+			CloudFoundryDeployAppStep deployAppStep) {
+		return new CloudFoundrySimpleRedBlackUpgradeStrategy(healthCheckStep, handleHealthCheckStep, deployAppStep);
+	}
+
+	@Bean
+	public CloudFoundryHealthCheckStep cloudFoundryHealthCheckStep(
+			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+		return new CloudFoundryHealthCheckStep(cfManifestApplicationDeployer);
+	}
+
+	@Bean
+	public CloudFoundryDeleteStep cloudFoundryDeleteStep(ReleaseRepository releaseRepository,
+			PlatformCloudFoundryOperations platformCloudFoundryOperations) {
+		return new CloudFoundryDeleteStep(releaseRepository, platformCloudFoundryOperations);
+	}
+
+	@Bean
+	public CloudFoundryDeployAppStep cloudFoundryDeployAppStep(AppDeployerDataRepository appDeployerDataRepository,
+			ReleaseRepository releaseRepository, PlatformCloudFoundryOperations platformCloudFoundryOperations,
+			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+		return new CloudFoundryDeployAppStep(appDeployerDataRepository, releaseRepository,
+				platformCloudFoundryOperations, cfManifestApplicationDeployer);
+	}
+
+	@Bean
+	public PlatformCloudFoundryOperations platformCloudFoundryOperations(
+			CloudFoundryPlatformProperties cloudFoundryPlatformProperties) {
+		return new PlatformCloudFoundryOperations(cloudFoundryPlatformProperties);
+	}
+
+	@Bean
+	public CFManifestApplicationDeployer cfApplicationDeployer(CFApplicationManifestReader cfApplicationManifestReader,
+			PlatformCloudFoundryOperations platformCloudFoundryOperations,
+			DelegatingResourceLoader delegatingResourceLoader) {
+		return new CFManifestApplicationDeployer(cfApplicationManifestReader, platformCloudFoundryOperations,
+				delegatingResourceLoader);
+	}
+
+	@Bean
+	public CloudFoundryReleaseAnalyzer cloudFoundryReleaseAnalyzer(
+			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+		return new CloudFoundryReleaseAnalyzer(cfManifestApplicationDeployer);
+	}
+}

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -186,10 +186,6 @@
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-skipper-platform-cloudfoundry</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.skipper.server.config;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -36,9 +37,10 @@ import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.maven.MavenResourceLoader;
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
 import org.springframework.cloud.deployer.resource.support.LRUCleaningResourceLoaderBeanPostProcessor;
-import org.springframework.cloud.skipper.deployer.cloudfoundry.CloudFoundryPlatformProperties;
-import org.springframework.cloud.skipper.deployer.cloudfoundry.PlatformCloudFoundryOperations;
-import org.springframework.cloud.skipper.domain.CFApplicationManifestReader;
+//import org.springframework.cloud.skipper.deployer.cloudfoundry.CFManifestApplicationDeployer;
+//import org.springframework.cloud.skipper.deployer.cloudfoundry.CloudFoundryPlatformProperties;
+//import org.springframework.cloud.skipper.deployer.cloudfoundry.PlatformCloudFoundryOperations;
+//import org.springframework.cloud.skipper.domain.CFApplicationManifestReader;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.cloud.skipper.io.DefaultPackageReader;
 import org.springframework.cloud.skipper.io.DefaultPackageWriter;
@@ -51,10 +53,12 @@ import org.springframework.cloud.skipper.server.controller.RootController;
 import org.springframework.cloud.skipper.server.controller.SkipperErrorAttributes;
 import org.springframework.cloud.skipper.server.controller.VersionInfoProperties;
 import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
-import org.springframework.cloud.skipper.server.deployer.CFManifestApplicationDeployer;
 import org.springframework.cloud.skipper.server.deployer.DefaultReleaseManager;
+import org.springframework.cloud.skipper.server.deployer.DefaultReleaseManagerFactory;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalyzer;
 import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
+import org.springframework.cloud.skipper.server.deployer.ReleaseManagerFactory;
+import org.springframework.cloud.skipper.server.deployer.strategies.DefaultUpgradeStrategyFactory;
 import org.springframework.cloud.skipper.server.deployer.strategies.DeleteStep;
 import org.springframework.cloud.skipper.server.deployer.strategies.DeployAppStep;
 import org.springframework.cloud.skipper.server.deployer.strategies.HandleHealthCheckStep;
@@ -62,6 +66,7 @@ import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckP
 import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckStep;
 import org.springframework.cloud.skipper.server.deployer.strategies.SimpleRedBlackUpgradeStrategy;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategyFactory;
 import org.springframework.cloud.skipper.server.index.PackageMetadataResourceProcessor;
 import org.springframework.cloud.skipper.server.index.PackageSummaryResourceProcessor;
 import org.springframework.cloud.skipper.server.index.SkipperLinksResourceProcessor;
@@ -102,7 +107,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @Configuration
 @EnableConfigurationProperties({ SkipperServerProperties.class, VersionInfoProperties.class,
-		LocalPlatformProperties.class, CloudFoundryPlatformProperties.class, MavenConfigurationProperties.class, HealthCheckProperties.class })
+		LocalPlatformProperties.class, /*CloudFoundryPlatformProperties.class,*/ MavenConfigurationProperties.class, HealthCheckProperties.class })
 @EntityScan({ "org.springframework.cloud.skipper.domain",
 		"org.springframework.cloud.skipper.server.domain" })
 @EnableMapRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
@@ -198,28 +203,36 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 
 	@Bean
 	public ReleaseReportService releaseReportService(PackageMetadataRepository packageMetadataRepository,
-			ReleaseRepository releaseRepository,
-			PackageService packageService,
-			ReleaseManager releaseManager) {
-		return new ReleaseReportService(packageMetadataRepository, releaseRepository, packageService, releaseManager);
+			ReleaseRepository releaseRepository, PackageService packageService,
+			ReleaseManagerFactory releaseManagerFactory) {
+		return new ReleaseReportService(packageMetadataRepository, releaseRepository, packageService,
+				releaseManagerFactory);
 	}
 
 	@Bean
+	public ReleaseManagerFactory releaseManagerFactory(List<ReleaseManager> managers) {
+		return new DefaultReleaseManagerFactory(managers);
+	}
+	
+	@Bean
+	public UpgradeStrategyFactory upgradeStrategyFactory(List<UpgradeStrategy> strategies) {
+		return new DefaultUpgradeStrategyFactory(strategies);
+	}
+	
+	@Bean
 	public ReleaseService releaseService(PackageMetadataRepository packageMetadataRepository,
-			ReleaseRepository releaseRepository,
-			PackageService packageService,
-			ReleaseManager releaseManager,
-			DeployerRepository deployerRepository,
+			ReleaseRepository releaseRepository, PackageService packageService,
+			ReleaseManagerFactory releaseManagerFactory, DeployerRepository deployerRepository,
 			PackageMetadataService packageMetadataService) {
-		return new ReleaseService(packageMetadataRepository, releaseRepository,
-				packageService, releaseManager, deployerRepository, packageMetadataService);
+		return new ReleaseService(packageMetadataRepository, releaseRepository, packageService, releaseManagerFactory,
+				deployerRepository, packageMetadataService);
 	}
 
 	@Bean
 	@ConditionalOnProperty(prefix = "spring.cloud.skipper.server", name = "enableReleaseStateUpdateService", matchIfMissing = true)
-	public ReleaseStateUpdateService releaseStateUpdateService(ReleaseManager releaseManager,
+	public ReleaseStateUpdateService releaseStateUpdateService(ReleaseManagerFactory releaseManagerFactory,
 			ReleaseRepository releaseRepository) {
-		return new ReleaseStateUpdateService(releaseManager, releaseRepository);
+		return new ReleaseStateUpdateService(releaseManagerFactory, releaseRepository);
 	}
 
 	@Bean
@@ -239,26 +252,9 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 			DeployerRepository deployerRepository,
 			ReleaseAnalyzer releaseAnalyzer,
 			AppDeploymentRequestFactory appDeploymentRequestFactory,
-			SpringCloudDeployerApplicationManifestReader applicationManifestReader,
-			CFApplicationManifestReader cfApplicationManifestReader,
-			PlatformCloudFoundryOperations platformCloudFoundryOperations,
-			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+			SpringCloudDeployerApplicationManifestReader applicationManifestReader) {
 		return new DefaultReleaseManager(releaseRepository, appDeployerDataRepository, deployerRepository,
-				releaseAnalyzer, appDeploymentRequestFactory, applicationManifestReader, cfApplicationManifestReader,
-				platformCloudFoundryOperations, cfManifestApplicationDeployer);
-	}
-
-	@Bean
-	public PlatformCloudFoundryOperations platformCloudFoundryOperations(CloudFoundryPlatformProperties cloudFoundryPlatformProperties) {
-		return new PlatformCloudFoundryOperations(cloudFoundryPlatformProperties);
-	}
-
-	@Bean
-	public CFManifestApplicationDeployer cfApplicationDeployer(CFApplicationManifestReader cfApplicationManifestReader,
-			PlatformCloudFoundryOperations platformCloudFoundryOperations,
-			DelegatingResourceLoader delegatingResourceLoader) {
-		return new CFManifestApplicationDeployer(cfApplicationManifestReader, platformCloudFoundryOperations,
-				delegatingResourceLoader);
+				releaseAnalyzer, appDeploymentRequestFactory, applicationManifestReader);
 	}
 
 	@Bean
@@ -267,17 +263,8 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 	}
 
 	@Bean
-	public CFApplicationManifestReader cfApplicationManifestReader() {
-		return new CFApplicationManifestReader();
-	}
-
-	@Bean
-	public DeleteStep deleteStep(ReleaseRepository releaseRepository,
-			DeployerRepository deployerRepository, SpringCloudDeployerApplicationManifestReader applicationManifestReader,
-			CFApplicationManifestReader cfApplicationManifestReader,
-			PlatformCloudFoundryOperations platformCloudFoundryOperations) {
-		return new DeleteStep(releaseRepository, deployerRepository, applicationManifestReader,
-				cfApplicationManifestReader, platformCloudFoundryOperations);
+	public DeleteStep deleteStep(ReleaseRepository releaseRepository, DeployerRepository deployerRepository) {
+		return new DeleteStep(releaseRepository, deployerRepository);
 	}
 
 	@Bean
@@ -291,34 +278,26 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 	@Bean
 	public HealthCheckStep healthCheckStep(AppDeployerDataRepository appDeployerDataRepository,
 			DeployerRepository deployerRepository,
-			SpringCloudDeployerApplicationManifestReader applicationManifestReader,
-			CFApplicationManifestReader cfApplicationManifestReader,
-			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+			SpringCloudDeployerApplicationManifestReader applicationManifestReader) {
 		return new HealthCheckStep(appDeployerDataRepository, deployerRepository,
-				applicationManifestReader, cfApplicationManifestReader, cfManifestApplicationDeployer);
+				applicationManifestReader/* , cfApplicationManifestReader, cfManifestApplicationDeployer */);
 	}
 
 	@Bean
-	public DeployAppStep DeployAppStep(DeployerRepository deployerRepository, AppDeploymentRequestFactory appDeploymentRequestFactory,
+	public DeployAppStep DeployAppStep(DeployerRepository deployerRepository,
+			AppDeploymentRequestFactory appDeploymentRequestFactory,
 			AppDeployerDataRepository appDeployerDataRepository, ReleaseRepository releaseRepository,
-			SpringCloudDeployerApplicationManifestReader applicationManifestReader,
-			CFApplicationManifestReader cfApplicationManifestReader,
-			PlatformCloudFoundryOperations platformCloudFoundryOperations,
-			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+			SpringCloudDeployerApplicationManifestReader applicationManifestReader) {
 		return new DeployAppStep(deployerRepository, appDeploymentRequestFactory, appDeployerDataRepository,
-				releaseRepository, applicationManifestReader, cfApplicationManifestReader, platformCloudFoundryOperations,
-				cfManifestApplicationDeployer);
+				releaseRepository, applicationManifestReader);
 	}
 
 	@Bean
 	public HandleHealthCheckStep healthCheckAndDeleteStep(ReleaseRepository releaseRepository,
-			AppDeployerDataRepository appDeployerDataRepository,
-			DeleteStep deleteStep,
-			ReleaseManager releaseManager) {
-		return new HandleHealthCheckStep(releaseRepository,
-				appDeployerDataRepository,
-				deleteStep,
-				releaseManager);
+			AppDeployerDataRepository appDeployerDataRepository, DeleteStep deleteStep,
+			ReleaseManagerFactory releaseManagerFactory) {
+		return new HandleHealthCheckStep(releaseRepository, appDeployerDataRepository, deleteStep,
+				releaseManagerFactory);
 	}
 
 	@Bean(name = SKIPPER_EXECUTOR)
@@ -340,11 +319,8 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 	@Bean
 	public ReleaseAnalyzer releaseAnalysisService(
 			SpringCloudDeployerApplicationManifestReader applicationManifestReader,
-			CFApplicationManifestReader cfApplicationManifestReader,
-			DelegatingResourceLoader delegatingResourceLoader,
-			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
-		return new ReleaseAnalyzer(applicationManifestReader , cfApplicationManifestReader, delegatingResourceLoader,
-				cfManifestApplicationDeployer);
+			DelegatingResourceLoader delegatingResourceLoader) {
+		return new ReleaseAnalyzer(applicationManifestReader, delegatingResourceLoader);
 	}
 
 	@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManagerFactory.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManagerFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.cloud.skipper.SkipperException;
+
+/**
+ * Default implementation of a {@link ReleaseManagerFactory} returning
+ * instances from a context.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultReleaseManagerFactory implements ReleaseManagerFactory {
+
+	private final Map<String, ReleaseManager> managers = new HashMap<>();
+	
+	public DefaultReleaseManagerFactory(List<ReleaseManager> managers) {
+		if (managers != null) {
+			for (ReleaseManager manager : managers) {
+				for (String kind : manager.getSupportedKinds()) {
+					this.managers.put(kind, manager);
+				}
+			}
+		}
+	}
+
+	@Override
+	public ReleaseManager getReleaseManager(String kind) {
+		ReleaseManager manager = managers.get(kind);
+		if (manager != null) {
+			return manager;
+		}
+		throw new SkipperException("No release manager available for '" + kind + "'");
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalyzer.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,22 +17,18 @@ package org.springframework.cloud.skipper.server.deployer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.cloudfoundry.operations.applications.ApplicationManifest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
 import org.springframework.cloud.skipper.SkipperException;
-import org.springframework.cloud.skipper.domain.CFApplicationManifestReader;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifest;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.cloud.skipper.domain.deployer.ApplicationManifestDifference;
 import org.springframework.cloud.skipper.domain.deployer.ReleaseDifference;
-import org.springframework.cloud.skipper.support.PropertiesDiff;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 
@@ -49,23 +45,14 @@ import org.springframework.util.StringUtils;
 public class ReleaseAnalyzer {
 
 	private final SpringCloudDeployerApplicationManifestReader applicationManifestReader;
-
-	private final CFApplicationManifestReader cfApplicationManifestReader;
-
 	private final Logger logger = LoggerFactory.getLogger(ReleaseAnalyzer.class);
 	private final DelegatingResourceLoader delegatingResourceLoader;
 	private ApplicationManifestDifferenceFactory applicationManifestDifferenceFactory = new ApplicationManifestDifferenceFactory();
 
-	private final CFManifestApplicationDeployer cfManifestApplicationDeployer;
-
 	public ReleaseAnalyzer(SpringCloudDeployerApplicationManifestReader applicationManifestReader,
-			CFApplicationManifestReader cfApplicationManifestReader,
-			DelegatingResourceLoader delegatingResourceLoader,
-			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+			DelegatingResourceLoader delegatingResourceLoader) {
 		this.applicationManifestReader = applicationManifestReader;
-		this.cfApplicationManifestReader = cfApplicationManifestReader;
 		this.delegatingResourceLoader = delegatingResourceLoader;
-		this.cfManifestApplicationDeployer = cfManifestApplicationDeployer;
 	}
 
 	/**
@@ -77,55 +64,37 @@ public class ReleaseAnalyzer {
 	 * @return an analysis report describing the changes to make, if any.
 	 */
 	public ReleaseAnalysisReport analyze(Release existingRelease, Release replacingRelease) {
-		if (this.applicationManifestReader.canSupport(existingRelease.getManifest().getData())) {
-			// For now, assume single package with no deps or package with same number of deps
-			List<? extends SpringCloudDeployerApplicationManifest> existingApplicationSpecList = this.applicationManifestReader
-					.read(existingRelease.getManifest().getData());
-			List<? extends SpringCloudDeployerApplicationManifest> replacingApplicationSpecList = this.applicationManifestReader
-					.read(replacingRelease.getManifest().getData());
-			if (existingRelease.getPkg().getDependencies().size() == replacingRelease.getPkg().getDependencies()
-					.size()) {
-				if (existingRelease.getPkg().getDependencies().size() == 0) {
-					logger.info("Existing Package and Upgrade Package both have no dependent packages.");
-					return analyzeTopLevelPackagesOnly(existingApplicationSpecList,
+		// For now, assume single package with no deps or package with same number of deps
+		List<? extends SpringCloudDeployerApplicationManifest> existingApplicationSpecList = this.applicationManifestReader
+				.read(existingRelease.getManifest().getData());
+		List<? extends SpringCloudDeployerApplicationManifest> replacingApplicationSpecList = this.applicationManifestReader
+				.read(replacingRelease.getManifest().getData());
+		if (existingRelease.getPkg().getDependencies().size() == replacingRelease.getPkg().getDependencies()
+				.size()) {
+			if (existingRelease.getPkg().getDependencies().size() == 0) {
+				logger.info("Existing Package and Upgrade Package both have no dependent packages.");
+				return analyzeTopLevelPackagesOnly(existingApplicationSpecList,
+						replacingApplicationSpecList,
+						existingRelease, replacingRelease);
+			}
+			else {
+				if (existingRelease.getPkg().getTemplates().size() == 0 &&
+						replacingRelease.getPkg().getTemplates().size() == 0) {
+					logger.info("Existing Package and Upgrade package both have no top level templates");
+					return analyzeDependentPackagesOnly(existingApplicationSpecList,
 							replacingApplicationSpecList,
 							existingRelease, replacingRelease);
 				}
 				else {
-					if (existingRelease.getPkg().getTemplates().size() == 0 &&
-							replacingRelease.getPkg().getTemplates().size() == 0) {
-						logger.info("Existing Package and Upgrade package both have no top level templates");
-						return analyzeDependentPackagesOnly(existingApplicationSpecList,
-								replacingApplicationSpecList,
-								existingRelease, replacingRelease);
-					}
-					else {
-						throw new SkipperException(
-								"Can not yet compare package with top level templates and dependencies");
-					}
+					throw new SkipperException(
+							"Can not yet compare package with top level templates and dependencies");
 				}
 			}
-			else {
-				throw new SkipperException(
-						"Can not yet compare existing package and to be released packages with different sizes.");
-			}
 		}
-		else if ((this.cfApplicationManifestReader.canSupport(existingRelease.getManifest().getData()))) {
-			List<ApplicationManifestDifference> applicationManifestDifferences = new ArrayList<>();
-			ApplicationManifest existingApplicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(existingRelease);
-			ApplicationManifest replacingApplicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(replacingRelease);
-			if (!existingApplicationManifest.equals(replacingApplicationManifest)) {
-				Map<String, String> existingMap = CFApplicationManifestUtils.getCFManifestMap(existingApplicationManifest);
-				Map<String, String> replacingMap = CFApplicationManifestUtils.getCFManifestMap(replacingApplicationManifest);
-				PropertiesDiff emptyPropertiesDiff = PropertiesDiff.builder().build();
-				PropertiesDiff propertiesDiff = PropertiesDiff.builder().left(existingMap).right(replacingMap).build();
-				ApplicationManifestDifference applicationManifestDifference = new ApplicationManifestDifference(existingApplicationManifest.getName(),
-						emptyPropertiesDiff, emptyPropertiesDiff, emptyPropertiesDiff, propertiesDiff, emptyPropertiesDiff);
-				applicationManifestDifferences.add(applicationManifestDifference);
-			}
-			return createReleaseAnalysisReport(existingRelease, replacingRelease, applicationManifestDifferences);
+		else {
+			throw new SkipperException(
+					"Can not yet compare existing package and to be released packages with different sizes.");
 		}
-		return null;
 	}
 
 	private ReleaseAnalysisReport analyzeDependentPackagesOnly(

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.skipper.server.deployer;
 
+import java.util.Collection;
+
 import org.springframework.cloud.skipper.domain.Release;
 
 /**
@@ -28,6 +30,13 @@ import org.springframework.cloud.skipper.domain.Release;
  */
 public interface ReleaseManager {
 
+	/**
+	 * Return a supported application kinds.
+	 * 
+	 * @return supported application kinds
+	 */
+	Collection<String> getSupportedKinds();
+	
 	/**
 	 * Install the requested release.
 	 * @param release the requested release

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManagerFactory.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManagerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer;
+
+/**
+ * Interface resolving {@link ReleaseManager} for an {@code application kind}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public interface ReleaseManagerFactory {
+
+	/**
+	 * Resolve {@link ReleaseManager} for an {@code application kind}.
+	 * 
+	 * @param kind the application kind
+	 * @return the resolved released manager
+	 */
+	ReleaseManager getReleaseManager(String kind);
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DefaultUpgradeStrategyFactory.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DefaultUpgradeStrategyFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer.strategies;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.cloud.skipper.SkipperException;
+
+/**
+ * Default implementation of a {@link UpgradeStrategyFactory} returning
+ * instances from a context.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultUpgradeStrategyFactory implements UpgradeStrategyFactory {
+
+	private final Map<String, UpgradeStrategy> strategies = new HashMap<>();
+	
+	public DefaultUpgradeStrategyFactory(List<UpgradeStrategy> strategies) {
+		if (strategies != null) {
+			for (UpgradeStrategy strategy : strategies) {
+				for (String kind : strategy.getSupportedKinds()) {
+					this.strategies.put(kind, strategy);
+				}
+			}
+		}
+	}
+
+	@Override
+	public UpgradeStrategy getUpgradeStrategy(String kind) {
+		UpgradeStrategy strategy = strategies.get(kind);
+		if (strategy != null) {
+			return strategy;
+		}
+		throw new SkipperException("No update strategy available for '" + kind + "'");
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeployAppStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeployAppStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,32 +20,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.cloudfoundry.operations.applications.ApplicationManifest;
-import org.cloudfoundry.operations.applications.PushApplicationManifestRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
-import org.springframework.cloud.skipper.deployer.cloudfoundry.PlatformCloudFoundryOperations;
-import org.springframework.cloud.skipper.domain.CFApplicationManifestReader;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifest;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.cloud.skipper.domain.Status;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
-import org.springframework.cloud.skipper.server.deployer.CFManifestApplicationDeployer;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.domain.AppDeployerData;
 import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
 import org.springframework.cloud.skipper.server.repository.DeployerRepository;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
-import org.springframework.cloud.skipper.server.util.ArgumentSanitizer;
 import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.springframework.cloud.skipper.server.deployer.CFManifestApplicationDeployer.isNotFoundError;
 
 /**
  * Responsible for taking the ReleaseAnalysisReport and deploying the apps in the
@@ -55,8 +44,6 @@ import static org.springframework.cloud.skipper.server.deployer.CFManifestApplic
  * @author Ilayaperumal Gopinathan
  */
 public class DeployAppStep {
-
-	private static final Logger logger = LoggerFactory.getLogger(DeployAppStep.class);
 
 	private final DeployerRepository deployerRepository;
 
@@ -68,26 +55,14 @@ public class DeployAppStep {
 
 	private final SpringCloudDeployerApplicationManifestReader applicationManifestReader;
 
-	private final CFApplicationManifestReader cfApplicationManifestReader;
-
-	private final PlatformCloudFoundryOperations platformCloudFoundryOperations;
-
-	private final CFManifestApplicationDeployer cfManifestApplicationDeployer;
-
 	public DeployAppStep(DeployerRepository deployerRepository, AppDeploymentRequestFactory appDeploymentRequestFactory,
 			AppDeployerDataRepository appDeployerDataRepository, ReleaseRepository releaseRepository,
-			SpringCloudDeployerApplicationManifestReader applicationManifestReader,
-			CFApplicationManifestReader cfApplicationManifestReader,
-			PlatformCloudFoundryOperations platformCloudFoundryOperations,
-			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+			SpringCloudDeployerApplicationManifestReader applicationManifestReader) {
 		this.deployerRepository = deployerRepository;
 		this.appDeploymentRequestFactory = appDeploymentRequestFactory;
 		this.appDeployerDataRepository = appDeployerDataRepository;
 		this.releaseRepository = releaseRepository;
 		this.applicationManifestReader = applicationManifestReader;
-		this.cfApplicationManifestReader = cfApplicationManifestReader;
-		this.platformCloudFoundryOperations = platformCloudFoundryOperations;
-		this.cfManifestApplicationDeployer = cfManifestApplicationDeployer;
 	}
 
 	@Transactional
@@ -96,27 +71,21 @@ public class DeployAppStep {
 		List<String> applicationNamesToUpgrade = new ArrayList<>();
 		try {
 			applicationNamesToUpgrade = releaseAnalysisReport.getApplicationNamesToUpgrade();
-			String releaseManifest = replacingRelease.getManifest().getData();
-			if (this.applicationManifestReader.canSupport(releaseManifest)) {
-				AppDeployer appDeployer = this.deployerRepository.findByNameRequired(replacingRelease.getPlatformName())
-												.getAppDeployer();
+			AppDeployer appDeployer = this.deployerRepository.findByNameRequired(replacingRelease.getPlatformName())
+											.getAppDeployer();
 
-				// Deploy the application
-				Map<String, String> appNameDeploymentIdMap = deploy(replacingRelease, applicationNamesToUpgrade,
-						appDeployer);
+			// Deploy the application
+			Map<String, String> appNameDeploymentIdMap = deploy(replacingRelease, applicationNamesToUpgrade,
+					appDeployer);
 
-				// Carry over the applicationDeployment information for apps that were not updated.
-				carryOverAppDeploymentIds(existingRelease, appNameDeploymentIdMap);
+			// Carry over the applicationDeployment information for apps that were not updated.
+			carryOverAppDeploymentIds(existingRelease, appNameDeploymentIdMap);
 
-				AppDeployerData appDeployerData = new AppDeployerData();
-				appDeployerData.setReleaseName(replacingRelease.getName());
-				appDeployerData.setReleaseVersion(replacingRelease.getVersion());
-				appDeployerData.setDeploymentDataUsingMap(appNameDeploymentIdMap);
-				this.appDeployerDataRepository.save(appDeployerData);
-			}
-			else if (this.cfApplicationManifestReader.canSupport(releaseManifest)) {
-				deployCFApp(replacingRelease);
-			}
+			AppDeployerData appDeployerData = new AppDeployerData();
+			appDeployerData.setReleaseName(replacingRelease.getName());
+			appDeployerData.setReleaseVersion(replacingRelease.getVersion());
+			appDeployerData.setDeploymentDataUsingMap(appNameDeploymentIdMap);
+			this.appDeployerDataRepository.save(appDeployerData);
 		}
 		catch (DataAccessException e) {
 			throw e;
@@ -130,44 +99,6 @@ public class DeployAppStep {
 			this.releaseRepository.save(replacingRelease);
 		}
 		return applicationNamesToUpgrade;
-	}
-
-	private void deployCFApp(Release replacingRelease) {
-		ApplicationManifest applicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(replacingRelease);
-		logger.debug("Manifest = " + ArgumentSanitizer.sanitizeYml(replacingRelease.getManifest().getData()));
-		// Deploy the application
-		String applicationName = applicationManifest.getName();
-		Map<String, String> appDeploymentData = new HashMap<>();
-		appDeploymentData.put(applicationManifest.getName(), applicationManifest.toString());
-		this.platformCloudFoundryOperations.getCloudFoundryOperations(replacingRelease.getPlatformName())
-				.applications().pushManifest(
-				PushApplicationManifestRequest.builder()
-						.manifest(applicationManifest)
-						.stagingTimeout(CFManifestApplicationDeployer.STAGING_TIMEOUT)
-						.startupTimeout(CFManifestApplicationDeployer.STARTUP_TIMEOUT)
-						.build())
-				.doOnSuccess(v -> logger.info("Done uploading bits for {}", applicationName))
-				.doOnError(e -> logger.error(
-						String.format("Error creating app %s.  Exception Message %s", applicationName,
-								e.getMessage())))
-				.timeout(CFManifestApplicationDeployer.PUSH_REQUEST_TIMEOUT)
-				.doOnSuccess(item -> {
-					logger.info("Successfully deployed {}", applicationName);
-					AppDeployerData appDeployerData = new AppDeployerData();
-					appDeployerData.setReleaseName(replacingRelease.getName());
-					appDeployerData.setReleaseVersion(replacingRelease.getVersion());
-					appDeployerData.setDeploymentDataUsingMap(appDeploymentData);
-					this.appDeployerDataRepository.save(appDeployerData);
-				})
-				.doOnError(error -> {
-					if (isNotFoundError().test(error)) {
-						logger.warn("Unable to deploy application. It may have been destroyed before start completed: " + error.getMessage());
-					}
-					else {
-						logger.error(String.format("Failed to deploy %s", applicationName));
-					}
-				})
-				.block();
 	}
 
 	private void carryOverAppDeploymentIds(Release existingRelease, Map<String, String> appNameDeploymentIdMap) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckStep.java
@@ -23,10 +23,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
-import org.springframework.cloud.skipper.domain.CFApplicationManifestReader;
+//import org.springframework.cloud.skipper.deployer.cloudfoundry.CFManifestApplicationDeployer;
+//import org.springframework.cloud.skipper.domain.CFApplicationManifestReader;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifestReader;
-import org.springframework.cloud.skipper.server.deployer.CFManifestApplicationDeployer;
 import org.springframework.cloud.skipper.server.domain.AppDeployerData;
 import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
 import org.springframework.cloud.skipper.server.repository.DeployerRepository;
@@ -45,49 +45,28 @@ public class HealthCheckStep {
 
 	private final DeployerRepository deployerRepository;
 
-	private final SpringCloudDeployerApplicationManifestReader applicationManifestReader;
-
-	private final CFApplicationManifestReader cfApplicationManifestReader;
-
-	private final CFManifestApplicationDeployer cfManifestApplicationDeployer;
-
-	public HealthCheckStep(AppDeployerDataRepository appDeployerDataRepository,
-			DeployerRepository deployerRepository,
-			SpringCloudDeployerApplicationManifestReader applicationManifestReader,
-			CFApplicationManifestReader cfApplicationManifestReader,
-			CFManifestApplicationDeployer cfManifestApplicationDeployer) {
+	public HealthCheckStep(AppDeployerDataRepository appDeployerDataRepository, DeployerRepository deployerRepository,
+			SpringCloudDeployerApplicationManifestReader applicationManifestReader) {
 		this.appDeployerDataRepository = appDeployerDataRepository;
 		this.deployerRepository = deployerRepository;
-		this.applicationManifestReader = applicationManifestReader;
-		this.cfApplicationManifestReader = cfApplicationManifestReader;
-		this.cfManifestApplicationDeployer = cfManifestApplicationDeployer;
 	}
 
 	public boolean isHealthy(Release replacingRelease) {
-		String releaseManifest = replacingRelease.getManifest().getData();
-		if (this.applicationManifestReader.canSupport(releaseManifest)) {
-			AppDeployerData replacingAppDeployerData = this.appDeployerDataRepository
-					.findByReleaseNameAndReleaseVersionRequired(
-							replacingRelease.getName(), replacingRelease.getVersion());
-			Map<String, String> appNamesAndDeploymentIds = replacingAppDeployerData.getDeploymentDataAsMap();
-			AppDeployer appDeployer = this.deployerRepository
-					.findByNameRequired(replacingRelease.getPlatformName())
-					.getAppDeployer();
-			logger.debug("Getting status for apps in replacing release {}-v{}", replacingRelease.getName(),
-					replacingRelease.getVersion());
-			for (Map.Entry<String, String> appNameAndDeploymentId : appNamesAndDeploymentIds.entrySet()) {
-				AppStatus status = appDeployer.status(appNameAndDeploymentId.getValue());
-				if (status.getState() == DeploymentState.deployed) {
-					return true;
-				}
-			}
-		}
-		else if (this.cfApplicationManifestReader.canSupport(releaseManifest)) {
-			AppStatus appStatus = cfManifestApplicationDeployer.status(replacingRelease);
-			if (appStatus.getState() == DeploymentState.deployed) {
+		AppDeployerData replacingAppDeployerData = this.appDeployerDataRepository
+				.findByReleaseNameAndReleaseVersionRequired(
+						replacingRelease.getName(), replacingRelease.getVersion());
+		Map<String, String> appNamesAndDeploymentIds = replacingAppDeployerData.getDeploymentDataAsMap();
+		AppDeployer appDeployer = this.deployerRepository
+				.findByNameRequired(replacingRelease.getPlatformName())
+				.getAppDeployer();
+		logger.debug("Getting status for apps in replacing release {}-v{}", replacingRelease.getName(),
+				replacingRelease.getVersion());
+		for (Map.Entry<String, String> appNameAndDeploymentId : appNamesAndDeploymentIds.entrySet()) {
+			AppStatus status = appDeployer.status(appNameAndDeploymentId.getValue());
+			if (status.getState() == DeploymentState.deployed) {
 				return true;
 			}
 		}
-		return false;
+	return false;
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.skipper.server.deployer.strategies;
 
+import java.util.Collection;
+
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 
@@ -25,6 +27,8 @@ import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
  * @author Mark Pollack
  */
 public interface UpgradeStrategy {
+	
+	Collection<String> getSupportedKinds();
 
 	void deployApps(Release existingRelease, Release replacingRelease, ReleaseAnalysisReport releaseAnalysisReport);
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategyFactory.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/UpgradeStrategyFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer.strategies;
+
+/**
+ * Interface resolving {@link UpgradeStrategy} for an {@code application kind}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public interface UpgradeStrategyFactory {
+
+	/**
+	 * Resolve {@link UpgradeStrategy} for an {@code application kind}.
+	 * 
+	 * @param kind the application kind
+	 * @return the resolved upgrade strategy
+	 */
+	UpgradeStrategy getUpgradeStrategy(String kind);
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/InstallInstallAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/InstallInstallAction.java
@@ -47,7 +47,6 @@ public class InstallInstallAction extends AbstractAction {
 	 * Instantiates a new install install action.
 	 *
 	 * @param releaseService the release service
-	 * @param releaseRepository the release repository
 	 */
 	public InstallInstallAction(ReleaseService releaseService) {
 		super();

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/StateMachineConfiguration.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckProperties;
-import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategyFactory;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 import org.springframework.cloud.skipper.server.service.ReleaseReportService;
 import org.springframework.cloud.skipper.server.service.ReleaseService;
@@ -89,7 +89,7 @@ public class StateMachineConfiguration {
 		private ReleaseRepository releaseRepository;
 
 		@Autowired
-		private UpgradeStrategy upgradeStrategy;
+		private UpgradeStrategyFactory upgradeStrategyFactory;
 
 		@Autowired
 		private HealthCheckProperties healthCheckProperties;
@@ -333,12 +333,12 @@ public class StateMachineConfiguration {
 
 		@Bean
 		public UpgradeDeployTargetAppsAction upgradeDeployTargetAppsAction() {
-			return new UpgradeDeployTargetAppsAction(releaseReportService, upgradeStrategy, healthCheckProperties);
+			return new UpgradeDeployTargetAppsAction(releaseReportService, upgradeStrategyFactory, healthCheckProperties);
 		}
 
 		@Bean
 		public UpgradeCheckTargetAppsAction upgradeCheckTargetAppsAction() {
-			return new UpgradeCheckTargetAppsAction(releaseReportService, upgradeStrategy);
+			return new UpgradeCheckTargetAppsAction(releaseReportService, upgradeStrategyFactory);
 		}
 
 		@Bean
@@ -363,12 +363,12 @@ public class StateMachineConfiguration {
 
 		@Bean
 		public UpgradeCancelAction upgradeCancelAction() {
-			return new UpgradeCancelAction(releaseReportService, upgradeStrategy);
+			return new UpgradeCancelAction(releaseReportService, upgradeStrategyFactory);
 		}
 
 		@Bean
 		public UpgradeDeleteSourceAppsAction upgradeDeleteSourceAppsAction() {
-			return new UpgradeDeleteSourceAppsAction(releaseReportService, upgradeStrategy);
+			return new UpgradeDeleteSourceAppsAction(releaseReportService, upgradeStrategyFactory);
 		}
 
 		@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/util/ManifestUtils.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/util/ManifestUtils.java
@@ -32,6 +32,7 @@ import org.yaml.snakeyaml.representer.Representer;
 
 import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.domain.Template;
+import org.springframework.util.StringUtils;
 
 /**
  * Utility functions for manifest file processing.
@@ -49,6 +50,29 @@ public class ManifestUtils {
 	 */
 	private static final Pattern SINGLE_BACKSLASH = Pattern.compile("(?<!\\\\)(\\\\)(?![\\\\0abtnvfreN_LP\\s\"])");
 
+	/**
+	 * Resolve a kind from a raw manifest yaml.
+	 * 
+	 * @param manifest the raw yaml
+	 * @return the kind or {@code null} if not found
+	 */
+	public static String resolveKind(String manifest) {
+		if (!StringUtils.hasText(manifest)) {
+			return null;
+		}
+		Yaml yaml = new Yaml();
+		Iterable<Object> object = yaml.loadAll(manifest);
+		for (Object o : object) {
+			if (o != null && o instanceof Map) {
+				Object kind = ((Map<?, ?>)o).get("kind");
+				if (kind instanceof String) {
+					return (String)kind;
+				}
+			}
+		}
+		return null;
+	}
+	
 	/**
 	 * Iterate overall the template files, replacing placeholders with model values. One
 	 * string is returned that contain all the YAML of multiple files using YAML file

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.Manifest;
 import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
@@ -44,6 +45,7 @@ import org.springframework.cloud.skipper.server.deployer.strategies.HandleHealth
 import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckProperties;
 import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckStep;
 import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategyFactory;
 import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
 import org.springframework.cloud.skipper.server.service.PackageService;
 import org.springframework.cloud.skipper.server.service.ReleaseReportService;
@@ -109,6 +111,9 @@ public class StateMachineTests {
 
 	@MockBean
 	private UpgradeStrategy upgradeStrategy;
+
+	@MockBean
+	private UpgradeStrategyFactory upgradeStrategyFactory;
 
 	@MockBean
 	private DeployAppStep deployAppStep;
@@ -212,10 +217,14 @@ public class StateMachineTests {
 
 	@Test
 	public void testRestoreFromUpgradeUsingUpgradeRequest() throws Exception {
+		Manifest manifest = new Manifest();
+		Release release = new Release();
+		release.setManifest(manifest);
 		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), new Release(), new Release()));
+				new ReleaseDifference(), release, release));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(true);
+		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
 
 		DefaultExtendedState extendedState = new DefaultExtendedState();
 		extendedState.getVariables().put(SkipperEventHeaders.UPGRADE_REQUEST, new UpgradeRequest());
@@ -273,11 +282,15 @@ public class StateMachineTests {
 	}
 
 	@Test
-	public void testSimpleUpgradeShouldNotError() throws Exception {
+	public void testSimpleUpgradeShouldNotError() throws Exception {		
+		Manifest manifest = new Manifest();
+		Release release = new Release();
+		release.setManifest(manifest);
 		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), new Release(), new Release()));
+				new ReleaseDifference(), release, release));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(true);
+		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
 
 		UpgradeRequest upgradeRequest = new UpgradeRequest();
 
@@ -310,10 +323,14 @@ public class StateMachineTests {
 
 	@Test
 	public void testUpgradeFailsNewAppFailToDeploy() throws Exception {
+		Manifest manifest = new Manifest();
+		Release release = new Release();
+		release.setManifest(manifest);
 		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), new Release(), new Release()));
+				new ReleaseDifference(), release, release));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);
+		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
 
 		UpgradeRequest upgradeRequest = new UpgradeRequest();
 
@@ -358,10 +375,14 @@ public class StateMachineTests {
 
 	@Test
 	public void testUpgradeCancelWhileCheckingApps() throws Exception {
+		Manifest manifest = new Manifest();
+		Release release = new Release();
+		release.setManifest(manifest);
 		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), new Release(), new Release()));
+				new ReleaseDifference(), release, release));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);
+		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
 
 		UpgradeRequest upgradeRequest = new UpgradeRequest();
 
@@ -552,10 +573,14 @@ public class StateMachineTests {
 
 	@Test
 	public void testInstallDeniedWhileUpgrading() throws Exception {
+		Manifest manifest = new Manifest();
+		Release release = new Release();
+		release.setManifest(manifest);
 		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), new Release(), new Release()));
+				new ReleaseDifference(), release, release));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);
+		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
 
 		UpgradeRequest upgradeRequest = new UpgradeRequest();
 


### PR DESCRIPTION
- spring-cloud-skipper-platform-kubernetes now depends
  on spring-cloud-skipper-server-core.
- New interfaces ReleaseManagerFactory and UpgradeStrategyFactory
  which can return particular instances per application kind, which
  then allows to move cf manifest classes out from server core
  to cf platform package.
- Rest of the changes are pretty much refactoring and moving
  stuff around.
- Fixes #629