### PR TITLE
Fix the LocalServerSecurityWithOAuth2Tests

### DIFF
--- a/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/security/SkipperWebSecurityAutoConfiguration.java
+++ b/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/security/SkipperWebSecurityAutoConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.server.autoconfigure.security;
+
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.WebSecurityEnablerConfiguration;
+import org.springframework.cloud.common.security.support.OnSecurityEnabledAndOAuth2Enabled;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * Skipper basic security control. By default the security for all endpoints is disabled.
+ *
+ * When {@code spring.cloud.skipper.security.enabled} is not true
+ * and {@code security.oauth2.client.client-id} is not set (e.g. the default condition) then
+ * the Skipper security is disabled allowing unauthenticated access to all Skipper endpoints.
+ *
+ * If {@code spring.cloud.skipper.security.enabled} is set to true the security falls back to
+ * the {@link ManagementWebSecurityAutoConfiguration} allowing unauthenticated access only
+ * to the HealthEndpoint and InfoEndpoint.
+ *
+ * If {@code security.oauth2.client.client-id} is set (e.g. OnSecurityEnabledAndOAuth2Enabled condition
+ * is matched) then the security configuration is handled by the
+ * {@link org.springframework.cloud.skipper.server.config.security.SkipperOAuthSecurityConfiguration}.
+ *
+ * Note: if the {@link OnSecurityEnabledAndOAuth2Enabled} condition is true then the
+ * {@link OnSecurityDisabled.SkipperBasicSecurityEnabled} is ignored.
+ *
+ * @author Christian Tzolov
+ */
+@Configuration
+@ConditionalOnClass(WebSecurityConfigurerAdapter.class)
+@ConditionalOnMissingBean(WebSecurityConfigurerAdapter.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.ANY)
+@Conditional(SkipperWebSecurityAutoConfiguration.OnSecurityDisabled.class)
+@AutoConfigureBefore({ ManagementWebSecurityAutoConfiguration.class, SecurityAutoConfiguration.class })
+@Import({ SkipperWebSecurityConfigurerAdapter.class, WebSecurityEnablerConfiguration.class })
+public class SkipperWebSecurityAutoConfiguration {
+
+	public static class OnSecurityDisabled extends NoneNestedConditions {
+
+		public OnSecurityDisabled() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnProperty(name = "spring.cloud.skipper.security.enabled", havingValue = "true")
+		static class SkipperBasicSecurityEnabled {
+		}
+
+		@Conditional(OnSecurityEnabledAndOAuth2Enabled.class)
+		static class OAuth2Enabled {
+		}
+	}
+}

--- a/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/security/SkipperWebSecurityConfigurerAdapter.java
+++ b/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/security/SkipperWebSecurityConfigurerAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.server.autoconfigure.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * When the {@link OnSecurityDisabled} condition is matched (default), following configuration would
+ * permit unauthenticated access to all Skipper endpoints.
+ *
+ * @author Christian Tzolov
+ *
+ */
+@Configuration
+public class SkipperWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+
+	@Override
+	public void configure(WebSecurity builder) {
+		builder.ignoring().antMatchers("/**");
+	}
+}

--- a/spring-cloud-skipper-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-skipper-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   org.springframework.cloud.skipper.server.autoconfigure.SkipperServerAutoConfiguration,\
   org.springframework.cloud.skipper.server.autoconfigure.CloudFoundryPlatformAutoConfiguration,\
-  org.springframework.cloud.skipper.server.autoconfigure.KubernetesPlatformAutoConfiguration
+  org.springframework.cloud.skipper.server.autoconfigure.KubernetesPlatformAutoConfiguration, \
+  org.springframework.cloud.skipper.server.autoconfigure.security.SkipperWebSecurityAutoConfiguration

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SecurityConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SecurityConfiguration.java
@@ -16,10 +16,7 @@
 
 package org.springframework.cloud.skipper.server.config;
 
-import org.springframework.cloud.common.security.BasicAuthSecurityConfiguration;
-import org.springframework.cloud.common.security.DefaultBootUserAuthenticationConfiguration;
-import org.springframework.cloud.common.security.IgnoreAllSecurityConfiguration;
-import org.springframework.cloud.common.security.OAuthSecurityConfiguration;
+import org.springframework.cloud.skipper.server.config.security.SkipperOAuthSecurityConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -27,9 +24,6 @@ import org.springframework.context.annotation.Import;
  * @author Gunnar Hillert
  */
 @Configuration
-// TODO Tzolov
-@Import({ BasicAuthSecurityConfiguration.class, DefaultBootUserAuthenticationConfiguration.class,
-		OAuthSecurityConfiguration.class, IgnoreAllSecurityConfiguration.class })
-// @Import({ SkipperOAuthSecurityConfiguration.class })
+@Import({ SkipperOAuthSecurityConfiguration.class })
 public class SecurityConfiguration {
 }

--- a/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/local/security/LocalServerSecurityWithOAuth2Tests.java
+++ b/spring-cloud-skipper-server/src/test/java/org/springframework/cloud/skipper/server/local/security/LocalServerSecurityWithOAuth2Tests.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.skipper.server.local.security;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
@@ -37,8 +36,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Gunnar Hillert
  */
-// TODO Tzolov
-@Ignore("TODO fix before 2.1.x release")
 public class LocalServerSecurityWithOAuth2Tests {
 
 	private final static OAuth2ServerResource oAuth2ServerResource = new OAuth2ServerResource();
@@ -65,7 +62,6 @@ public class LocalServerSecurityWithOAuth2Tests {
 
 	@Test
 	public void testAccessApiUrlWithBasicAuthCredentials() throws Exception {
-		localSkipperResource.getWebApplicationContext().getEnvironment().getPropertySources();
 		localSkipperResource.getMockMvc()
 				.perform(get("/api").header("Authorization", basicAuthorizationHeader("user", "secret10"))).andDo(print())
 				.andExpect(status().isOk());
@@ -73,7 +69,6 @@ public class LocalServerSecurityWithOAuth2Tests {
 
 	@Test
 	public void testAccessRootUrlWithBasicAuthCredentials() throws Exception {
-		localSkipperResource.getWebApplicationContext().getEnvironment().getPropertySources();
 		localSkipperResource.getMockMvc()
 				.perform(get("/").header("Authorization", basicAuthorizationHeader("user", "secret10"))).andDo(print())
 				.andExpect(status().is3xxRedirection());


### PR DESCRIPTION
 - Add custom WebSercurityAutoConfiguration to control the Skipper web security
 - By default the security for all endpoints is disabled (similar to boot 1.5.x).
 - Use the spring.could.skipper.security.enabled=true property to enable the default Boot security
 - If the Skipper OAuth is enabled the custom WebSercurityAutoConfiguration is deactivated
 Note: In the future this customer security configuration will be replaced by the spring-cloud-common-security-config-web

 Resolve #751