### PR TITLE
Fix hibernate_sequence with MSSQL

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/resources/db/migration/sqlserver/V2__FIX_SEQUENCE.sql
+++ b/spring-cloud-skipper-server-core/src/main/resources/db/migration/sqlserver/V2__FIX_SEQUENCE.sql
@@ -1,0 +1,10 @@
+-- stash old hibernate_sequence table
+exec sp_rename 'hibernate_sequence', 'hibernate_sequence_old';  
+
+-- create new sequence with value from hibernate_sequence_old
+declare @max int;
+select @max = max(next_val) from hibernate_sequence_old;
+exec('create sequence hibernate_sequence start with ' + @max + ' increment by 1;');
+
+-- drop old table
+drop table hibernate_sequence_old;


### PR DESCRIPTION
- Add sqlserver/V2__FIX_SEQUENCE.sql which basically moves from `hibernate_sequence`
  table to a real sequence and copies existing value.
- Fixes #774

I did some manual testing locally and hopefully this actually fixes broken tests in concourse.