### PR TITLE
Fix postgres image healtcheck

### DIFF
--- a/acceptance-tests/spring-cloud-skipper-acceptance-tests/src/test/resources/postgres.yml
+++ b/acceptance-tests/spring-cloud-skipper-acceptance-tests/src/test/resources/postgres.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - 5432
     healthcheck:
-      test: ["CMD", "psql", "-U", "postgres", "-w", "-c", "SELECT version();"]
+      test: ["CMD", "psql", "-U", "spring", "-d", "skipper", "-w", "-c", "SELECT version();"]
       interval: 1s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
- As official image tweaked how env variables are used
  to create user and db, need to fix healthcheck
  as otherwise container will not come up.
- Fixes #730