### PR TITLE
Enable configuration on connection pool on PCF - Take 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <spring-cloud.version>Edgware.SR5</spring-cloud.version>
         <spring-cloud-services.version>1.6.3.RELEASE</spring-cloud-services.version>
         <spring-cloud-sso.version>1.1.0.RELEASE</spring-cloud-sso.version>
+        <spring-cloud-cloudfoundry-connector>2.0.3.RELEASE</spring-cloud-cloudfoundry-connector>
         <spring-cloud-deployer.version>1.3.4.RELEASE</spring-cloud-deployer.version>
         <spring-cloud-deployer-local.version>1.3.10.RELEASE</spring-cloud-deployer-local.version>
 
@@ -173,6 +174,16 @@
                 <groupId>io.pivotal.spring.cloud</groupId>
                 <artifactId>spring-cloud-sso-connector</artifactId>
                 <version>${spring-cloud-sso.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-spring-service-connector</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- just having hikaricp.version didn't work, need to redefine dependency -->
             <dependency>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -183,12 +183,35 @@
         <dependency>
             <groupId>io.pivotal.spring.cloud</groupId>
             <artifactId>spring-cloud-services-starter-config-client</artifactId>
+            <version>1.6.3.RELEASE</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-spring-service-connector</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.pivotal.spring.cloud</groupId>
             <artifactId>spring-cloud-sso-connector</artifactId>
+            <version>${spring-cloud-sso.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+            <version>${spring-cloud-cloudfoundry-connector}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-spring-service-connector</artifactId>
+            <version>${spring-cloud-cloudfoundry-connector}</version>
+        </dependency>
+
          <dependency>
             <groupId>org.springframework.restdocs</groupId>
             <artifactId>spring-restdocs-mockmvc</artifactId>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/DataSourceCloudConfig.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/DataSourceCloudConfig.java
@@ -17,6 +17,9 @@ package org.springframework.cloud.skipper.server.config;
 
 import javax.sql.DataSource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.cloud.config.java.AbstractCloudConfig;
 import org.springframework.cloud.service.PooledServiceConnectorConfig;
 import org.springframework.cloud.service.relational.DataSourceConfig;
@@ -33,11 +36,15 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 public class DataSourceCloudConfig extends AbstractCloudConfig {
 
+	private final Logger logger = LoggerFactory.getLogger(DataSourceCloudConfig.class);
+
 	@Bean
 	public DataSource dataSource(SkipperServerProperties skipperServerProperties) {
+		int maxPoolSize = skipperServerProperties.getCloudFoundry().getMaxPoolSize();
+		int maxWaitTime = skipperServerProperties.getCloudFoundry().getMaxWaitTime();
 		PooledServiceConnectorConfig.PoolConfig poolConfig =
-				new PooledServiceConnectorConfig.PoolConfig(skipperServerProperties.getCloudFoundry().getMaxPoolSize(),
-						skipperServerProperties.getCloudFoundry().getMaxWaitTime());
+				new PooledServiceConnectorConfig.PoolConfig(maxPoolSize, maxWaitTime);
+		logger.info("Configured connection pool with max size " + maxPoolSize + " and max wait time " + maxWaitTime);
 		DataSourceConfig dbConfig = new DataSourceConfig(poolConfig, null);
 		return connectionFactory().dataSource(dbConfig);
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -109,17 +109,12 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @EnableAsync
 @Import({ StateMachinePersistConfiguration.class, StateMachineExecutorConfiguration.class,
-		StateMachineConfiguration.class, SecurityConfiguration.class })
+		StateMachineConfiguration.class, SecurityConfiguration.class, DataSourceCloudConfig.class })
 public class SkipperServerConfiguration implements AsyncConfigurer {
 
 	public static final String SKIPPER_EXECUTOR = "skipperThreadPoolTaskExecutor";
 
 	private final Logger logger = LoggerFactory.getLogger(SkipperServerConfiguration.class);
-
-	@Bean
-	public DataSourceCloudConfig dataSourceCloudConfig() {
-		return new DataSourceCloudConfig();
-	}
 
 	@Bean
 	public ErrorAttributes errorAttributes() {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -100,7 +100,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @Configuration
 @EnableConfigurationProperties({ SkipperServerProperties.class, VersionInfoProperties.class,
-		LocalPlatformProperties.class, /* CloudFoundryPlatformProperties.class, */ MavenConfigurationProperties.class,
+		LocalPlatformProperties.class, MavenConfigurationProperties.class,
 		HealthCheckProperties.class })
 @EntityScan({ "org.springframework.cloud.skipper.domain",
 		"org.springframework.cloud.skipper.server.domain" })
@@ -115,6 +115,11 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 	public static final String SKIPPER_EXECUTOR = "skipperThreadPoolTaskExecutor";
 
 	private final Logger logger = LoggerFactory.getLogger(SkipperServerConfiguration.class);
+
+	@Bean
+	public DataSourceCloudConfig dataSourceCloudConfig() {
+		return new DataSourceCloudConfig();
+	}
 
 	@Bean
 	public ErrorAttributes errorAttributes() {

--- a/spring-cloud-skipper-server/pom.xml
+++ b/spring-cloud-skipper-server/pom.xml
@@ -45,6 +45,37 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.pivotal.spring.cloud</groupId>
+            <artifactId>spring-cloud-services-starter-config-client</artifactId>
+            <version>1.6.3.RELEASE</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-spring-service-connector</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.pivotal.spring.cloud</groupId>
+            <artifactId>spring-cloud-sso-connector</artifactId>
+            <version>${spring-cloud-sso.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-cloudfoundry-connector</artifactId>
+            <version>${spring-cloud-cloudfoundry-connector}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-spring-service-connector</artifactId>
+            <version>${spring-cloud-cloudfoundry-connector}</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>


### PR DESCRIPTION
Added commit that imports `DataSourceCloudConfig` instead of creating it as a `@Bean`
 
Fixes #777 