### PR TITLE
Remove default experimental repo

### DIFF
--- a/spring-cloud-skipper-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/getting-started.adoc
@@ -55,7 +55,7 @@ There is also a docker image hosted on https://hub.docker.com/r/springcloud/spri
 == A Three-second Tour
 
 The default configuration of Skipper deploys apps to the local machine.
-The default configuration also has one local repository, named `local`, where you can upload packages, and one remote repository, named `experimental`, where some sample test packages are located.
+The default configuration also has one local repository, named `local`, where you can upload packages.
 You can get a list of the package repositories by using the command `repo list`, as shown (with its output) in the following example:
 
 [source,bash,options="nowrap"]
@@ -64,7 +64,6 @@ skipper:>repo list
 ╔════════════╤═══════════════════════════════════════════════════════════╤═════╤═════╗
 ║    Name    │                            URL                            │Local│Order║
 ╠════════════╪═══════════════════════════════════════════════════════════╪═════╪═════╣
-║experimental│http://skipper-repository.cfapps.io/repository/experimental│false│0    ║
 ║local       │http://10.55.13.45:7577                                    │true │1    ║
 ╚════════════╧═══════════════════════════════════════════════════════════╧═════╧═════╝
 ----

--- a/spring-cloud-skipper-docs/src/main/asciidoc/installation.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/installation.adoc
@@ -81,7 +81,7 @@ NOTE: The `deleteRoutes` deployment setting is `false` so that "`v2`" of an appl
 Otherwise, undeploying "`v1`" removes the route.
 
 You can also run the Skipper server locally and deploy to Cloud Foundry.
-In this case, it is more convenient to specify the configuration in a `skipper.yml` file and start the server with the `--spring.config.location=skipper.yml` option.
+In this case, it is more convenient to specify the configuration in a `skipper.yml` file and start the server with the `--spring.config.additional-location=skipper.yml` option.
 
 If you use `cf push` to deploy Skipper, a Cloud Foundry manifest is more appropriate to use.
 You can modify the following sample manifest.yml to fit your needs:

--- a/spring-cloud-skipper-docs/src/main/asciidoc/security.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/security.adoc
@@ -37,7 +37,7 @@ server:
 <6> The path to the truststore file. Classpath resources may also be specified, by using the classpath prefix: `classpath:path/to/trust-store`
 <7> The password of the trust store.
 
-TIP: You can reference the YAML file using the following parameter: `--spring.config.location=skipper.yml`
+TIP: You can reference the YAML file using the following parameter: `--spring.config.additional-location=skipper.yml`
 
 NOTE: If HTTPS is enabled, it completely replaces HTTP as the protocol over which the REST endpoints interact.
 Plain HTTP requests then fail. Therefore, you must make sure that you configure the Skipper shell accordingly.

--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
@@ -781,19 +781,20 @@ Released demo. Now at version v1.
 
 Congratulations! You have now created, packaged, uploaded, and installed your own Skipper package!
 
+[[using-repositories]]
 == Repositories
 
 Repositories store package metadata and host package .zip files.
 Repositores can be local or remote, were local means backed by Skipper's relational database and remote means a filesystem exposed over HTTP.
 
-When registering a remote registry (for example, the `experimental` one that is currently defined by default in addition to one named local`), use the following format:
+When registering a remote registry (for example, the `experimental` one that is currently not defined by default in addition to one named local`), use the following format:
 
 ----
 spring
   cloud:
     skipper:
       server:
-        packageRepositories:
+        package-repositories:
           -
             name: experimental
             url: http://skipper-repository.cfapps.io/repository/experimental
@@ -807,6 +808,8 @@ spring
             repoOrder: 1
 
 ----
+
+IMPORTANT: When modifying default configuration you need to re-define everything under `spring.cloud.skipper.server.package-repositories`.
 
 The `repoOrder` determines which repository serves up a package if one with the same name is registered in two or more repositories.
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-minute-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-minute-tour.adoc
@@ -215,6 +215,9 @@ skipper:>repo list
 ╚════════════╧═══════════════════════════════════════════════════════════╧═════╧═════╝
 ----
 
+NOTE: Above example assumes that `experimental` repository has been added to the server configuration. More about
+working with repositories can be found from <<using-repositories>>.
+
 The following example shows the `package search` command and the output of our example:
 
 [source,bash,options="nowrap"]
@@ -526,7 +529,7 @@ NOTE: The upgrade approach in 1.02 does not correctly handle the routing of HTTP
 The Spring Cloud Deployer for Kubernetes creates a service, a replication controller, and a pod for the app (or, optionally, a deployment).
 This is not an issue for apps that communicate over Messaging middleware and will be addressed in a future release.
 
-Start the Skipper server with the `--spring.config.location=skipper.yml` option. The YAML content follows:
+Start the Skipper server with the `--spring.config.additional-location=skipper.yml` option. The YAML content follows:
 
 ----
 spring:

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -35,12 +35,7 @@ spring:
               url: "{repository}/org/springframework/cloud/spring-cloud-skipper-shell/{version}/spring-cloud-skipper-shell-{version}.jar"
               checksum-sha1-url: "{repository}/org/springframework/cloud/spring-cloud-skipper-shell/{version}/spring-cloud-skipper-shell-{version}.jar.sha1"
               checksum-sha256-url: "{repository}/org/springframework/cloud/spring-cloud-skipper-shell/{version}/spring-cloud-skipper-shell-{version}.jar.sha256"
-        packageRepositories:
-          -
-            name: experimental
-            url: http://skipper-repository.cfapps.io/repository/experimental
-            description: Experimental Skipper Repository
-            repoOrder: 0
+        package-repositories:
           -
             name: local
             url: http://${spring.cloud.client.hostname}:7577


### PR DESCRIPTION
- Remove experimental remote sample repo from a default
  configuration and document how to add it back. This should
  allow server to start with access to internet.
- Fixes #762