### PR TITLE
Fix enableLocalPlatform property binding

### DIFF
--- a/spring-cloud-skipper-autoconfigure/pom.xml
+++ b/spring-cloud-skipper-autoconfigure/pom.xml
@@ -23,6 +23,11 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-skipper-platform-cloudfoundry</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/spring-cloud-skipper-autoconfigure/src/test/java/org/springframework/cloud/skipper/server/autoconfigure/SkipperServerPropertiesTests.java
+++ b/spring-cloud-skipper-autoconfigure/src/test/java/org/springframework/cloud/skipper/server/autoconfigure/SkipperServerPropertiesTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.autoconfigure;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.skipper.server.config.SkipperServerProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SkipperServerPropertiesTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+	@Test
+	public void defaultNoPropSet() {
+		this.contextRunner
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				SkipperServerProperties properties = context.getBean(SkipperServerProperties.class);
+				assertThat(properties.isEnableLocalPlatform()).isTrue();
+				assertThat(context).hasBean("myBean1");
+				assertThat(context).hasBean("myBean2");
+			});
+	}
+
+	@Test
+	public void noUnderscore() {
+		this.contextRunner
+			// env variables can only be tests by using SystemEnvironmentPropertySource
+			// and setting its name to 'systemEnvironment'
+			.withInitializer(context -> {
+				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+						StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+						Collections.singletonMap("SPRING_CLOUD_SKIPPER_SERVER_ENABLELOCALPLATFORM", "false")));
+			})
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				SkipperServerProperties properties = context.getBean(SkipperServerProperties.class);
+				assertThat(properties.isEnableLocalPlatform()).isFalse();
+				assertThat(context).doesNotHaveBean("myBean1");
+				assertThat(context).doesNotHaveBean("myBean2");
+			});
+	}
+
+	@Test
+	public void useUnderscore() {
+		this.contextRunner
+			.withInitializer(context -> {
+				context.getEnvironment().getPropertySources().addLast(new SystemEnvironmentPropertySource(
+						StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+						Collections.singletonMap("SPRING_CLOUD_SKIPPER_SERVER_ENABLE_LOCAL_PLATFORM", "false")));
+			})
+			.withUserConfiguration(Config1.class)
+			.run((context) -> {
+				SkipperServerProperties properties = context.getBean(SkipperServerProperties.class);
+				assertThat(properties.isEnableLocalPlatform()).isFalse();
+				// shows how underscores in a property name from env variable doesn't work
+				// if binding uses camel case format but works with kebab case naming.
+				// leaving this assert here for future reference in case it starts failing
+				assertThat(context).hasBean("myBean1");
+				assertThat(context).doesNotHaveBean("myBean2");
+			});
+	}
+
+	@EnableConfigurationProperties({ SkipperServerProperties.class })
+	private static class Config1 {
+
+		@Bean
+		@ConditionalOnProperty(value = "spring.cloud.skipper.server.enableLocalPlatform", matchIfMissing = true)
+		public String myBean1() {
+			return "hi";
+		}
+
+		@Bean
+		@ConditionalOnProperty(value = "spring.cloud.skipper.server.enable-local-platform", matchIfMissing = true)
+		public String myBean2() {
+			return "hi";
+		}
+	}
+}

--- a/spring-cloud-skipper-docs/src/main/asciidoc/installation.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/installation.adoc
@@ -99,7 +99,7 @@ applications:
   path: spring-cloud-skipper-server.jar
 env:
     SPRING_APPLICATION_NAME: mlp-skipper
-    SPRING_CLOUD_SKIPPER_SERVER_ENABLE_LOCAL_PLATFORM: false
+    SPRING_CLOUD_SKIPPER_SERVER_ENABLELOCALPLATFORM: false
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_URL: https://api.run.pivotal.io
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_ORG: myOrgQA
     SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_CONNECTION_SPACE: mySpaceQA
@@ -116,7 +116,7 @@ services:
 NOTE: In the preceding manifest, we bound the application to the `mysqlboost` service.
 If you do not specify a service, the server uses an embedded database.
 
-NOTE: You must set `SPRING_CLOUD_SKIPPER_SERVER_ENABLE_LOCAL_PLATFORM` to `false` so that the local platform deployer is never used.
+NOTE: You must set `SPRING_CLOUD_SKIPPER_SERVER_ENABLELOCALPLATFORM` to `false` so that the local platform deployer is never used.
 
 NOTE: You must set `SPRING_CLOUD_SKIPPER_SERVER_PLATFORM_CLOUDFOUNDRY_ACCOUNTS[pws]_DEPLOYMENT_DELETE_ROUTES: false` so that "`v2`" of an application has the same route as "`v1`".
 Otherwise, undeploying "`v1`" removes the route.

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class SkipperServerPlatformConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(value = "spring.cloud.skipper.server.enableLocalPlatform", matchIfMissing = true)
+	@ConditionalOnProperty(value = "spring.cloud.skipper.server.enable-local-platform", matchIfMissing = true)
 	public Platform localDeployers(LocalPlatformProperties localPlatformProperties) {
 		List<Deployer> deployers = new ArrayList<>();
 		Map<String, LocalDeployerProperties> localDeployerPropertiesMap = localPlatformProperties.getAccounts();


### PR DESCRIPTION
- Change `ConditionalOnProperty` to use kebab case from a camel case.
- Added binding tests to autoconfigure package because eventually
  SkipperServerProperties should be moved there as it's a boot class.
- Changed docs not to instruct to use underscores in env variable based
  property names.
- Fixes #764