### PR TITLE
Update docs for manifest support

### DIFF
--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
@@ -140,12 +140,16 @@ The properties available for each platform can be found in the following classes
 == Packages
 
 Packages contain all the necessary information to install your application or group of applications.
-The approach to describing the applications is to use a YAML file that provides all the necessary information to help facilitate searching for your application hosted in a Package Registry and to install your application to a platform.
+The approach to describing the applications is to use a YAML file that provides all the necessary information to help
+facilitate searching for your application hosted in a Package Registry and to install your application to a
+platform.
 
 To make it easy to customize a package, the YAML files are templated.
 The final version of the YAML file, with all values substituted, is known as the release `manifest`.
-Skipper currently understands how to deploy applications based off a YAML file that contains the information needed for a Spring Cloud Deployer implementation to deploy an application.
-It describes where to find the application (an HTTP, Maven or Docker location), application properties (think Spring Boot `@ConfigurationProperties`), and deployment properties (such as how much memory to use).
+Skipper currently understands how to deploy applications based off a YAML file that contains the information needed for
+a _Spring Cloud Deployer_ or _Cloud Foundry_ implementation to deploy an application.
+It describes where to find the application (an HTTP, Maven or Docker location), application properties (think Spring
+Boot `@ConfigurationProperties`), and deployment properties (such as how much memory to use).
 
 [[using-package-format]]
 === Package Format
@@ -155,8 +159,12 @@ A package is a collection of YAML files that are zipped up into a file with the 
 
 A package can define a single application or a group of applications.
 
-The single application package file, `mypackage-1.0.0.zip`, when unzipped, should have the following directory structure:
+==== Single Application
 
+The single application package file, `mypackage-1.0.0.zip`, when unzipped, should have the following directory
+structure:
+
+[source,text]
 ----
 mypackage-1.0.0
 ├── package.yml
@@ -167,7 +175,8 @@ mypackage-1.0.0
 
 The `package.yml` file contains metadata about the package and is used to support Skipper's search functionality.
 The `template.yml` file contains placeholders for values that are specified in the `values.yml` file.
-When installing a package, placeholder values can also be specified, and they would override the values in the `values.yml` file.
+When installing a package, placeholder values can also be specified, and they would override the values in the
+`values.yml` file.
 The templating engine that Skipper uses is https://github.com/samskivert/jmustache[JMustache].
 The YAML files can have either `.yml` or `.yaml` extensions.
 
@@ -176,11 +185,12 @@ The  https://github.com/markpollack/skipper-sample-repository/blob/master/src/ma
 The source code for the `helloworld` sample can be found https://github.com/markpollack/skipper-samples[here].
 
 [[using-package-format-multiple-apps]]
-=== Package with multiple applications
+==== Multiple Applications
 
 A package can contain a group of applications bundled in it.
 In those cases, the structure of the package would resemble the following:
 
+[source,text]
 ----
 mypackagegroup-1.0.0
 ├── package.yml
@@ -198,14 +208,18 @@ mypackagegroup-1.0.0
 └── values.yml
 ----
 
-In the preceding example, the `mypackagegroup` still has its own `package.yml` and `values.yml` to specify the package metadata
- and the values to override.
-All the applications inside the `mypackagegroup`  are considered to be sub-packages and follow a  package
-structure similar to the individual packages.
-These sub packages need to be specified inside the `packages` directory of the root package, `mypackagegroup`.
+In the preceding example, the `mypackagegroup` still has its own `package.yml` and `values.yml` to specify the package
+metadata and the values to override. All the applications inside the `mypackagegroup`  are considered to be
+sub-packages and follow a package structure similar to the individual packages. These sub packages need to be specified
+inside the `packages` directory of the root package, `mypackagegroup`.
 
-The  https://github.com/spring-cloud/spring-cloud-skipper/blob/master/spring-cloud-skipper-server-core/src/test/resources/repositories/binaries/test/ticktock/ticktock-1.0.0.zip[ticktock-1.0.0.zip] file is a good example to use as a basis for creating your own package 'by-hand'.
-
+The  https://github.com/spring-cloud/spring-cloud-skipper/blob/master/spring-cloud-skipper-server-core/src/test/resources/repositories/binaries/test/ticktock/ticktock-1.0.0.zip[ticktock-1.0.0.zip]
+file is a good example to use as a basis for creating your own package 'by-hand'.
+ 
+[NOTE]
+====
+Packages with template kind _CloudFoundryApplication_ currently doesn't support multiple applications format.
+====
 
 [[using-package-metadata]]
 === Package Metadata
@@ -235,6 +249,11 @@ description: This is a mypackage sample.
 * `name`: The name of the package.
 * `version`: The version of the package.
 
+[NOTE]
+====
+Currently only supported _kind_ is *SkipperPackageMetadata*.
+====
+
 *Optional Fields:*
 
 * `packageSourceUrl`: The location of the source code for this package.
@@ -246,15 +265,26 @@ description: This is a mypackage sample.
 * `iconUrl`: The URL for an icon to show for this package.
 * `origin`: Free-form text describing the origin of this package -- for example, your company name.
 
-NOTE: Currently, the package search functionality is only a wildcard match against the name of the package.
+[NOTE]
+====
+Currently, the package search functionality is only a wildcard match against the name of the package.
+====
 
 A Package Repository exposes an `index.yml` file that contains multiple metadata documents and that uses the standard three dash notation `---` to separate the documents -- for example, http://skipper-repository.cfapps.io/repository/experimental/index.yml[index.yml].
 
 [[package-templates]]
 === Package Templates
+Currently, two type of applications are supported. One having `SpringCloudDeployerApplication` kind, which means the
+applications can be deployed into the target platforms only by using their corresponding Spring Cloud Deployer
+implementations (CF, Kubernetes Deployer, and so on). Other is having `CloudFoundryApplication` kind, which means the
+applications are directly deployed into _Cloud Foundry_ using its manifest support.
+
+[[package-templates-scdep]]
+==== Spring Cloud Deployer 
 
 The `template.yml` file has a package structure similar to that of the following example:
 
+[source,text]
 ----
 mypackage-1.0.0
 ├── package.yml
@@ -263,8 +293,13 @@ mypackage-1.0.0
 └── values.yml
 ----
 
-`template.yml` commonly has content similar to the following:
+[NOTE]
+====
+Actual template file name doesn't matter and you can have multiple template files. These just need to be inside of a
+`templates` directory.
+====
 
+[source,yaml]
 ----
 # template.yml
 apiVersion: skipper.spring.io/v1
@@ -286,23 +321,155 @@ spec:
     {{/spec.deploymentProperties.entrySet}}
 ----
 
-Skipper knows only how to manage applications defined in this way.
-A future release will introduce support for different formats -- for example supporting the Cloud Foundry manifest format.
-
 The `apiVersion`, `kind`, and `spec.resource` are required.
 
-The `spec.resource` and `spec.version` define where the application executable is located.
-The `spec.resourceMetadata` field defines where a https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html[Spring Boot Configuration metadata] jar is located that contains the configuration properties of the application.
-This is either a Spring Boot uber jar hosted under a HTTP endpoint or a Maven or Docker repository.
-The template placeholder `{{spec.version}}` exists so that the version of a specific application can be easily upgraded without having to create a new package .zip file.
+The `spec.resource` and `spec.version` define where the application executable is located. The `spec.resourceMetadata`
+field defines where a https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html[Spring Boot Configuration metadata]
+jar is located that contains the configuration properties of the application. This is either a Spring Boot uber jar
+hosted under a HTTP endpoint or a Maven or Docker repository. The template placeholder `{{spec.version}}` exists so that
+the version of a specific application can be easily upgraded without having to create a new package .zip file.
 
-The `resource` is based on `http://` or `maven://` or `docker:`.
-The format for specifying a `resource` follows:
+The `resource` is based on `http://` or `maven://` or `docker:`. The format for specifying a `resource` follows documented
+types in <<package-templates-resources>>.
 
-==== HTTP Resources
+
+[[package-templates-cf]]
+==== Cloud Foundry
+The `template.yml` file has a package structure similar to that of the following example:
+
+[source,text]
+----
+mypackage-1.0.0
+├── package.yml
+├── templates
+│   └── template.yml
+└── values.yml
+----
+
+`template.yml` commonly has content similar to the following:
+
+[NOTE]
+====
+Actual template file name doesn't matter and you can have multiple template files. These just need to be inside of a
+`templates` directory.
+====
+
+[source,yaml]
+----
+# template.yml
+apiVersion: skipper.spring.io/v1
+kind: CloudFoundryApplication
+spec:
+  resource: maven://org.mysample:mypackage
+  version: {{spec.version}}
+  manifest:
+    {{#spec.manifest.entrySet}}
+    {{key}}: {{value}}
+    {{/spec.manifest.entrySet}}
+----
+
+Where values could for example be something like:
+
+[source,yaml]
+----
+# values.yml
+spec:
+  version: 1.0.0
+  manifest:
+    memory: 1024
+    disk-quota: 1024
+----
+
+Possible values of a `spec.manifest` are:
+
+[cols="10,10,15"]
+|===
+| Key | Value | Notes
+
+| `buildpack`
+| (String)
+| _buildpack_ attribute as is.
+
+| `command`
+| (String)
+| _command_ attribute as is.
+
+| `memory`
+| (String or Integer)
+| _memory_ attribute as is if type is Integer, String is converted using same format in a CF, like `1024M` or `2G`. `1024` and `1024M` are equivalent. 
+
+| `disk-quota`
+| (String or Integer)
+| _disk_quota_ attribute as is if type is Integer, String is converted using same format in a CF, like `1024M` or `2G`. `1024` and `1024M` are equivalent. 
+
+| `timeout`
+| (Integer)
+| _timeout_ attribute as is.
+
+| `instances`
+| (Integer)
+| _instances_ attribute as is.
+
+| `no-hostname`
+| (Boolean)
+| _no-hostname_ attribute as is.
+
+| `no-route`
+| (Boolean)
+| _no-route_ attribute as is.
+
+| `random-route`
+| (Boolean)
+| _random-route_ attribute as is.
+
+| `health-check-type`
+| (String) 
+| _health-check-type_ having possible values of `port`, `process` or `http`.
+
+| `health-check-http-endpoint`
+| (String)
+| _health-check-http-endpoint_ attribute as is.
+
+| `stack`
+| (String)
+| _stack_ attribute as is.
+
+| `services`
+| (List<String>)
+| _services_ attribute as is.
+
+| `domains`
+| (List<String>)
+| _domains_ attribute as is.
+
+| `hosts`
+| (List<String>)
+| _hosts_ attribute as is.
+
+| `env`
+| (Map<String,Object>)
+| _env_ attribute as is.
+|===
+
+[NOTE]
+====
+Remember that when a value is given from a command-line, replacement happens as is defined in a template. Using a template
+format `{{#spec.manifest.entrySet}}` shown above, _List_ would be given in format `spec.manifest.services=[service1, service2]`
+and _Map_ would be given in format `spec.manifest.env={key1: value1, key2: value2}`.
+====
+
+The `resource` is based on `http://` or `maven://` or `docker:`. The format for specifying a `resource` follows documented
+types in <<package-templates-resources>>.
+
+[[package-templates-resources]]
+==== Resources
+This section contains resource types currently supported.
+
+===== HTTP Resources
 
 The following example shows a typical spec for HTTP:
 
+[source,yaml]
 ----
 spec:
   resource: http://example.com/app/hello-world
@@ -313,10 +480,11 @@ There is a naming convention that must be followed for HTTP-based resources so t
 The preceding `spec` references a URL at `http://example.com/app/hello-world-1.0.0.RELEASE.jar`.
 The `resource` and `version` fields should not have any numbers after the `-` character.
 
-==== Docker Resources
+===== Docker Resources
 
 The following example shows a typical spec for Docker:
 
+[source,yaml]
 ----
 spec:
   resource: docker:springcloud/spring-cloud-skipper-samples-helloworld
@@ -325,14 +493,14 @@ spec:
 
 The mapping to docker registry names follows:
 
+[source,yaml]
 ----
 spec:
   resource: docker:<user>/<repo>
   version: <tag>
 ----
 
-
-==== Maven Resources
+===== Maven Resources
 
 The following example shows a typical spec for Maven:
 
@@ -343,6 +511,8 @@ spec:
 ----
 
 The mapping to Maven artifact names follows
+
+[source,yaml]
 ----
 spec:
   resource: maven://<maven-group-name>:<maven-artifact-name>
@@ -353,6 +523,7 @@ There is only one setting to specify with Maven repositories to search.
 This setting applies across all platform accounts.
 By default, the following configuration is used:
 
+[source,yaml]
 ----
 maven:
   remoteRepositories:
@@ -363,6 +534,7 @@ You can specify other entries and also specify proxy properties.
 This is currently best documented https://docs.spring.io/spring-cloud-dataflow/docs/1.3.0.M2/reference/htmlsingle/#getting-started-maven-configuration[here].
 Essentially, this needs to be set as a property in your launch properties or `manifest.yml` (when pushing to PCF), as follows:
 
+[source,yaml]
 ----
 # manifest.yml
 ...
@@ -374,20 +546,24 @@ env:
 The metadata section is used to help search for applications after they have been installed.
 This feature will be made available in a future release.
 
-Currently, only the `SpringCloudDeployerApplication` kind is supported, which means the applications can be deployed into the target platforms only by using their corresponding Spring Cloud Deployer implementations (CF, Kubernetes Deployer, and so on).
-
 The `spec` contains the resource specification and the properties for the package.
 
 The `resource` represents the resource URI to download the application from.
 This would typically be a Maven co-ordinate or a Docker image URL.
 
-The `SpringCloudDeployerApplication` kind of application can have `applicationProperties` and `deploymentProperties` as the configuration properties.
+The `SpringCloudDeployerApplication` kind of application can have `applicationProperties` and `deploymentProperties`
+as the configuration properties.
 
 The application properties correspond to the properties for the application itself.
 
-The deployment properties correspond to the properties for the deployment operation performed by Spring Cloud Deployer implementations.
+The deployment properties correspond to the properties for the deployment operation performed by Spring Cloud Deployer
+implementations.
 
-NOTE: The `name` of the template file can be anything, as all the files under `templates` directory are loaded to apply the template configurations.
+[NOTE]
+====
+The `name` of the template file can be anything, as all the files under `templates` directory are loaded to apply the
+template configurations.
+====
 
 [[using-package-values]]
 === Package Values
@@ -396,6 +572,7 @@ The `values.yml` file contains the default values for any of the keys specified 
 
 For instance, in a package that defines one application, the format is as follows:
 
+[source,yaml]
 ----
 version: 1.0.0.RELEASE
 spec:
@@ -403,9 +580,10 @@ spec:
     server.port: 9090
 ----
 
-If the package defines multiple applications, provide the name of the package in the top-level YML section to scope the `spec` section.
-Consider the example of a multiple application package with the following layout:
+If the package defines multiple applications, provide the name of the package in the top-level YML section to scope the
+`spec` section. Consider the example of a multiple application package with the following layout:
 
+[source,text]
 ----
 ticktock-1.0.0/
 ├── packages
@@ -421,6 +599,7 @@ ticktock-1.0.0/
 ----
 The top-level `values.yml` file might resemble the following:
 
+[source,yaml]
 ----
 #values.yml
 
@@ -440,8 +619,10 @@ log:
       log.name: skipperlogger
 ----
 
-The preceding `values.yml` file sets `hello` as a variable available to be used as a placeholder in the `packages\log\values.yml` file and the `packages\time\values.yml`.
-However, the YML section under `time:` is applied only to the `packages\time\values.yml` file and the YML section under `log:` is applied only to the `packages\time\values.yml` file.
+The preceding `values.yml` file sets `hello` as a variable available to be used as a placeholder in the
+`packages\log\values.yml` file and the `packages\time\values.yml`. However, the YML section under `time:` is applied
+only to the `packages\time\values.yml` file and the YML section under `log:` is applied only to the
+`packages\time\values.yml` file.
 
 [[using-package-upload]]
 === Package Upload


### PR DESCRIPTION
NOTE: I have a feeling that docs should go complete overhaul as just adding something about cf manifest feels a bit awkward and produces slightly unclear docs.

- Polish some doc content in packages section
  and separate Spring Cloud Deployer and
  Cloud Foundry in its own sections.
- Fixes #635