### PR TITLE
Doc generation using wiremocks

### DIFF
--- a/spring-cloud-skipper-docs/pom.xml
+++ b/spring-cloud-skipper-docs/pom.xml
@@ -20,11 +20,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.restdocs</groupId>
-			<artifactId>spring-restdocs-mockmvc</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.restdocs</groupId>
 			<artifactId>spring-restdocs-core</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -204,9 +204,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <includes>
-                        <include>**/*Documentation.java</include>
                         <include>**/*Tests.java</include>
                     </includes>
+                    <excludes>
+                        <exclude>**/*Documentation.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ApiDocumentation.java
@@ -20,6 +20,8 @@ import javax.servlet.RequestDispatcher;
 
 import org.junit.Test;
 
+import org.springframework.test.context.ActiveProfiles;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -36,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
  */
+@ActiveProfiles("repository")
 public class ApiDocumentation extends BaseDocumentation {
 
 	@Test
@@ -86,6 +89,5 @@ public class ApiDocumentation extends BaseDocumentation {
 				linkWithRel("about").description("Provides meta information about the server."),
 				linkWithRel("release").description("Exposes the release resource."),
 				linkWithRel("package").description("Exposes the package resource."))));
-
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/CancelDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/CancelDocumentation.java
@@ -16,30 +16,30 @@
 
 package org.springframework.cloud.skipper.server.controller.docs;
 
+import java.nio.charset.Charset;
+
+import org.junit.Test;
+
+import org.springframework.cloud.skipper.domain.CancelRequest;
+import org.springframework.http.MediaType;
+
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.nio.charset.Charset;
-
-import org.junit.Test;
-import org.springframework.cloud.skipper.domain.CancelRequest;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-
 /**
  * @author Janne Valkealahti
  */
-@ActiveProfiles("repo-test")
 public class CancelDocumentation extends BaseDocumentation {
 
 	@Test
 	public void cancelRelease() throws Exception {
 		final String releaseName = "myLogRelease";
-		install("testapp", "1.0.0", releaseName);
-		upgrade("testapp", "1.1.0", releaseName, false);
+
+		when(this.skipperStateMachineService.cancelRelease(releaseName)).thenReturn(Boolean.TRUE);
 
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -20,21 +20,15 @@ import java.nio.charset.Charset;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageIdentifier;
+import org.springframework.cloud.skipper.domain.DeleteProperties;
+import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
-import org.springframework.cloud.skipper.domain.UploadRequest;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.util.Assert;
-import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
@@ -45,46 +39,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
  */
-@ActiveProfiles("repo-test")
 public class DeleteDocumentation extends BaseDocumentation {
 
 	@Test
 	public void deleteRelease() throws Exception {
-		final UploadRequest uploadProperties = new UploadRequest();
-		uploadProperties.setRepoName("local");
-		uploadProperties.setName("mylog");
-		uploadProperties.setVersion("9.9.9");
-		uploadProperties.setExtension("zip");
-		final Resource resource = new ClassPathResource(
-				"/org/springframework/cloud/skipper/server/service/mylog-9.9.9.zip");
-		assertThat(resource.exists()).isTrue();
-		final byte[] originalPackageBytes = StreamUtils.copyToByteArray(resource.getInputStream());
-		assertThat(originalPackageBytes).isNotEmpty();
-		Assert.isTrue(originalPackageBytes.length != 0,
-				"PackageServiceTests.Assert.isTrue: Package file as bytes must not be empty");
-		uploadProperties.setPackageFileAsBytes(originalPackageBytes);
-
-		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
-				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
-
-		mockMvc.perform(post("/api/package/upload").accept(MediaType.APPLICATION_JSON).contentType(contentType)
-								.content(convertObjectToJson(uploadProperties))).andDo(print())
-				.andExpect(status().isCreated());
-
-		final String releaseName = "myLogRelease";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("mylog");
-		packageIdentifier.setPackageVersion("9.9.9");
-		packageIdentifier.setRepositoryName("local");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		installPackage(installRequest);
-
+		Release release = createTestRelease("test", StatusCode.DELETED);
+		when(this.skipperStateMachineService.deleteRelease(any(String.class), any(DeleteProperties.class))).thenReturn(release);
 		this.mockMvc.perform(
-				delete("/api/release/{releaseName}/package", releaseName)
-						.accept(MediaType.APPLICATION_JSON).contentType(contentType))
+				delete("/api/release/{releaseName}/package", release.getName())
+						.accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
@@ -145,22 +108,13 @@ public class DeleteDocumentation extends BaseDocumentation {
 
 	@Test
 	public void deleteReleaseDefault() throws Exception {
-		final String releaseName = "myLogRelease1";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		installPackage(installRequest);
-
+		Release release = createTestRelease("test", StatusCode.DELETED);
+		when(this.skipperStateMachineService.deleteRelease(any(String.class), any(DeleteProperties.class))).thenReturn(release);
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
 		this.mockMvc.perform(
-				delete("/api/release/{releaseName}", releaseName)
+				delete("/api/release/{releaseName}", "test")
 						.accept(MediaType.APPLICATION_JSON).contentType(contentType))
 				.andDo(print())
 				.andExpect(status().isOk())

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Gunnar Hillert
  */
-@ActiveProfiles("repo-test")
+@ActiveProfiles("repository")
 public class DeployersDocumentation extends BaseDocumentation {
 
 	@Test

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DocumentationTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DocumentationTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.controller.docs;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Documentation tests suite.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({AboutDocumentation.class, InstallDocumentation.class, ListDocumentation.class, CancelDocumentation.class, DeleteDocumentation.class, HistoryDocumentation.class, ManifestDocumentation.class,
+		RollbackDocumentation.class, StatusDocumentation.class, UpgradeDocumentation.class, UploadDocumentation.class})
+public class DocumentationTests {
+
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
@@ -19,8 +19,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.StringUtils;
@@ -34,25 +32,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
-@ActiveProfiles("repo-test")
+@ActiveProfiles("repository")
 public class HistoryDocumentation extends BaseDocumentation {
 
 	@Test
 	public void showVersionHistoryForRelease() throws Exception {
-		final String releaseName = "myLogRelease";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		installPackage(installRequest);
+		this.releaseRepository.save(createTestRelease());
 
 		this.mockMvc.perform(
-				get("/api/releases/search/findByNameIgnoreCaseContainingOrderByNameAscVersionDesc?name={name}", releaseName)).andDo(print())
+				get("/api/releases/search/findByNameIgnoreCaseContainingOrderByNameAscVersionDesc?name={name}", "test")).andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						responseFields(

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
@@ -16,15 +16,16 @@
 
 package org.springframework.cloud.skipper.server.controller.docs;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageIdentifier;
+import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.StringUtils;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -34,24 +35,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
-@ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
 public class ListDocumentation extends BaseDocumentation {
 
 	@Test
 	public void listRelease() throws Exception {
-		final String releaseName = "myLogRelease";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		installPackage(installRequest);
-
+		List<Release> releaseList = new ArrayList<>();
+		releaseList.add(createTestRelease());
+		when(this.releaseService.list()).thenReturn(releaseList);
 		this.mockMvc.perform(
 				get("/api/release/list")).andDo(print())
 				.andExpect(status().isOk())
@@ -117,19 +109,12 @@ public class ListDocumentation extends BaseDocumentation {
 
 	@Test
 	public void listReleasesByReleaseName() throws Exception {
-		final String releaseName = "myLogRelease2";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		installPackage(installRequest);
-
+		Release release = createTestRelease();
+		List<Release> releaseList = new ArrayList<>();
+		releaseList.add(release);
+		when(this.releaseService.list(release.getName())).thenReturn(releaseList);
 		this.mockMvc.perform(
-				get("/api/release/list/{releaseName}", releaseName)).andDo(print())
+				get("/api/release/list/{releaseName}", release.getName())).andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
 						responseFields(

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ManifestDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ManifestDocumentation.java
@@ -20,13 +20,10 @@ import java.nio.charset.Charset;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseBody;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -34,24 +31,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
-@ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
 public class ManifestDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getManifestOfRelease() throws Exception {
-		final String releaseName = "myLogRelease";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		final Release release = installPackage(installRequest);
-
+		Release release = createTestRelease();
+		when(this.releaseService.manifest(release.getName())).thenReturn(release.getManifest());
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
@@ -66,16 +53,9 @@ public class ManifestDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getManifestOfReleaseForVersion() throws Exception {
-		final String releaseName = "myLogRelease2";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
+		Release release = createTestRelease();
 
-		final Release release = installPackage(installRequest);
+		when(this.releaseService.manifest(release.getName(), 1)).thenReturn(release.getManifest());
 
 		this.mockMvc.perform(
 				get("/api/release/manifest/{releaseName}/{releaseVersion}",

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/PackageMetadataDocumentation.java
@@ -18,6 +18,12 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
+import org.springframework.cloud.skipper.domain.Package;
+import org.springframework.cloud.skipper.domain.PackageMetadata;
+import org.springframework.cloud.skipper.io.DefaultPackageReader;
+import org.springframework.cloud.skipper.io.PackageReader;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -33,11 +39,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gunnar Hillert
  * @author Ilayaperumal Gopinathan
  */
-@ActiveProfiles("repo-test")
+@ActiveProfiles("repository")
 public class PackageMetadataDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getAllPackageMetadata() throws Exception {
+		Resource resource = new ClassPathResource("/repositories/sources/test/log/log-1.0.0");
+		PackageReader packageReader = new DefaultPackageReader();
+		Package pkg = packageReader.read(resource.getFile());
+		PackageMetadata packageMetadata = pkg.getMetadata();
+		packageMetadata.setRepositoryName("local");
+		packageMetadata.setRepositoryId(this.repositoryRepository.findByName("local").getId());
+		PackageMetadata saved = this.packageMetadataRepository.save(pkg.getMetadata());
 		this.mockMvc.perform(
 				get("/api/packageMetadata")
 						.param("page", "0")
@@ -89,10 +102,15 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getPackageMetadataDetails() throws Exception {
-		install("log", "1.0.0", "test2");
-
+		Resource resource = new ClassPathResource("/repositories/sources/test/log/log-1.0.0");
+		PackageReader packageReader = new DefaultPackageReader();
+		Package pkg = packageReader.read(resource.getFile());
+		PackageMetadata packageMetadata = pkg.getMetadata();
+		packageMetadata.setRepositoryName("local");
+		packageMetadata.setRepositoryId(this.repositoryRepository.findByName("local").getId());
+		PackageMetadata saved = this.packageMetadataRepository.save(pkg.getMetadata());
 		this.mockMvc.perform(
-				get("/api/packageMetadata/{packageMetadataId}", 1))
+				get("/api/packageMetadata/{packageMetadataId}", saved.getId()))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document(
@@ -129,6 +147,13 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getPackageMetadataSearchFindByName() throws Exception {
+		Resource resource = new ClassPathResource("/repositories/sources/test/log/log-1.0.0");
+		PackageReader packageReader = new DefaultPackageReader();
+		Package pkg = packageReader.read(resource.getFile());
+		PackageMetadata packageMetadata = pkg.getMetadata();
+		packageMetadata.setRepositoryName("local");
+		packageMetadata.setRepositoryId(this.repositoryRepository.findByName("local").getId());
+		PackageMetadata saved = this.packageMetadataRepository.save(pkg.getMetadata());
 		this.mockMvc.perform(
 				get("/api/packageMetadata/search/findByName?name=log"))
 				.andDo(print())
@@ -167,6 +192,13 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getPackageMetadataSearchFindByNameContainingIgnoreCase() throws Exception {
+		Resource resource = new ClassPathResource("/repositories/sources/test/log/log-1.0.0");
+		PackageReader packageReader = new DefaultPackageReader();
+		Package pkg = packageReader.read(resource.getFile());
+		PackageMetadata packageMetadata = pkg.getMetadata();
+		packageMetadata.setRepositoryName("local");
+		packageMetadata.setRepositoryId(this.repositoryRepository.findByName("local").getId());
+		PackageMetadata saved = this.packageMetadataRepository.save(pkg.getMetadata());
 		this.mockMvc.perform(
 				get("/api/packageMetadata/search/findByNameContainingIgnoreCase?name=LO"))
 				.andDo(print())
@@ -213,6 +245,13 @@ public class PackageMetadataDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getPackageMetadataSummary() throws Exception {
+		Resource resource = new ClassPathResource("/repositories/sources/test/log/log-1.0.0");
+		PackageReader packageReader = new DefaultPackageReader();
+		Package pkg = packageReader.read(resource.getFile());
+		PackageMetadata packageMetadata = pkg.getMetadata();
+		packageMetadata.setRepositoryName("local");
+		packageMetadata.setRepositoryId(this.repositoryRepository.findByName("local").getId());
+		PackageMetadata saved = this.packageMetadataRepository.save(pkg.getMetadata());
 		this.mockMvc.perform(
 				get("/api/packageMetadata?projection=summary"))
 				.andDo(print())

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
@@ -18,9 +18,6 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageIdentifier;
-import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.StringUtils;
@@ -33,23 +30,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
-@ActiveProfiles("repo-test")
+@ActiveProfiles("repository")
 public class ReleasesDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getAllReleases() throws Exception {
-		final String releaseName = "myLogRelease";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		final Release release = installPackage(installRequest);
-
+		this.releaseRepository.save(createTestRelease());
 		this.mockMvc.perform(
 				get("/api/releases")
 						.param("page", "0")

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoriesDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoriesDocumentation.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Gunnar Hillert
  */
-@ActiveProfiles("repo-test")
+@ActiveProfiles({"repository"})
 public class RepositoriesDocumentation extends BaseDocumentation {
 
 	@Test

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoryConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoryConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.controller.docs;
+
+import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
+import org.springframework.cloud.skipper.server.repository.DeployerRepository;
+import org.springframework.cloud.skipper.server.repository.PackageMetadataRepository;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.cloud.skipper.server.repository.RepositoryRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.map.repository.config.EnableMapRepositories;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Configuration class for repositories.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@Configuration
+public class RepositoryConfiguration {
+
+	@Configuration
+	@Profile("!repository")
+	public class RepositoryMocks {
+		@Bean
+		public RepositoryRepository repositoryRepository() {
+			return mock(RepositoryRepository.class);
+		}
+
+		@Bean
+		public PackageMetadataRepository packageMetadataRepository() {
+			return mock(PackageMetadataRepository.class);
+		}
+
+		@Bean
+		public ReleaseRepository releaseRepository() {
+			return mock(ReleaseRepository.class);
+		}
+
+		@Bean
+		public DeployerRepository deployerRepository() {
+			return mock(DeployerRepository.class);
+		}
+
+		@Bean
+		public AppDeployerDataRepository appDeployerDataRepository() {
+			return mock(AppDeployerDataRepository.class);
+		}
+	}
+
+	@Configuration
+	@EnableMapRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
+	@EnableJpaRepositories(basePackages = "org.springframework.cloud.skipper.server.repository")
+	@Profile("repository")
+	public class JPARepositoryConfiguration {
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoryDocumentationTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RepositoryDocumentationTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.controller.docs;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Repository based documentation tests suite.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({ApiDocumentation.class, DeployersDocumentation.class,
+		PackageMetadataDocumentation.class, RepositoriesDocumentation.class, ReleasesDocumentation.class})
+public class RepositoryDocumentationTests {
+
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ServerDependencies.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ServerDependencies.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.controller.docs;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ErrorAttributes;
+import org.springframework.boot.autoconfigure.web.ErrorMvcAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.common.security.AuthorizationProperties;
+import org.springframework.cloud.common.security.support.SecurityStateBean;
+import org.springframework.cloud.deployer.resource.docker.DockerResourceLoader;
+import org.springframework.cloud.deployer.resource.maven.MavenProperties;
+import org.springframework.cloud.deployer.resource.maven.MavenResourceLoader;
+import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
+import org.springframework.cloud.deployer.resource.support.LRUCleaningResourceLoaderBeanPostProcessor;
+import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifestReader;
+import org.springframework.cloud.skipper.io.DefaultPackageReader;
+import org.springframework.cloud.skipper.io.DefaultPackageWriter;
+import org.springframework.cloud.skipper.io.PackageReader;
+import org.springframework.cloud.skipper.io.PackageWriter;
+import org.springframework.cloud.skipper.server.config.LocalPlatformProperties;
+import org.springframework.cloud.skipper.server.config.MavenConfigurationProperties;
+import org.springframework.cloud.skipper.server.config.SkipperServerConfiguration;
+import org.springframework.cloud.skipper.server.config.SkipperServerPlatformConfiguration;
+import org.springframework.cloud.skipper.server.config.SkipperServerProperties;
+import org.springframework.cloud.skipper.server.controller.AboutController;
+import org.springframework.cloud.skipper.server.controller.PackageController;
+import org.springframework.cloud.skipper.server.controller.ReleaseController;
+import org.springframework.cloud.skipper.server.controller.RootController;
+import org.springframework.cloud.skipper.server.controller.SkipperErrorAttributes;
+import org.springframework.cloud.skipper.server.controller.VersionInfoProperties;
+import org.springframework.cloud.skipper.server.deployer.AppDeploymentRequestFactory;
+import org.springframework.cloud.skipper.server.deployer.DefaultReleaseManager;
+import org.springframework.cloud.skipper.server.deployer.DefaultReleaseManagerFactory;
+import org.springframework.cloud.skipper.server.deployer.ReleaseAnalyzer;
+import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
+import org.springframework.cloud.skipper.server.deployer.ReleaseManagerFactory;
+import org.springframework.cloud.skipper.server.deployer.strategies.DefaultUpgradeStrategyFactory;
+import org.springframework.cloud.skipper.server.deployer.strategies.DeleteStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.DeployAppStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.HandleHealthCheckStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckProperties;
+import org.springframework.cloud.skipper.server.deployer.strategies.HealthCheckStep;
+import org.springframework.cloud.skipper.server.deployer.strategies.SimpleRedBlackUpgradeStrategy;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategy;
+import org.springframework.cloud.skipper.server.deployer.strategies.UpgradeStrategyFactory;
+import org.springframework.cloud.skipper.server.index.PackageMetadataResourceProcessor;
+import org.springframework.cloud.skipper.server.index.PackageSummaryResourceProcessor;
+import org.springframework.cloud.skipper.server.index.SkipperLinksResourceProcessor;
+import org.springframework.cloud.skipper.server.repository.AppDeployerDataRepository;
+import org.springframework.cloud.skipper.server.repository.DeployerRepository;
+import org.springframework.cloud.skipper.server.repository.PackageMetadataRepository;
+import org.springframework.cloud.skipper.server.repository.ReleaseRepository;
+import org.springframework.cloud.skipper.server.repository.RepositoryRepository;
+import org.springframework.cloud.skipper.server.service.PackageMetadataService;
+import org.springframework.cloud.skipper.server.service.PackageService;
+import org.springframework.cloud.skipper.server.service.ReleaseReportService;
+import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.cloud.skipper.server.service.ReleaseStateUpdateService;
+import org.springframework.cloud.skipper.server.service.RepositoryInitializationService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.statemachine.boot.autoconfigure.StateMachineJpaRepositoriesAutoConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.cloud.skipper.server.config.SkipperServerConfiguration.SKIPPER_EXECUTOR;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+@Configuration
+@EnableConfigurationProperties({ SkipperServerProperties.class, VersionInfoProperties.class,
+		LocalPlatformProperties.class, /*CloudFoundryPlatformProperties.class,*/ MavenConfigurationProperties.class, HealthCheckProperties.class })
+@EntityScan({ "org.springframework.cloud.skipper.domain",
+		"org.springframework.cloud.skipper.server.domain" })
+@EnableAsync
+@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
+		HibernateJpaAutoConfiguration.class, RepositoryRestMvcAutoConfiguration.class,
+		ErrorMvcAutoConfiguration.class, StateMachineJpaRepositoriesAutoConfiguration.class,
+		SkipperServerPlatformConfiguration.class })
+@Import(RepositoryConfiguration.class)
+@WebAppConfiguration
+public class ServerDependencies implements AsyncConfigurer {
+
+	private final Logger logger = LoggerFactory.getLogger(SkipperServerConfiguration.class);
+
+	@Bean
+	public ErrorAttributes errorAttributes() {
+		// override boot's DefaultErrorAttributes
+		return new SkipperErrorAttributes();
+	}
+
+	@Bean
+	public PackageSummaryResourceProcessor packageSummaryResourceProcessor() {
+		return new PackageSummaryResourceProcessor();
+	}
+
+	@Bean
+	public PackageMetadataResourceProcessor packageMetadataResourceProcessor() {
+		return new PackageMetadataResourceProcessor();
+	}
+
+	@Bean
+	public SkipperLinksResourceProcessor skipperControllerResourceProcessor() {
+		return new SkipperLinksResourceProcessor();
+	}
+
+	@Bean
+	public SkipperStateMachineService skipperStateMachineService() {
+		return mock(SkipperStateMachineService.class);
+	}
+
+	@Bean
+	public ReleaseController releaseController(ReleaseService releaseService,
+			SkipperStateMachineService skipperStateMachineService) {
+		return new ReleaseController(releaseService, skipperStateMachineService);
+	}
+
+	@Bean
+	public PackageController packageController(PackageService packageService,
+			PackageMetadataService packageMetadataService, SkipperStateMachineService skipperStateMachineService) {
+		return new PackageController(packageService, packageMetadataService, skipperStateMachineService);
+	}
+
+	@Bean
+	public AboutController aboutController(VersionInfoProperties versionInfoProperties) {
+		return new AboutController(versionInfoProperties);
+	}
+
+	@Bean
+	public RootController rootController() {
+		return new RootController();
+	}
+
+
+
+	// Services
+
+	@Bean
+	public PackageMetadataService packageMetadataService(RepositoryRepository repositoryRepository,
+			PackageMetadataRepository packageMetadataRepository,
+			ReleaseRepository releaseRepository) {
+		return new PackageMetadataService(repositoryRepository,
+				packageMetadataRepository,
+				releaseRepository);
+	}
+
+	@Bean
+	public PackageService packageService() {
+		return mock(PackageService.class);
+	}
+
+	@Bean
+	public DelegatingResourceLoader delegatingResourceLoader(MavenConfigurationProperties mavenProperties) {
+		DockerResourceLoader dockerLoader = new DockerResourceLoader();
+		MavenResourceLoader mavenResourceLoader = new MavenResourceLoader(mavenProperties);
+		Map<String, ResourceLoader> loaders = new HashMap<>();
+		loaders.put("docker", dockerLoader);
+		loaders.put("maven", mavenResourceLoader);
+		return new DelegatingResourceLoader(loaders);
+	}
+
+	@Bean
+	public LRUCleaningResourceLoaderBeanPostProcessor lruCleaningResourceLoaderBeanPostProcessor(
+			SkipperServerProperties skipperServerProperties, MavenProperties mavenProperties) {
+		return new LRUCleaningResourceLoaderBeanPostProcessor(
+				skipperServerProperties.getFreeDiskSpacePercentage() / 100F,
+				new File(mavenProperties.getLocalRepository()));
+	}
+
+	@Bean
+	public ReleaseReportService releaseReportService() {
+		return mock(ReleaseReportService.class);
+	}
+
+	@Bean
+	public ReleaseManagerFactory releaseManagerFactory(List<ReleaseManager> managers) {
+		return new DefaultReleaseManagerFactory(managers);
+	}
+
+	@Bean
+	public UpgradeStrategyFactory upgradeStrategyFactory(List<UpgradeStrategy> strategies) {
+		return new DefaultUpgradeStrategyFactory(strategies);
+	}
+
+	@Bean
+	public ReleaseService releaseService() {
+		return mock(ReleaseService.class);
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = "spring.cloud.skipper.server", name = "enableReleaseStateUpdateService", matchIfMissing = true)
+	public ReleaseStateUpdateService releaseStateUpdateService(ReleaseManagerFactory releaseManagerFactory,
+			ReleaseRepository releaseRepository) {
+		return new ReleaseStateUpdateService(releaseManagerFactory, releaseRepository);
+	}
+
+	@Bean
+	public RepositoryInitializationService repositoryInitializationService(RepositoryRepository repositoryRepository,
+			PackageMetadataRepository packageMetadataRepository,
+			PackageMetadataService packageMetadataService,
+			SkipperServerProperties skipperServerProperties) {
+		return new RepositoryInitializationService(repositoryRepository, packageMetadataRepository,
+				packageMetadataService, skipperServerProperties);
+	}
+
+	// Deployer Package
+
+	@Bean
+	public DefaultReleaseManager defaultReleaseManager(ReleaseRepository releaseRepository,
+			AppDeployerDataRepository appDeployerDataRepository,
+			DeployerRepository deployerRepository,
+			ReleaseAnalyzer releaseAnalyzer,
+			AppDeploymentRequestFactory appDeploymentRequestFactory,
+			SpringCloudDeployerApplicationManifestReader applicationManifestReader) {
+		return new DefaultReleaseManager(releaseRepository, appDeployerDataRepository, deployerRepository,
+				releaseAnalyzer, appDeploymentRequestFactory, applicationManifestReader);
+	}
+
+	@Bean
+	public SpringCloudDeployerApplicationManifestReader applicationSpecReader() {
+		return new SpringCloudDeployerApplicationManifestReader();
+	}
+
+	@Bean
+	public DeleteStep deleteStep(ReleaseRepository releaseRepository, DeployerRepository deployerRepository) {
+		return new DeleteStep(releaseRepository, deployerRepository);
+	}
+
+	@Bean
+	public UpgradeStrategy updateStrategy(HealthCheckStep healthCheckStep,
+			HandleHealthCheckStep healthCheckAndDeleteStep,
+			DeployAppStep deployAppStep) {
+		return new SimpleRedBlackUpgradeStrategy(healthCheckStep, healthCheckAndDeleteStep,
+				deployAppStep);
+	}
+
+	@Bean
+	public HealthCheckStep healthCheckStep(AppDeployerDataRepository appDeployerDataRepository,
+			DeployerRepository deployerRepository,
+			SpringCloudDeployerApplicationManifestReader applicationManifestReader) {
+		return new HealthCheckStep(appDeployerDataRepository, deployerRepository,
+				applicationManifestReader/* , cfApplicationManifestReader, cfManifestApplicationDeployer */);
+	}
+
+	@Bean
+	public DeployAppStep DeployAppStep() {
+		return mock(DeployAppStep.class);
+	}
+
+	@Bean
+	public HandleHealthCheckStep healthCheckAndDeleteStep(ReleaseRepository releaseRepository,
+			AppDeployerDataRepository appDeployerDataRepository, DeleteStep deleteStep,
+			ReleaseManagerFactory releaseManagerFactory) {
+		return new HandleHealthCheckStep(releaseRepository, appDeployerDataRepository, deleteStep,
+				releaseManagerFactory);
+	}
+
+	@Bean(name = SKIPPER_EXECUTOR)
+	@Override
+	public Executor getAsyncExecutor() {
+		ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+		threadPoolTaskExecutor.setCorePoolSize(5);
+		threadPoolTaskExecutor.setMaxPoolSize(10);
+		threadPoolTaskExecutor.setThreadNamePrefix("StateUpdate-");
+		return threadPoolTaskExecutor;
+	}
+
+	@Override
+	public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+		return (throwable, method, objects) -> logger.error("Exception thrown in @Async Method " + method.getName(),
+				throwable);
+	}
+
+	@Bean
+	public ReleaseAnalyzer releaseAnalysisService(
+			SpringCloudDeployerApplicationManifestReader applicationManifestReader,
+			DelegatingResourceLoader delegatingResourceLoader) {
+		return new ReleaseAnalyzer(applicationManifestReader, delegatingResourceLoader);
+	}
+
+	@Bean
+	public AppDeploymentRequestFactory appDeploymentRequestFactory(DelegatingResourceLoader delegatingResourceLoader) {
+		return new AppDeploymentRequestFactory(delegatingResourceLoader);
+	}
+
+	@Bean
+	public PackageReader packageReader() {
+		return new DefaultPackageReader();
+	}
+
+	@Bean
+	public PackageWriter packageWriter() {
+		return new DefaultPackageWriter();
+	}
+
+	@Bean
+	public SecurityStateBean securityStateBean() {
+		return new SecurityStateBean();
+	}
+
+	@Bean
+	@ConfigurationProperties(prefix = "spring.cloud.skipper.security.authorization")
+	public AuthorizationProperties authorizationProperties() {
+		return new AuthorizationProperties();
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/StatusDocumentation.java
@@ -18,14 +18,11 @@ package org.springframework.cloud.skipper.server.controller.docs;
 
 import org.junit.Test;
 
-import org.springframework.cloud.skipper.domain.InstallRequest;
-import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.StatusCode;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.StringUtils;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -35,24 +32,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
-@ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "spring.cloud.skipper.server.enableReleaseStateUpdateService=false" })
 public class StatusDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getStatusOfRelease() throws Exception {
-		final String releaseName = "myLogRelease";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		final Release release = installPackage(installRequest);
-
+		Release release = createTestRelease();
+		when(this.releaseService.status(release.getName())).thenReturn(release.getInfo());
 		this.mockMvc.perform(
 				get("/api/release/status/{releaseName}", release.getName())).andDo(print())
 				.andExpect(status().isOk())
@@ -73,17 +60,8 @@ public class StatusDocumentation extends BaseDocumentation {
 
 	@Test
 	public void getStatusOfReleaseForVersion() throws Exception {
-		final String releaseName = "myLogRelease2";
-		final InstallRequest installRequest = new InstallRequest();
-		final PackageIdentifier packageIdentifier = new PackageIdentifier();
-		packageIdentifier.setPackageName("log");
-		packageIdentifier.setPackageVersion("1.0.0");
-		packageIdentifier.setRepositoryName("notused");
-		installRequest.setPackageIdentifier(packageIdentifier);
-		installRequest.setInstallProperties(createInstallProperties(releaseName));
-
-		final Release release = installPackage(installRequest);
-
+		Release release = createTestRelease();
+		when(this.releaseService.status(release.getName(), release.getVersion())).thenReturn(release.getInfo());
 		this.mockMvc.perform(
 				get("/api/release/status/{releaseName}/{releaseVersion}",
 						release.getName(), release.getVersion()))


### PR DESCRIPTION
- Apply changes from https://github.com/spring-cloud/spring-cloud-skipper/pull/242 from @eddumelendez. Credits to him for the initial PR.
  - Configure the BaseDocumentation to use the Skipper server dependencies conditionally
  - Use mocks to verify the documentation tests
  - Use Mock repositories and JPA repositories based on the nature of the tests
      - If the documentation tests the native repository methods then use the JPA repositories. Otherwise, use the mocks
  - Refactor the existing documentation tests
  - Run the Repository based and other tests in different test suites

Resolves #165
Resolves #672