### PR TITLE
URL Cleanup

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -54,7 +54,7 @@ configure(allprojects) {
 		maven { url "https://dl.bintray.com/palantir/releases" }
 		mavenLocal()
 		maven {
-			url "http://repo.springsource.org/ext-private-local"
+			url "https://repo.springsource.org/ext-private-local"
 			credentials {
 				username = System.getenv('ARTIFACTORY_USERNAME') ?: artifactoryUsername
 				password = System.getenv('ARTIFACTORY_PASSWORD') ?: artifactoryPassword

--- a/acceptance-tests/custom-apps/skipper-server-with-drivers100/build.gradle
+++ b/acceptance-tests/custom-apps/skipper-server-with-drivers100/build.gradle
@@ -25,11 +25,11 @@ sourceCompatibility = 1.8
 repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
-	maven { url "http://repo.springsource.org/libs-release" }
-	maven { url "http://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
 	maven {
-		url "http://repo.springsource.org/ext-private-local"
+		url "https://repo.springsource.org/ext-private-local"
 		credentials {
             username = System.getenv('ARTIFACTORY_USERNAME') ?: artifactoryUsername
             password = System.getenv('ARTIFACTORY_PASSWORD') ?: artifactoryPassword

--- a/acceptance-tests/custom-apps/skipper-server-with-drivers101/build.gradle
+++ b/acceptance-tests/custom-apps/skipper-server-with-drivers101/build.gradle
@@ -25,11 +25,11 @@ sourceCompatibility = 1.8
 repositories {
 	mavenCentral()
 	mavenLocal()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
-	maven { url "http://repo.springsource.org/libs-release" }
-	maven { url "http://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
 	maven {
-		url "http://repo.springsource.org/ext-private-local"
+		url "https://repo.springsource.org/ext-private-local"
 		credentials {
             username = System.getenv('ARTIFACTORY_USERNAME') ?: artifactoryUsername
             password = System.getenv('ARTIFACTORY_PASSWORD') ?: artifactoryPassword

--- a/acceptance-tests/custom-apps/skipper-server-with-drivers102/build.gradle
+++ b/acceptance-tests/custom-apps/skipper-server-with-drivers102/build.gradle
@@ -27,11 +27,11 @@ sourceCompatibility = 1.8
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
-	maven { url "http://repo.springsource.org/libs-release" }
-	maven { url "http://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
 	maven {
-		url "http://repo.springsource.org/ext-private-local"
+		url "https://repo.springsource.org/ext-private-local"
 		credentials {
 			username = System.getenv('ARTIFACTORY_USERNAME') ?: artifactoryUsername
 			password = System.getenv('ARTIFACTORY_PASSWORD') ?: artifactoryPassword

--- a/acceptance-tests/custom-apps/skipper-server-with-drivers103/build.gradle
+++ b/acceptance-tests/custom-apps/skipper-server-with-drivers103/build.gradle
@@ -27,11 +27,11 @@ sourceCompatibility = 1.8
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
-	maven { url "http://repo.springsource.org/libs-release" }
-	maven { url "http://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
 	maven {
-		url "http://repo.springsource.org/ext-private-local"
+		url "https://repo.springsource.org/ext-private-local"
 		credentials {
 			username = System.getenv('ARTIFACTORY_USERNAME') ?: artifactoryUsername
 			password = System.getenv('ARTIFACTORY_PASSWORD') ?: artifactoryPassword

--- a/acceptance-tests/custom-apps/skipper-server-with-drivers104/build.gradle
+++ b/acceptance-tests/custom-apps/skipper-server-with-drivers104/build.gradle
@@ -27,11 +27,11 @@ sourceCompatibility = 1.8
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
-	maven { url "http://repo.springsource.org/libs-release" }
-	maven { url "http://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
 	maven {
-		url "http://repo.springsource.org/ext-private-local"
+		url "https://repo.springsource.org/ext-private-local"
 		credentials {
 			username = System.getenv('ARTIFACTORY_USERNAME') ?: artifactoryUsername
 			password = System.getenv('ARTIFACTORY_PASSWORD') ?: artifactoryPassword

--- a/acceptance-tests/custom-apps/skipper-server-with-drivers105/build.gradle
+++ b/acceptance-tests/custom-apps/skipper-server-with-drivers105/build.gradle
@@ -27,11 +27,11 @@ sourceCompatibility = 1.8
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
-	maven { url "http://repo.springsource.org/libs-release" }
-	maven { url "http://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
 	maven {
-		url "http://repo.springsource.org/ext-private-local"
+		url "https://repo.springsource.org/ext-private-local"
 		credentials {
 			username = System.getenv('ARTIFACTORY_USERNAME') ?: artifactoryUsername
 			password = System.getenv('ARTIFACTORY_PASSWORD') ?: artifactoryPassword

--- a/acceptance-tests/custom-apps/skipper-server-with-drivers110/build.gradle
+++ b/acceptance-tests/custom-apps/skipper-server-with-drivers110/build.gradle
@@ -27,11 +27,11 @@ sourceCompatibility = 1.8
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
-	maven { url "http://repo.springsource.org/libs-release" }
-	maven { url "http://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
 	maven {
-		url "http://repo.springsource.org/ext-private-local"
+		url "https://repo.springsource.org/ext-private-local"
 		credentials {
 			username = System.getenv('ARTIFACTORY_USERNAME') ?: artifactoryUsername
 			password = System.getenv('ARTIFACTORY_PASSWORD') ?: artifactoryPassword

--- a/acceptance-tests/docker-images/oracle/dockerfiles/12.1.0.2/installPerl.sh
+++ b/acceptance-tests/docker-images/oracle/dockerfiles/12.1.0.2/installPerl.sh
@@ -17,7 +17,7 @@ set -e
 
 cd $INSTALL_DIR
 mv $ORACLE_HOME/perl $ORACLE_HOME/perl.old
-curl -o perl.tar.gz http://www.cpan.org/src/5.0/perl-5.14.1.tar.gz
+curl -o perl.tar.gz https://www.cpan.org/src/5.0/perl-5.14.1.tar.gz
 tar -xzf perl.tar.gz
 cd perl-*
 ./Configure -des -Dprefix=$ORACLE_HOME/perl -Doptimize=-O3 -Dusethreads -Duseithreads -Duserelocatableinc

--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-skipper-parent</artifactId>
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
     <organization>
         <name>Pivotal Software, Inc.</name>
-        <url>http://www.spring.io</url>
+        <url>https://www.spring.io</url>
     </organization>
     <parent>
         <!-- NOTE: Make sure to update `spring-cloud-build` version and `spring-cloud-dependencies` version (spring-cloud.version)
@@ -253,7 +253,7 @@
                     <excludes>
                         <exclude>**/Abstract*.java</exclude>
                     </excludes>
-                    <!-- see http://stackoverflow.com/questions/18107375/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-upon-exec -->
+                    <!-- see https://stackoverflow.com/questions/18107375/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-upon-exec -->
                     <argLine>${argLine}</argLine>
                 </configuration>
             </plugin>
@@ -371,7 +371,7 @@
                 <repository>
                     <id>spring-snapshots</id>
                     <name>Spring Snapshots</name>
-                    <url>http://repo.spring.io/libs-snapshot</url>
+                    <url>https://repo.spring.io/libs-snapshot</url>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
@@ -379,7 +379,7 @@
                 <repository>
                     <id>spring-milestones</id>
                     <name>Spring Milestones</name>
-                    <url>http://repo.spring.io/libs-milestone-local</url>
+                    <url>https://repo.spring.io/libs-milestone-local</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
@@ -387,7 +387,7 @@
                 <repository>
                     <id>spring-releases</id>
                     <name>Spring Releases</name>
-                    <url>http://repo.spring.io/release</url>
+                    <url>https://repo.spring.io/release</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
@@ -397,7 +397,7 @@
                 <pluginRepository>
                     <id>spring-snapshots</id>
                     <name>Spring Snapshots</name>
-                    <url>http://repo.spring.io/libs-snapshot-local</url>
+                    <url>https://repo.spring.io/libs-snapshot-local</url>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
@@ -405,7 +405,7 @@
                 <pluginRepository>
                     <id>spring-milestones</id>
                     <name>Spring Milestones</name>
-                    <url>http://repo.spring.io/libs-milestone-local</url>
+                    <url>https://repo.spring.io/libs-milestone-local</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>

--- a/spring-cloud-skipper-autoconfigure/pom.xml
+++ b/spring-cloud-skipper-autoconfigure/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-skipper-autoconfigure</artifactId>
 	<packaging>jar</packaging>

--- a/spring-cloud-skipper-client/pom.xml
+++ b/spring-cloud-skipper-client/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-skipper-client</artifactId>
     <packaging>jar</packaging>

--- a/spring-cloud-skipper-dependencies/pom.xml
+++ b/spring-cloud-skipper-dependencies/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<version>1.1.5.BUILD-SNAPSHOT</version>
 	<artifactId>spring-cloud-skipper-dependencies</artifactId>

--- a/spring-cloud-skipper-docs/pom.xml
+++ b/spring-cloud-skipper-docs/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.cloud</groupId>
@@ -85,9 +85,9 @@
                                     <stylesheetfile>${basedir}/src/main/javadoc/spring-javadoc.css</stylesheetfile>
                                     <links>
                                         <link>
-                                            http://docs.spring.io/spring-framework/docs/${spring.version}/javadoc-api/
+                                            https://docs.spring.io/spring-framework/docs/${spring.version}/javadoc-api/
                                         </link>
-                                        <link>http://docs.spring.io/spring-shell/docs/current/api/</link>
+                                        <link>https://docs.spring.io/spring-shell/docs/current/api/</link>
                                     </links>
                                 </configuration>
                             </execution>

--- a/spring-cloud-skipper-platform-cloudfoundry/pom.xml
+++ b/spring-cloud-skipper-platform-cloudfoundry/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-skipper-platform-cloudfoundry</artifactId>
     <packaging>jar</packaging>

--- a/spring-cloud-skipper-platform-kubernetes/pom.xml
+++ b/spring-cloud-skipper-platform-kubernetes/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-skipper-platform-kubernetes</artifactId>
     <packaging>jar</packaging>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-skipper-server-core</artifactId>
     <packaging>jar</packaging>

--- a/spring-cloud-skipper-server/pom.xml
+++ b/spring-cloud-skipper-server/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-skipper-server</artifactId>
     <packaging>jar</packaging>

--- a/spring-cloud-skipper-shell-commands/pom.xml
+++ b/spring-cloud-skipper-shell-commands/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-skipper-shell-commands</artifactId>
     <name>Spring Cloud Skipper :: Shell Commands</name>

--- a/spring-cloud-skipper-shell/pom.xml
+++ b/spring-cloud-skipper-shell/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-skipper-shell</artifactId>
     <name>Spring Cloud Skipper :: Shell</name>

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>spring-cloud-skipper</artifactId>
     <packaging>jar</packaging>

--- a/spring-cloud-starter-skipper-server/pom.xml
+++ b/spring-cloud-starter-skipper-server/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-starter-skipper-server</artifactId>
 	<packaging>jar</packaging>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.spring.io/spring-framework/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/ ([https](https://docs.spring.io/spring-framework/docs/) result 200).
* http://docs.spring.io/spring-shell/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-shell/docs/current/api/ ([https](https://docs.spring.io/spring-shell/docs/current/api/) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 13 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://stackoverflow.com/questions/18107375/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-upon-exec with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/18107375/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-upon-exec ([https](https://stackoverflow.com/questions/18107375/getting-skipping-jacoco-execution-due-to-missing-execution-data-file-upon-exec) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.cpan.org/src/5.0/perl-5.14.1.tar.gz with 1 occurrences migrated to:  
  https://www.cpan.org/src/5.0/perl-5.14.1.tar.gz ([https](https://www.cpan.org/src/5.0/perl-5.14.1.tar.gz) result 200).
* http://repo.springsource.org/ext-private-local with 8 occurrences migrated to:  
  https://repo.springsource.org/ext-private-local ([https](https://repo.springsource.org/ext-private-local) result 301).
* http://repo.springsource.org/libs-milestone with 7 occurrences migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-release with 7 occurrences migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/libs-snapshot with 7 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://www.spring.io with 1 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://repo.spring.io/libs-milestone-local with 2 occurrences migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/libs-snapshot-local with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).
* http://repo.spring.io/release with 1 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 26 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 13 occurrences