### PR TITLE
Change package-repositories config from list to map

### DIFF
--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
@@ -795,13 +795,11 @@ spring
     skipper:
       server:
         package-repositories:
-          -
-            name: experimental
+          experimental:
             url: http://skipper-repository.cfapps.io/repository/experimental
             description: Experimental Skipper Repository
             repoOrder: 0
-          -
-            name: local
+          local:
             url: http://${spring.cloud.client.hostname}:7577
             local: true
             description: Default local database backed repository
@@ -809,7 +807,7 @@ spring
 
 ----
 
-IMPORTANT: When modifying default configuration you need to re-define everything under `spring.cloud.skipper.server.package-repositories`.
+IMPORTANT: For Skipper 2.x, `spring.cloud.skipper.server.package-repositories` structure has been changed from a list to a map where key is the repository name. Having a map format makes it easier to define and override configuration values.
 
 The `repoOrder` determines which repository serves up a package if one with the same name is registered in two or more repositories.
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerProperties.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  */
 package org.springframework.cloud.skipper.server.config;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.skipper.domain.Repository;
 
 /**
  * Configurable properties of the server.
@@ -33,9 +32,9 @@ public class SkipperServerProperties {
 	private CloudFoundry cloudFoundry = new CloudFoundry();
 
 	/**
-	 * List of locations for package Repositories
+	 * Map of Package Repositories configurations.
 	 */
-	private List<Repository> packageRepositories = new ArrayList<>();
+	private Map<String, PackageRepository> packageRepositories = new HashMap<>();
 
 	/**
 	 * Flag indicating to sync the local contents of the index directory with the database on
@@ -54,11 +53,11 @@ public class SkipperServerProperties {
 	 */
 	private boolean enableReleaseStateUpdateService;
 
-	public List<Repository> getPackageRepositories() {
+	public Map<String, PackageRepository> getPackageRepositories() {
 		return packageRepositories;
 	}
 
-	public void setPackageRepositories(List<Repository> packageRepositories) {
+	public void setPackageRepositories(Map<String, PackageRepository> packageRepositories) {
 		this.packageRepositories = packageRepositories;
 	}
 
@@ -114,6 +113,55 @@ public class SkipperServerProperties {
 
 		public void setMaxWaitTime(int maxWaitTime) {
 			this.maxWaitTime = maxWaitTime;
+		}
+	}
+
+	public static class PackageRepository {
+
+		private String url;
+		private String sourceUrl;
+		private Boolean local = false;
+		private String description;
+		private Integer repoOrder;
+
+		public String getUrl() {
+			return url;
+		}
+
+		public void setUrl(String url) {
+			this.url = url;
+		}
+
+		public String getSourceUrl() {
+			return sourceUrl;
+		}
+
+		public void setSourceUrl(String sourceUrl) {
+			this.sourceUrl = sourceUrl;
+		}
+
+		public Boolean getLocal() {
+			return local;
+		}
+
+		public void setLocal(Boolean local) {
+			this.local = local;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+
+		public Integer getRepoOrder() {
+			return repoOrder;
+		}
+
+		public void setRepoOrder(Integer repoOrder) {
+			this.repoOrder = repoOrder;
 		}
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
               checksum-sha1-url: "{repository}/org/springframework/cloud/spring-cloud-skipper-shell/{version}/spring-cloud-skipper-shell-{version}.jar.sha1"
               checksum-sha256-url: "{repository}/org/springframework/cloud/spring-cloud-skipper-shell/{version}/spring-cloud-skipper-shell-{version}.jar.sha256"
         package-repositories:
-          -
+          local:
             name: local
             url: http://${spring.cloud.client.hostname}:7577
             local: true

--- a/spring-cloud-skipper-server-core/src/test/resources/application-repo-test.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/application-repo-test.yml
@@ -2,13 +2,11 @@ spring:
   cloud:
     skipper:
       server:
-        packageRepositories:
-          -
-            name: test
+        package-repositories:
+          test:
             url: "classpath:/repositories/binaries/test"
             description: test repository with a few packages
-          -
-            name: local
+          local:
             url: "http://localhost:7577"
             local: true
             description: Default local database backed repository


### PR DESCRIPTION
- Change actual configuration class not to use `Repository` entity class
  directly and introduce `PackageRepository` which is then used in
  `RepositoryInitializationService` to wire settings.
- Fix tests and docs.
- With this it's now possible to change values i.e. using
  spring.cloud.skipper.server.package-repositories.local.local=false
- Fixes #789