### PR TITLE
Fix blob size in state_machine table

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/db2/V1__Initial_Setup.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/db2/V1__Initial_Setup.java
@@ -182,7 +182,7 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 			"create table state_machine (\n" +
 			"    machine_id varchar(255) not null,\n" +
 			"    state varchar(255),\n" +
-			"    state_machine_context blob(255),\n" +
+			"    state_machine_context blob(1048576),\n" +
 			"    primary key (machine_id)\n" +
 			")";
 


### PR DESCRIPTION
- Use same blob size used elsewhere as for some reason
  this value has been way too low as given to use
  by schema generation tests.
- We simply change value in initial schema as it has been wrong
  and schema has been non-functional, there can't be existing users.
- Fixes #819