### PR TITLE
Add force upgrade option

### DIFF
--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseAnalyzer.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseAnalyzer.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.skipper.deployer.cloudfoundry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -56,9 +57,10 @@ public class CloudFoundryReleaseAnalyzer {
 	 * @param existingRelease the release that is currently deployed
 	 * @param replacingRelease the proposed release to be deployed that will replace the
 	 * existing release.
+	 * @param isForceUpdate flag to indicate if the update is forced
 	 * @return an analysis report describing the changes to make, if any.
 	 */
-	public ReleaseAnalysisReport analyze(Release existingRelease, Release replacingRelease) {
+	public ReleaseAnalysisReport analyze(Release existingRelease, Release replacingRelease, boolean isForceUpdate) {
 		List<ApplicationManifestDifference> applicationManifestDifferences = new ArrayList<>();
 		ApplicationManifest existingApplicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(existingRelease);
 		ApplicationManifest replacingApplicationManifest = this.cfManifestApplicationDeployer.getCFApplicationManifest(replacingRelease);
@@ -71,12 +73,14 @@ public class CloudFoundryReleaseAnalyzer {
 					emptyPropertiesDiff, emptyPropertiesDiff, emptyPropertiesDiff, propertiesDiff, emptyPropertiesDiff);
 			applicationManifestDifferences.add(applicationManifestDifference);
 		}
-		return createReleaseAnalysisReport(existingRelease, replacingRelease, applicationManifestDifferences);
+		return createReleaseAnalysisReport(existingRelease, replacingRelease, applicationManifestDifferences,
+				Arrays.asList(existingApplicationManifest.getName()), isForceUpdate);
 	}
 
 	private ReleaseAnalysisReport createReleaseAnalysisReport(Release existingRelease,
 			Release replacingRelease,
-			List<ApplicationManifestDifference> applicationManifestDifferences) {
+			List<ApplicationManifestDifference> applicationManifestDifferences, List<String> allApplicationNames,
+			boolean isForceUpdate) {
 		List<String> appsToUpgrade = new ArrayList<>();
 		ReleaseDifference releaseDifference = new ReleaseDifference();
 		releaseDifference.setDifferences(applicationManifestDifferences);
@@ -86,6 +90,7 @@ public class CloudFoundryReleaseAnalyzer {
 					StringUtils.collectionToCommaDelimitedString(releaseDifference.getChangedApplicationNames()) + "]");
 			appsToUpgrade.addAll(releaseDifference.getChangedApplicationNames());
 		}
-		return new ReleaseAnalysisReport(appsToUpgrade, releaseDifference, existingRelease, replacingRelease);
+		return new ReleaseAnalysisReport(appsToUpgrade, releaseDifference, existingRelease, replacingRelease,
+				allApplicationNames, isForceUpdate);
 	}
 }

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -141,14 +141,14 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 	}
 
 	@Override
-	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease, boolean initial) {
+	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease, boolean initial,
+			boolean isForceUpdate, String[] appNamesToUpgrade) {
 		ReleaseAnalysisReport releaseAnalysisReport = this.cloudFoundryReleaseAnalyzer
-				.analyze(existingRelease, replacingRelease);
+				.analyze(existingRelease, replacingRelease, isForceUpdate);
 		if (initial) {
 			this.releaseRepository.save(replacingRelease);
 		}
-		return new ReleaseAnalysisReport(releaseAnalysisReport.getApplicationNamesToUpgrade(),
-				releaseAnalysisReport.getReleaseDifference(), existingRelease, replacingRelease);
+		return releaseAnalysisReport;
 	}
 
 	public Release status(Release release) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
@@ -150,10 +150,12 @@ public class DefaultReleaseManager implements ReleaseManager {
 	}
 
 	@Override
-	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease, boolean initial) {
+	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease, boolean initial,
+			boolean isForceUpdate, String[] appNamesToUpgrade) {
 		ReleaseAnalysisReport releaseAnalysisReport = this.releaseAnalyzer
-				.analyze(existingRelease, replacingRelease);
-		if (releaseAnalysisReport.getReleaseDifference().areEqual()) {
+				.analyze(existingRelease, replacingRelease, isForceUpdate, appNamesToUpgrade);
+		List<String> applicationNamesToUpgrade = releaseAnalysisReport.getApplicationNamesToUpgrade();
+		if (releaseAnalysisReport.getReleaseDifference().areEqual() && !isForceUpdate) {
 			throw new SkipperException(
 					"Package to upgrade has no difference than existing deployed/deleted package. Not upgrading.");
 		}
@@ -161,7 +163,6 @@ public class DefaultReleaseManager implements ReleaseManager {
 				.findByReleaseNameAndReleaseVersionRequired(
 						existingRelease.getName(), existingRelease.getVersion());
 		Map<String, String> existingAppNamesAndDeploymentIds = existingAppDeployerData.getDeploymentDataAsMap();
-		List<String> applicationNamesToUpgrade = releaseAnalysisReport.getApplicationNamesToUpgrade();
 		List<AppStatus> appStatuses = status(existingRelease).getInfo().getStatus().getAppStatusList();
 
 		Map<String, Object> model = calculateAppCountsForRelease(replacingRelease, existingAppNamesAndDeploymentIds,

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalysisReport.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseAnalysisReport.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  * report. The reports dictates what needs to change, and the strategies determine how to
  * make the change.
  * @author Mark Pollack
+ * @author Ilayaperumal Gopinathan
  */
 public class ReleaseAnalysisReport {
 
@@ -40,6 +41,10 @@ public class ReleaseAnalysisReport {
 
 	private final Release replacingRelease;
 
+	private final List<String> allApplicationNames;
+
+	private final boolean isForceUpdate;
+
 	/**
 	 * Create an analysis report.
 	 * @param applicationNamesToUpgrade the list of application names that needs to be updates
@@ -47,21 +52,31 @@ public class ReleaseAnalysisReport {
 	 * the proposed release
 	 * @param existingRelease the currently deployed release
 	 * @param replacingRelease the release to be deployed
+	 * @param allApplicationNames the list of all the application names that are part of the package
+	 * @param isForceUpdate boolean flag to indicate if the update is forced
 	 */
 	public ReleaseAnalysisReport(List<String> applicationNamesToUpgrade, ReleaseDifference releaseDifference,
-			Release existingRelease, Release replacingRelease) {
+			Release existingRelease, Release replacingRelease, List<String> allApplicationNames, boolean isForceUpdate) {
 		Assert.notNull(applicationNamesToUpgrade, "ApplicationNamesToUpgrade can not be null.");
 		Assert.notNull(releaseDifference, "ReleaseDifference can not be null.");
 		Assert.notNull(existingRelease, "ExistingRelease can not be null.");
 		Assert.notNull(replacingRelease, "ReplacingRelease can not be null.");
+		Assert.notNull(allApplicationNames, "AllApplicationNames can not be null.");
 		this.applicationNamesToUpgrade = applicationNamesToUpgrade;
 		this.releaseDifference = releaseDifference;
 		this.existingRelease = existingRelease;
 		this.replacingRelease = replacingRelease;
+		this.allApplicationNames = allApplicationNames;
+		this.isForceUpdate = isForceUpdate;
 	}
 
 	public List<String> getApplicationNamesToUpgrade() {
-		return this.applicationNamesToUpgrade;
+		if (this.isForceUpdate) {
+			return this.applicationNamesToUpgrade.size() > 0 ? this.applicationNamesToUpgrade : this.allApplicationNames;
+		}
+		else{
+			return this.applicationNamesToUpgrade;
+		}
 	}
 
 	public ReleaseDifference getReleaseDifference() {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -51,9 +51,12 @@ public interface ReleaseManager {
 	 * @param replacingRelease the release that is to be deployed in place of the existing
 	 * release
 	 * @param initial the flag indicating this is initial report creation
+	 * @param isForceUpdate the flag indicating the upgrade is by force
+	 * @param appNamesToUpgrade the application names to force upgrade
 	 * @return a report describing the actions to take to update
 	 */
-	ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease, boolean initial);
+	ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease, boolean initial,
+			boolean isForceUpdate, String[] appNamesToUpgrade);
 
 	/**
 	 * Delete the release

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseReportService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseReportService.java
@@ -115,7 +115,8 @@ public class ReleaseReportService {
 		// TODO: should check both releases
 		String kind = ManifestUtils.resolveKind(existingRelease.getManifest().getData());
 		ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);
-		return releaseManager.createReport(existingRelease, replacingRelease, initial);
+		return releaseManager.createReport(existingRelease, replacingRelease, initial, upgradeRequest.isForce(),
+				upgradeRequest.getAppNames());
 	}
 
 	private Release updateReplacingReleaseConfigValues(Release targetRelease, Release replacingRelease) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -313,7 +313,7 @@ public class ReleaseService {
 	public ReleaseAnalysisReport createReport(Release existingRelease, Release replacingRelease) {
 		String kind = ManifestUtils.resolveKind(existingRelease.getManifest().getData());
 		ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);
-		return releaseManager.createReport(existingRelease, replacingRelease, true);
+		return releaseManager.createReport(existingRelease, replacingRelease, true, false, null);
 	}
 
 	protected Release createInitialRelease(InstallProperties installProperties, Package packageToInstall,

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseAnalyzerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseAnalyzerTests.java
@@ -89,7 +89,7 @@ public class ReleaseAnalyzerTests extends AbstractIntegrationTest {
 		// Upgrade Release
 		Release upgradedRelease = upgrade(upgradeRequest);
 		ReleaseAnalysisReport releaseAnalysisReport = this.releaseAnalyzer.analyze(installedRelease,
-				upgradedRelease);
+				upgradedRelease, false, null);
 		String releaseDifferenceSummary = releaseAnalysisReport.getReleaseDifferenceSummary();
 		String manifest =  upgradedRelease.getManifest().getData();
 
@@ -113,7 +113,7 @@ public class ReleaseAnalyzerTests extends AbstractIntegrationTest {
 
 		// Upgrade Release to V3, ensure application property foo=bar and foo2=bar2 are both present.
 		Release upgradedReleaseV3 = upgrade(upgradeRequest);
-		releaseAnalysisReport = this.releaseAnalyzer.analyze(upgradedRelease, upgradedReleaseV3);
+		releaseAnalysisReport = this.releaseAnalyzer.analyze(upgradedRelease, upgradedReleaseV3, false, null);
 		releaseDifferenceSummary = releaseAnalysisReport.getReleaseDifferenceSummary();
 		manifest =  upgradedReleaseV3.getManifest().getData();
 
@@ -123,6 +123,16 @@ public class ReleaseAnalyzerTests extends AbstractIntegrationTest {
 		assertThat(manifest).contains("\"foo\": \"bar\"");
 		assertThat(manifest).contains("\"log.level\": \"error\"");
 		assertThat(manifest).contains("\"foo2\": \"bar2\"");
+
+		// Upgrade Release to V4, ensure `force` upgrade is set.
+		upgradeRequest.setForce(true);
+		Release upgradedReleaseV4 = upgrade(upgradeRequest);
+		releaseAnalysisReport = this.releaseAnalyzer.analyze(upgradedReleaseV3, upgradedReleaseV4, true, null);
+		manifest =  upgradedReleaseV4.getManifest().getData();
+
+		logger.info("Release Manifest v4: \n" + manifest);
+
+		assertThat(releaseAnalysisReport.getReleaseDifference().areEqual()).isTrue();
 	}
 
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/statemachine/StateMachineTests.java
@@ -220,8 +220,8 @@ public class StateMachineTests {
 		Manifest manifest = new Manifest();
 		Release release = new Release();
 		release.setManifest(manifest);
-		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), release, release));
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(
+				new ArrayList<>(), new ReleaseDifference(), release, release, new ArrayList<>(), false));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(true);
 		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
@@ -286,8 +286,8 @@ public class StateMachineTests {
 		Manifest manifest = new Manifest();
 		Release release = new Release();
 		release.setManifest(manifest);
-		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), release, release));
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(
+				new ArrayList<>(), new ReleaseDifference(), release, release, new ArrayList<>(), false));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(true);
 		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
@@ -326,8 +326,8 @@ public class StateMachineTests {
 		Manifest manifest = new Manifest();
 		Release release = new Release();
 		release.setManifest(manifest);
-		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), release, release));
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(
+				new ArrayList<>(), new ReleaseDifference(), release, release, new ArrayList<>(), false));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);
 		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
@@ -378,8 +378,8 @@ public class StateMachineTests {
 		Manifest manifest = new Manifest();
 		Release release = new Release();
 		release.setManifest(manifest);
-		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), release, release));
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(
+				new ArrayList<>(), new ReleaseDifference(), release, release, new ArrayList<>(), false));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);
 		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);
@@ -576,8 +576,8 @@ public class StateMachineTests {
 		Manifest manifest = new Manifest();
 		Release release = new Release();
 		release.setManifest(manifest);
-		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(new ArrayList<>(),
-				new ReleaseDifference(), release, release));
+		Mockito.when(releaseReportService.createReport(any(), any(), any(boolean.class))).thenReturn(new ReleaseAnalysisReport(
+				new ArrayList<>(), new ReleaseDifference(), release, release, new ArrayList<>(), false));
 		Mockito.when(upgradeStrategy.checkStatus(any()))
 				.thenReturn(false);
 		Mockito.when(upgradeStrategyFactory.getUpgradeStrategy(any())).thenReturn(upgradeStrategy);

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
@@ -133,13 +133,18 @@ public class ReleaseCommands extends AbstractSkipperCommand {
 			@ShellOption(help = "the version of the package to use for the upgrade, if not specified latest version will be used", defaultValue = NULL) String packageVersion,
 			@ShellOption(help = "specify values in a YAML file", defaultValue = NULL) File file,
 			@ShellOption(help = "the expression for upgrade timeout", defaultValue = NULL) String timeoutExpression,
-			@ShellOption(help = "the comma separated set of properties to override during upgrade", defaultValue = NULL) String properties)
+			@ShellOption(help = "the comma separated set of properties to override during upgrade", defaultValue = NULL) String properties,
+			@ShellOption(help = "force upgrade") boolean force,
+			@ShellOption(help = "application names to force upgrade. If no specific list is provided, all the apps in the packages are force upgraded", defaultValue = NULL) String appNames)
 			throws IOException {
 		// Commented out until https://github.com/spring-cloud/spring-cloud-skipper/issues/263 is
 		// addressed
 		// assertMutuallyExclusiveFileAndProperties(file, properties);
+		if (StringUtils.hasText(appNames)) {
+			Assert.isTrue(force, "App names can be used only when the stream update is forced.");
+		}
 		Release release = skipperClient
-				.upgrade(getUpgradeRequest(releaseName, packageName, packageVersion, file, properties, timeoutExpression));
+				.upgrade(getUpgradeRequest(releaseName, packageName, packageVersion, file, properties, timeoutExpression, force, appNames));
 		StringBuilder sb = new StringBuilder();
 		sb.append(release.getName() + " has been upgraded.  Now at version v" + release.getVersion() + ".");
 		return sb.toString();
@@ -166,8 +171,10 @@ public class ReleaseCommands extends AbstractSkipperCommand {
 	}
 
 	private UpgradeRequest getUpgradeRequest(String releaseName, String packageName, String packageVersion,
-			File propertiesFile, String propertiesToOverride, String timeoutExpression) throws IOException {
+			File propertiesFile, String propertiesToOverride, String timeoutExpression, boolean forceUpgrade, String appNames) throws IOException {
 		UpgradeRequest upgradeRequest = new UpgradeRequest();
+		upgradeRequest.setForce(forceUpgrade);
+		upgradeRequest.setAppNames(StringUtils.commaDelimitedListToStringArray(appNames));
 		UpgradeProperties upgradeProperties = new UpgradeProperties();
 		upgradeProperties.setReleaseName(releaseName);
 		String configValuesYML = YmlUtils.getYamlConfigValues(propertiesFile, propertiesToOverride);

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/UpgradeRequest.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/UpgradeRequest.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import org.springframework.util.StringUtils;
+
 /**
  * This contains all the request attributes for upgrade operation.
  *
@@ -23,8 +25,14 @@ package org.springframework.cloud.skipper.domain;
 public class UpgradeRequest {
 
 	private PackageIdentifier packageIdentifier;
+
 	private UpgradeProperties upgradeProperties;
+
 	private Long timeout;
+
+	private boolean force;
+
+	private String[] appNames;
 
 	public PackageIdentifier getPackageIdentifier() {
 		return packageIdentifier;
@@ -50,9 +58,26 @@ public class UpgradeRequest {
 		this.timeout = timeout;
 	}
 
+	public boolean isForce() {
+		return force;
+	}
+
+	public void setForce(boolean force) {
+		this.force = force;
+	}
+
+	public String[] getAppNames() {
+		return appNames;
+	}
+
+	public void setAppNames(String[] appNames) {
+		this.appNames = appNames;
+	}
+
 	@Override
 	public String toString() {
-		return "UpgradeRequest [packageIdentifier=" + packageIdentifier + ", upgradeProperties=" + upgradeProperties
-				+ ", timeout=" + timeout + "]";
+		return "UpgradeRequest [packageIdentifier=" + this.packageIdentifier + ", upgradeProperties=" +
+				this.upgradeProperties + ", timeout=" + this.timeout + ", appNames=(" + StringUtils
+				.arrayToCommaDelimitedString(this.appNames) +"), force=" + this.force + "]";
 	}
 }


### PR DESCRIPTION
 - Add force upgrade option during release upgrade
   - When forced, the upgrade proceeds even if there are no differences
   - Allow users to set `appNames` to explicitly specify during upgrade when `force` option is used
 - Add command options
 - Update tests

Resolves #714