### PR TITLE
Use Greenwich.RC1 fix OAuth2 conf dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
          release versions -->
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-build</artifactId>
-        <version>2.1.0.BUILD-SNAPSHOT</version>
+        <version>2.1.0.RC3</version>
         <relativePath />
     </parent>
 
@@ -36,12 +36,14 @@
         <!-- NOTE: Make sure to update `spring-cloud-build` version and `spring-cloud-dependencies` version (spring-cloud.version)
         are in sync with the https://github.com/spring-cloud/spring-cloud-release/blob/master/pom.xml updates for the respective
         release versions -->
-        <spring-cloud.version>Greenwich.BUILD-SNAPSHOT</spring-cloud.version>
-        <spring-cloud-services.version>2.0.2.RELEASE</spring-cloud-services.version> <!--TODO Tzolov: https://github.com/spring-cloud/spring-cloud-skipper/issues/750-->
-        <spring-cloud-sso.version>2.0.0.RELEASE</spring-cloud-sso.version>
+        <spring-cloud.version>Greenwich.RC1</spring-cloud.version>
+        <!--TODO Tzolov: https://github.com/spring-cloud/spring-cloud-skipper/issues/750-->
+        <spring-cloud-services.version>2.0.2.RELEASE</spring-cloud-services.version>
+
+        <spring-cloud-sso.version>2.1.3.RELEASE</spring-cloud-sso.version>
         <spring-cloud-deployer.version>2.0.0.M2</spring-cloud-deployer.version>
         <spring-cloud-deployer-local.version>2.0.0.M2</spring-cloud-deployer-local.version>
-	<!-- note - check version of reactor at deployer-cf/cf-java-client uses -->
+	    <!-- note - check version of reactor at deployer-cf/cf-java-client uses -->
         <spring-cloud-deployer-cloudfoundry.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
         <reactor.version>3.1.8.RELEASE</reactor.version>
         <spring-cloud-deployer-kubernetes.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-deployer-kubernetes.version>
@@ -125,6 +127,15 @@
                 <groupId>org.springframework.security.oauth</groupId>
                 <artifactId>spring-security-oauth2</artifactId>
                 <version>2.3.4.RELEASE</version>
+            </dependency>
+            <!--
+            Required to override the spring-cloud-sso-connector versions. Related to
+            https://github.com/spring-cloud/spring-cloud-skipper/issues/750
+            -->
+            <dependency>
+                <groupId>org.springframework.security.oauth.boot</groupId>
+                <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+                <version>${spring-boot.version}</version>
             </dependency>
 
             <dependency>

--- a/spring-cloud-skipper-dependencies/pom.xml
+++ b/spring-cloud-skipper-dependencies/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>2.1.0.BUILD-SNAPSHOT</version>
+		<version>2.1.0.RC3</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
 - Update pom to Spring Cloud Greenwich.RC1 train, along with spring cloud build 2.1.RC3
 - Override the oauth2 configuration imported by spring-cloud-sso to latest alined with boot 2.1.1

Resolves #767