### PR TITLE
Review YAML !!null handling with boot 2.1

### DIFF
--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/util/ManifestUtilsTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/util/ManifestUtilsTest.java
@@ -67,7 +67,6 @@ public class ManifestUtilsTest {
 		assertThat(manifest).contains("\"bool\": \"true\"").describedAs("Handle Boolean");
 		assertThat(manifest).contains("\"adate\": " + dateAsStringWithQuotes).describedAs("Handle Date");
 		assertThat(manifest).contains("\"array\":\n  - \"a\"\n  - \"b\"\n  - \"c\"").describedAs("Handle Array");
-		// TODO: Tzolov
-		// assertThat(manifest).contains("\"applicationProperties\": !!null \"null\"").describedAs("Handle Null");
+		assertThat(manifest).contains("\"deploymentProperties\": !!null \"null\"").describedAs("Handle Null");
 	}
 }


### PR DESCRIPTION
 - The d39030e4fb470d8d10addc7a4ee72e004be05c68 commit has introduced an explicit application property (e.g. server.port) and in result later is not null anymore. Instead the assertion for !!null value is applied to the deployment property (later doesn't have any explicitly set properties).

 Resolves #752