### PR TITLE
Fix mysql initial hibernate_sequence value

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/mysql/V1__Initial_Setup.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/mysql/V1__Initial_Setup.java
@@ -25,11 +25,13 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 
 	public final static String CREATE_HIBERNATE_SEQUENCE_TABLE =
 			"create table if not exists hibernate_sequence (\n" +
-			"  next_val bigint\n" +
+			"    next_val bigint\n" +
 			")";
 
 	public final static String INSERT_HIBERNATE_SEQUENCE_TABLE =
-			"insert into hibernate_sequence values ( 1 )";
+			"insert into hibernate_sequence (next_val)\n" +
+			"    select * from (select 1 as next_val) as temp\n" +
+			"    where not exists(select * from hibernate_sequence)";
 
 	public final static String CREATE_SKIPPER_APP_DEPLOYER_DATA_TABLE =
 			"create table skipper_app_deployer_data (\n" +


### PR DESCRIPTION
- As mysql don't have a real sequence, initial value
  needs to be inserted. This change makes sure that
  we only insert value once and that value will be 1.
- Similar fix will also be done on a dataflow side.
- Fixes #815