### PR TITLE
Handle deletion of release that is being installed

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -163,6 +163,7 @@ public class ReleaseService {
 		}
 	}
 
+	@Transactional
 	protected Release install(PackageMetadata packageMetadata, InstallProperties installProperties) {
 		Assert.notNull(packageMetadata, "Can't download package, PackageMetadata is a null value.");
 		Release existingDeletedRelease = this.releaseRepository
@@ -182,6 +183,7 @@ public class ReleaseService {
 		return install(release);
 	}
 
+	@Transactional
 	public Release install(Release release) {
 		Map<String, Object> mergedMap = ConfigValueUtils.mergeConfigValues(release.getPkg(), release.getConfigValues());
 		// Render yaml resources


### PR DESCRIPTION
 - If the deletion of release request is sent while the release is being installed, the deletion has to wait until the state changes.
This will make sure we update the deletion correctly.

Resolves #669