### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 image:https://codecov.io/gh/spring-cloud/spring-cloud-skipper/branch/master/graph/badge.svg["Codecov", link="https://codecov.io/gh/spring-cloud/spring-cloud-skipper/branch/master"]
 
-== Spring Cloud Skipper image:https://build.spring.io/plugins/servlet/wittified/build-status/SCSKIP-BMASTER[Build Status, link=https://build.spring.io/browse/SCSKIP] image:https://badge.waffle.io/spring-cloud/spring-cloud-skipper.svg?label=ready&title=Ready[Stories Ready, link=http://waffle.io/spring-cloud/spring-cloud-skipper] image:https://badge.waffle.io/spring-cloud/spring-cloud-skipper.svg?label=In%20Progress&title=In%20Progress[Stories In Progress, link=http://waffle.io/spring-cloud/spring-cloud-skipper]
+== Spring Cloud Skipper image:https://build.spring.io/plugins/servlet/wittified/build-status/SCSKIP-BMASTER[Build Status, link=https://build.spring.io/browse/SCSKIP] image:https://badge.waffle.io/spring-cloud/spring-cloud-skipper.svg?label=ready&title=Ready[Stories Ready, link=https://waffle.io/spring-cloud/spring-cloud-skipper] image:https://badge.waffle.io/spring-cloud/spring-cloud-skipper.svg?label=In%20Progress&title=In%20Progress[Stories In Progress, link=https://waffle.io/spring-cloud/spring-cloud-skipper]
 
 == Spring Cloud Skipper
 

--- a/acceptance-tests/docker-images/oracle/dockerfiles/11.2.0.2/Dockerfile.xe
+++ b/acceptance-tests/docker-images/oracle/dockerfiles/11.2.0.2/Dockerfile.xe
@@ -10,7 +10,7 @@
 # ----------------------------------
 # (1) oracle-xe-11.2.0-1.0.x86_64.rpm.zip
 #     Download Oracle Database 11g Release 2 Express Edition for Linux x64
-#     from http://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html
+#     from https://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------

--- a/acceptance-tests/docker-images/oracle/dockerfiles/12.1.0.2/Dockerfile.ee
+++ b/acceptance-tests/docker-images/oracle/dockerfiles/12.1.0.2/Dockerfile.ee
@@ -11,7 +11,7 @@
 # (1) linuxamd64_12102_database_1of2.zip
 #     linuxamd64_12102_database_2of2.zip
 #     Download Oracle Database 12c Release 1 Enterprise Edition for Linux x64
-#     from http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
+#     from https://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------

--- a/acceptance-tests/docker-images/oracle/dockerfiles/12.1.0.2/Dockerfile.se2
+++ b/acceptance-tests/docker-images/oracle/dockerfiles/12.1.0.2/Dockerfile.se2
@@ -11,7 +11,7 @@
 # (1) linuxamd64_12102_database_se2_1of2.zip
 #     linuxamd64_12102_database_se2_2of2.zip
 #     Download Oracle Database 12c Release 1 Standard Edition 2 for Linux x64
-#     from http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
+#     from https://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------

--- a/acceptance-tests/docker-images/oracle/dockerfiles/12.2.0.1/Dockerfile.ee
+++ b/acceptance-tests/docker-images/oracle/dockerfiles/12.2.0.1/Dockerfile.ee
@@ -10,7 +10,7 @@
 # ----------------------------------
 # (1) linuxx64_12201_database.zip
 #     Download Oracle Database 12c Release 12 Enterprise Edition for Linux x64
-#     from http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
+#     from https://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------

--- a/acceptance-tests/docker-images/oracle/dockerfiles/12.2.0.1/Dockerfile.se2
+++ b/acceptance-tests/docker-images/oracle/dockerfiles/12.2.0.1/Dockerfile.se2
@@ -10,7 +10,7 @@
 # ----------------------------------
 # (1) linuxx64_12201_database.zip
 #     Download Oracle Database 12c Release 12 Standard Edition 2 for Linux x64
-#     from http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
+#     from https://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html
 #
 # HOW TO BUILD THIS IMAGE
 # -----------------------

--- a/spring-cloud-skipper-client/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/log/package.yml
+++ b/spring-cloud-skipper-client/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/log/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-client/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/time/package.yml
+++ b/spring-cloud-skipper-client/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/time/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: time
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: time, source
 maintainer: https://github.com/sobychacko
 description: The time source periodically emits a timestamp string.

--- a/spring-cloud-skipper-docs/src/main/asciidoc/appendix-building.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/appendix-building.adoc
@@ -82,7 +82,7 @@ Working build file for _Maven_ would look like something shown below:
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>
@@ -185,9 +185,9 @@ sourceCompatibility = 1.8
 repositories {
 	mavenLocal()
 	mavenCentral()
-	maven { url "http://repo.springsource.org/libs-snapshot" }
-	maven { url "http://repo.springsource.org/libs-release" }
-	maven { url "http://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-snapshot" }
+	maven { url "https://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
 }
 
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/appendix-contributing.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/appendix-contributing.adoc
@@ -24,5 +24,5 @@ To do so, copy from existing files in the project.
 * Add some Javadocs and, if you change the namespace, some XSD doc elements.
 * A few unit tests would help a lot as well -- someone has to do it, and your fellow developers appreciate it.
 * If no-one else is using your branch, please rebase it against the current master (or other target branch in the main project).
-* When writing a commit message, please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions].
+* When writing a commit message, please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions].
 If you are fixing an existing issue, please add `Fixes gh-XXXX` at the end of the commit message (where XXXX is the issue number).

--- a/spring-cloud-skipper-docs/src/main/asciidoc/appendix.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/appendix.adoc
@@ -5,8 +5,8 @@
 --
 Having trouble with Spring Cloud Skipper, We'd like to help!
 
-* Ask a question - we monitor http://stackoverflow.com[stackoverflow.com] for questions
-  tagged with http://stackoverflow.com/tags/spring-cloud-skipper[`spring-cloud-skipper`].
+* Ask a question - we monitor https://stackoverflow.com[stackoverflow.com] for questions
+  tagged with https://stackoverflow.com/tags/spring-cloud-skipper[`spring-cloud-skipper`].
 * Report bugs with Spring Cloud Skipper at https://github.com/spring-cloud/spring-cloud-skipper/issues.
 --
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/command-reference.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/command-reference.adoc
@@ -873,8 +873,8 @@ skipper:>repo list
 ╔════════════╤═══════════════════════════════════════════════════════════╤═════╤═════╗
 ║    Name    │                            URL                            │Local│Order║
 ╠════════════╪═══════════════════════════════════════════════════════════╪═════╪═════╣
-║experimental│http://skipper-repository.cfapps.io/repository/experimental│false│0    ║
-║local       │http://10.55.13.45:7577                                    │true │1    ║
+║experimental│https://skipper-repository.cfapps.io/repository/experimental│false│0    ║
+║local       │https://10.55.13.45:7577                                    │true │1    ║
 ╚════════════╧═══════════════════════════════════════════════════════════╧═════╧═════╝
 ----
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/getting-started.adoc
@@ -29,9 +29,9 @@ It also shows additional options for installing on your local machine.
 
 [source,bash,subs=attributes]
 ```
-wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{project-version}/spring-cloud-skipper-server-{project-version}.jar
+wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-server/{project-version}/spring-cloud-skipper-server-{project-version}.jar
 
-wget http://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-shell/{project-version}/spring-cloud-skipper-shell-{project-version}.jar
+wget https://repo.spring.io/{version-type-lowercase}/org/springframework/cloud/spring-cloud-skipper-shell/{project-version}/spring-cloud-skipper-shell-{project-version}.jar
 ```
 
 * Launch the server and shell apps by using the following commands in a terminal session:
@@ -64,7 +64,7 @@ skipper:>repo list
 ╔════════════╤═══════════════════════════════════════════════════════════╤═════╤═════╗
 ║    Name    │                            URL                            │Local│Order║
 ╠════════════╪═══════════════════════════════════════════════════════════╪═════╪═════╣
-║local       │http://10.55.13.45:7577                                    │true │1    ║
+║local       │https://10.55.13.45:7577                                    │true │1    ║
 ╚════════════╧═══════════════════════════════════════════════════════════╧═════╧═════╝
 ----
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/index.adoc
@@ -9,9 +9,9 @@ Mark Pollack; Ilayaperumal Gopinathan; Janne Valkealahti; Gunnar Hillert; Sabby 
 :hide-uri-scheme:
 :docinfo: shared
 
-:spring-cloud-skipper-docs: http://docs.spring.io/spring-cloud-skipper/docs/{project-version}/reference
-:spring-cloud-skipper-docs-current: http://docs.spring.io/spring-cloud-skipper/docs/current-SNAPSHOT/reference/htmlsingle/
-:spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html
+:spring-cloud-skipper-docs: https://docs.spring.io/spring-cloud-skipper/docs/{project-version}/reference
+:spring-cloud-skipper-docs-current: https://docs.spring.io/spring-cloud-skipper/docs/current-SNAPSHOT/reference/htmlsingle/
+:spring-cloud-stream-docs: https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html
 :github-repo: spring-cloud/spring-cloud-skipper
 :github-code: https://github.com/{github-repo}
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/preface.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/preface.adoc
@@ -4,7 +4,7 @@
 [[skipper-documentation-about]]
 == About the Documentation
 
-The documentation for this release is available in http://docs.spring.io/spring-cloud-skipper/docs/{project-version}/reference/htmlsingle[HTML].
+The documentation for this release is available in https://docs.spring.io/spring-cloud-skipper/docs/{project-version}/reference/htmlsingle[HTML].
 
 The latest copy of the Spring Cloud Skipper reference guide can be found {spring-cloud-skipper-docs-current}[here].
 
@@ -17,8 +17,8 @@ print or electronically.
 == Getting Help
 If you are having trouble with Spring Cloud Skipper, we would like to help!
 
-* Ask a question. We monitor http://stackoverflow.com[stackoverflow.com] for questions
-  tagged with http://stackoverflow.com/tags/spring-cloud-skipper[`spring-cloud-skipper`].
+* Ask a question. We monitor https://stackoverflow.com[stackoverflow.com] for questions
+  tagged with https://stackoverflow.com/tags/spring-cloud-skipper[`spring-cloud-skipper`].
 * Reach out to us on https://gitter.im/spring-cloud/spring-cloud-skipper[gitter].
 * Report bugs with Spring Cloud Skipper at https://github.com/spring-cloud/spring-cloud-skipper/issues.
 

--- a/spring-cloud-skipper-docs/src/main/asciidoc/security.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/security.adoc
@@ -284,7 +284,7 @@ where
 
 * HTTP_METHOD is one http method, capital case.
 * URL_PATTERN is an Ant-style URL pattern.
-* SECURITY_ATTRIBUTE is a SpEL expression (see http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#el-access)
+* SECURITY_ATTRIBUTE is a SpEL expression (see https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#el-access)
 * Each of those parts is separated by one or several white space characters (spaces, tabs, and others).
 
 Be mindful that the above is indeed a YAML list, not a map (thus the use of '-' dashes at the start of each line) that lives under the `spring.cloud.skipper.security.authorization.rules` key.
@@ -340,7 +340,7 @@ This section provides examples of some common security arrangements for Skipper:
 [[skipper-security-local-oauth2-server]]
 ==== Local OAuth2 Server
 
-With http://projects.spring.io/spring-security-oauth/[Spring Security OAuth], you
+With https://projects.spring.io/spring-security-oauth/[Spring Security OAuth], you
 can create your own OAuth2 Server by using the following annotations:
 
 * `@EnableResourceServer`

--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-hour-tour.adoc
@@ -94,7 +94,7 @@ Usually, different `accounts` correspond to different orgs or spaces for Cloud F
 Platforms are defined by using Spring Boot's https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html[Externalized Configuration] feature.
 To simplify the getting started experience, if a local platform account is not defined in your configuration, Skipper creates a `local` deployer implementation named `default`.
 
-You can make use of the http://cloud.spring.io/spring-cloud-static/spring-cloud-config/1.3.3.RELEASE/multi/multi__spring_cloud_config_server.html#_encryption_and_decryption[Encryption and Decryption] features of Spring Cloud Config as one way to secure credentials.
+You can make use of the https://cloud.spring.io/spring-cloud-static/spring-cloud-config/1.3.3.RELEASE/multi/multi__spring_cloud_config_server.html#_encryption_and_decryption[Encryption and Decryption] features of Spring Cloud Config as one way to secure credentials.
 
 Distinct from where Skipper deploys the application, you can also run the Skipper server itself on a platform.
 Installation on other platforms is covered in the <<skipper-installation>> section.
@@ -270,7 +270,7 @@ Currently only supported _kind_ is *SkipperPackageMetadata*.
 Currently, the package search functionality is only a wildcard match against the name of the package.
 ====
 
-A Package Repository exposes an `index.yml` file that contains multiple metadata documents and that uses the standard three dash notation `---` to separate the documents -- for example, http://skipper-repository.cfapps.io/repository/experimental/index.yml[index.yml].
+A Package Repository exposes an `index.yml` file that contains multiple metadata documents and that uses the standard three dash notation `---` to separate the documents -- for example, https://skipper-repository.cfapps.io/repository/experimental/index.yml[index.yml].
 
 [[package-templates]]
 === Package Templates
@@ -472,12 +472,12 @@ The following example shows a typical spec for HTTP:
 [source,yaml]
 ----
 spec:
-  resource: http://example.com/app/hello-world
+  resource: https://example.com/app/hello-world
   version: 1.0.0.RELEASE
 ----
 
 There is a naming convention that must be followed for HTTP-based resources so that Skipper can assemble a full URL from the `resource` and `version` field and also parse the version number given the URL.
-The preceding `spec` references a URL at `http://example.com/app/hello-world-1.0.0.RELEASE.jar`.
+The preceding `spec` references a URL at `https://example.com/app/hello-world-1.0.0.RELEASE.jar`.
 The `resource` and `version` fields should not have any numbers after the `-` character.
 
 ===== Docker Resources
@@ -797,7 +797,7 @@ spring
         package-repositories:
           -
             name: experimental
-            url: http://skipper-repository.cfapps.io/repository/experimental
+            url: https://skipper-repository.cfapps.io/repository/experimental
             description: Experimental Skipper Repository
             repoOrder: 0
           -
@@ -813,8 +813,8 @@ IMPORTANT: When modifying default configuration you need to re-define everything
 
 The `repoOrder` determines which repository serves up a package if one with the same name is registered in two or more repositories.
 
-The directory structure assumed for a remote repository is the registered `url` value followed by the package name and then the zip file name (for example, `http://skipper-repository.cfapps.io/repository/experimental/helloworld/helloworld-1.0.0.zip` for the package `helloworld` with a version of `1.0.0`).
-A file named `index.yml` is expected to be directly under the registered `url` -- for example, http://skipper-repository.cfapps.io/repository/experimental/index.yml.
+The directory structure assumed for a remote repository is the registered `url` value followed by the package name and then the zip file name (for example, `https://skipper-repository.cfapps.io/repository/experimental/helloworld/helloworld-1.0.0.zip` for the package `helloworld` with a version of `1.0.0`).
+A file named `index.yml` is expected to be directly under the registered `url` -- for example, https://skipper-repository.cfapps.io/repository/experimental/index.yml.
 This file contains the package metadata for all the packages hosted by the repository.
 
 It is up to you to update the `index.yml` file "'by hand'" for remote repositories.
@@ -826,4 +826,4 @@ However, you can upload packages to a local repository and do not need to mainta
 See the "`<<skipper-commands-reference>>`" section for information on creating local repositories.
 
 A good example that shows using a Spring Boot web application with static resources to host a Repository can be found https://github.com/markpollack/skipper-sample-repository[here].
-This application is currently running under http://skipper-repository.cfapps.io/repository/experimental.
+This application is currently running under https://skipper-repository.cfapps.io/repository/experimental.

--- a/spring-cloud-skipper-docs/src/main/asciidoc/three-minute-tour.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/three-minute-tour.adoc
@@ -210,7 +210,7 @@ skipper:>repo list
 ╔════════════╤═══════════════════════════════════════════════════════════╤═════╤═════╗
 ║    Name    │                            URL                            │Local│Order║
 ╠════════════╪═══════════════════════════════════════════════════════════╪═════╪═════╣
-║experimental│http://skipper-repository.cfapps.io/repository/experimental│false│0    ║
+║experimental│https://skipper-repository.cfapps.io/repository/experimental│false│0    ║
 ║local       │http://d4d6d1b6-c7e5-4226-69ec-01d4:7577                   │true │1    ║
 ╚════════════╧═══════════════════════════════════════════════════════════╧═════╧═════╝
 ----
@@ -296,9 +296,9 @@ You can now curl the `greeting` endpoint and the `about` endpoint, as shown in t
 
 [source,bash,options="nowrap"]
 ----
-$ curl http://helloworldpcf.cfapps.io/greeting
+$ curl https://helloworldpcf.cfapps.io/greeting
 Hello World!
-$ curl http://helloworldpcf.cfapps.io/about
+$ curl https://helloworldpcf.cfapps.io/about
 Hello World v1.0.0.RELEASE
 ----
 
@@ -401,9 +401,9 @@ More flexible upgrade strategies are planned in a future release.
 You can now curl the `greeting` endpoint and the `about` endpoint, as shown in the following example:
 [source,bash,options="nowrap"]
 ----
-$ curl http://helloworldpcf.cfapps.io/greeting
+$ curl https://helloworldpcf.cfapps.io/greeting
 yo
-$ curl http://helloworldpcf.cfapps.io/about
+$ curl https://helloworldpcf.cfapps.io/about
 Hello World v1.0.0.RELEASE
 ----
 
@@ -465,9 +465,9 @@ Now a `curl` command shows the following output:
 
 [source,bash,options="nowrap"]
 ----
-curl http://helloworldpcf.cfapps.io/greeting
+curl https://helloworldpcf.cfapps.io/greeting
 Olá Mundo!
-$ curl http://helloworldpcf.cfapps.io/about
+$ curl https://helloworldpcf.cfapps.io/about
 Hello World v1.0.1.RELEASE
 ----
 
@@ -513,9 +513,9 @@ skipper:>release history --release-name helloworldpcf
 The `curl` commands shows the following output:
 [source,bash,options="nowrap"]
 ----
-$ curl http://helloworldpcf.cfapps.io/greeting
+$ curl https://helloworldpcf.cfapps.io/greeting
 yo
-$ curl http://helloworldpcf.cfapps.io/about
+$ curl https://helloworldpcf.cfapps.io/about
 Hello World v1.0.0.RELEASE
 ----
 
@@ -551,7 +551,7 @@ skipper:>repo list
 ╔════════════╤═══════════════════════════════════════════════════════════╤═════╤═════╗
 ║    Name    │                            URL                            │Local│Order║
 ╠════════════╪═══════════════════════════════════════════════════════════╪═════╪═════╣
-║experimental│http://skipper-repository.cfapps.io/repository/experimental│false│0    ║
+║experimental│https://skipper-repository.cfapps.io/repository/experimental│false│0    ║
 ║local       │http://d4d6d1b6-c7e5-4226-69ec-01d4:7577                   │true │1    ║
 ╚════════════╧═══════════════════════════════════════════════════════════╧═════╧═════╝
 ----
@@ -628,15 +628,15 @@ To get the URL of this app on minikube, use the `minikube service` command, as f
 [source,bash,options="nowrap"]
 ----
 $ minikube service --url helloworldk8s-helloworld-docker-v1
-http://192.168.99.100:32123
+https://192.168.99.100:32123
 ----
 
 You can now curl the `greeting` endpoint and the `about` endpoint, as shown in the following example:
 [source,bash,options="nowrap"]
 ----
-$ curl http://192.168.99.100:32123/greeting
+$ curl https://192.168.99.100:32123/greeting
 Hello World!
-$ curl http://192.168.99.100:32123/about
+$ curl https://192.168.99.100:32123/about
 Hello World v1.0.0.RELEASE
 ----
 
@@ -729,9 +729,9 @@ You can now curl the `greeting` endpoint and the `about` endpoint, as follows:
 
 [source,bash,options="nowrap"]
 ----
-$ curl http://192.168.99.100:32124/greeting
+$ curl https://192.168.99.100:32124/greeting
 yo
-$ curl http://192.168.99.100:32124/about
+$ curl https://192.168.99.100:32124/about
 Hello World v1.0.0.RELEASE
 ----
 
@@ -787,10 +787,10 @@ skipper:>release status --release-name helloworldk8s
 A `curl` command shows the following output:
 [source,bash,options="nowrap"]
 ----
-$ curl http://192.168.99.100:32125/greeting
+$ curl https://192.168.99.100:32125/greeting
 Olá Mundo!
 
-$ curl http://192.168.99.100:32125/about
+$ curl https://192.168.99.100:32125/about
 Hello World v1.0.1.RELEASE
 ----
 
@@ -835,9 +835,9 @@ skipper:>release history --release-name helloworldk8s
 The `curl` commands now shows the following:
 [source,bash,options="nowrap"]
 ----
-$ curl http://192.168.99.100:32124/greeting
+$ curl https://192.168.99.100:32124/greeting
 yo
-$ curl http://192.168.99.100:32124/about
+$ curl https://192.168.99.100:32124/about
 Hello World v1.0.0.RELEASE
 ----
 

--- a/spring-cloud-skipper-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-skipper-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 xmlns:d="http://docbook.org/ns/docbook"
                 exclude-result-prefixes="xslthl d"
                 version='1.0'>

--- a/spring-cloud-skipper-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-skipper-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 xmlns:d="http://docbook.org/ns/docbook"
                 exclude-result-prefixes="xslthl d"
                 version='1.0'>

--- a/spring-cloud-skipper-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-skipper-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 xmlns:d="http://docbook.org/ns/docbook"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>

--- a/spring-cloud-skipper-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-skipper-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:d="http://docbook.org/ns/docbook"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 xmlns:xlink='http://www.w3.org/1999/xlink'
                 xmlns:exsl="http://exslt.org/common"
                 exclude-result-prefixes="exsl xslthl d xlink"

--- a/spring-cloud-skipper-platform-cloudfoundry/src/test/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryManifestApplicationDeployerTests.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/test/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryManifestApplicationDeployerTests.java
@@ -38,7 +38,7 @@ public class CloudFoundryManifestApplicationDeployerTests {
 		when(springBootAppSpec2.getResource()).thenReturn(dockerSpecResource);
 		when(springBootAppSpec2.getVersion()).thenReturn(dockerSpecVersion);
 		SpringCloudDeployerApplicationSpec springBootAppSpec3 = mock(SpringCloudDeployerApplicationSpec.class);
-		String httpSpecResource = "http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/"
+		String httpSpecResource = "https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/"
 				+ "log-sink-rabbit/1.2.0.RELEASE/log-sink-rabbit";
 		when(springBootAppSpec3.getResource()).thenReturn(httpSpecResource);
 		when(springBootAppSpec3.getVersion()).thenReturn("1.2.0.RELEASE");

--- a/spring-cloud-skipper-platform-kubernetes/src/test/java/org/springframework/cloud/skipper/deployer/KubernetesPlatformPropertiesTest.java
+++ b/spring-cloud-skipper-platform-kubernetes/src/test/java/org/springframework/cloud/skipper/deployer/KubernetesPlatformPropertiesTest.java
@@ -54,8 +54,8 @@ public class KubernetesPlatformPropertiesTest {
 		assertThat(k8sAccounts).hasSize(2);
 		assertThat(k8sAccounts).containsKeys("dev", "qa");
 		assertThat(devK8sClient.getNamespace()).isEqualTo("dev1");
-		assertThat(devK8sClient.getMasterUrl().toString()).isEqualTo("http://192.168.0.1:8443");
-		assertThat(qaK8sClient.getMasterUrl().toString()).isEqualTo("http://192.168.0.2:8443");
+		assertThat(devK8sClient.getMasterUrl().toString()).isEqualTo("https://192.168.0.1:8443");
+		assertThat(qaK8sClient.getMasterUrl().toString()).isEqualTo("https://192.168.0.2:8443");
 		assertThat(qaK8sClient.getNamespace()).isEqualTo("qaNamespace");
 		assertThat(k8sAccounts.get("dev").getImagePullPolicy()).isEqualTo(ImagePullPolicy.Always);
 		assertThat(k8sAccounts.get("dev").getEntryPointStyle()).isEqualTo(EntryPointStyle.exec);

--- a/spring-cloud-skipper-platform-kubernetes/src/test/resources/application-platform-properties.yml
+++ b/spring-cloud-skipper-platform-kubernetes/src/test/resources/application-platform-properties.yml
@@ -11,7 +11,7 @@ spring:
             accounts:
               dev:
                 fabric8:
-                  masterUrl: http://192.168.0.1:8443
+                  masterUrl: https://192.168.0.1:8443
                   namespace: dev1
                 namespace: devNamespace
                 imagePullPolicy: Always
@@ -20,7 +20,7 @@ spring:
                   cpu: 4
               qa:
                 fabric8:
-                  masterUrl: http://192.168.0.2:8443
+                  masterUrl: https://192.168.0.2:8443
                 namespace: qaNamespace
                 imagePullPolicy: IfNotPresent
                 entryPointStyle: boot

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/AppDeploymentRequestFactoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/AppDeploymentRequestFactoryTests.java
@@ -67,7 +67,7 @@ public class AppDeploymentRequestFactoryTests {
 		when(springBootAppSpec2.getResource()).thenReturn(dockerSpecResource);
 		when(springBootAppSpec2.getVersion()).thenReturn(dockerSpecVersion);
 		SpringCloudDeployerApplicationSpec springBootAppSpec3 = mock(SpringCloudDeployerApplicationSpec.class);
-		String httpSpecResource = "http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/"
+		String httpSpecResource = "https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/"
 				+ "log-sink-rabbit/1.2.0.RELEASE/log-sink-rabbit";
 		when(springBootAppSpec3.getResource()).thenReturn(httpSpecResource);
 		when(springBootAppSpec3.getVersion()).thenReturn("1.2.0.RELEASE");

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryCreator.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryCreator.java
@@ -26,11 +26,11 @@ public class RepositoryCreator {
 	public static void createTwoRepositories(RepositoryRepository repositoryRepository) {
 		Repository repository = new Repository();
 		repository.setName("stable");
-		repository.setUrl("http://www.example.com/skipper/repository/stable");
+		repository.setUrl("https://www.example.com/skipper/repository/stable");
 		repositoryRepository.save(repository);
 		repository = new Repository();
 		repository.setName("unstable");
-		repository.setUrl("http://www.example.com/skipper/repository/unstable");
+		repository.setUrl("https://www.example.com/skipper/repository/unstable");
 		repositoryRepository.save(repository);
 	}
 
@@ -38,7 +38,7 @@ public class RepositoryCreator {
 			Integer repoOrder) {
 		Repository repository = new Repository();
 		repository.setName(repoName);
-		repository.setUrl("http://www.example.com/skipper/repository/" + repoName);
+		repository.setUrl("https://www.example.com/skipper/repository/" + repoName);
 		repositoryRepository.save(repository);
 		repository.setRepoOrder(repoOrder);
 		repositoryRepository.save(repository);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/RepositoryRepositoryTests.java
@@ -54,8 +54,8 @@ public class RepositoryRepositoryTests extends AbstractIntegrationTest {
 		Iterable<Repository> repositories = repositoryRepository.findAll();
 		assertThat(repositories).isNotEmpty();
 		Repository repo1 = repositoryRepository.findByName("stable");
-		assertThat(repo1.getUrl()).isEqualTo("http://www.example.com/skipper/repository/stable");
+		assertThat(repo1.getUrl()).isEqualTo("https://www.example.com/skipper/repository/stable");
 		Repository repo2 = repositoryRepository.findByName("unstable");
-		assertThat(repo2.getUrl()).isEqualTo("http://www.example.com/skipper/repository/unstable");
+		assertThat(repo2.getUrl()).isEqualTo("https://www.example.com/skipper/repository/unstable");
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageMetadataServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageMetadataServiceTests.java
@@ -61,7 +61,7 @@ public class PackageMetadataServiceTests {
 		filename = packageMetadataService.computeFilename(urlResource);
 		assertThat(filename).isEqualTo("localhost_index.yml");
 
-		urlResource = new UrlResource("http://www.example.com/index.yml");
+		urlResource = new UrlResource("https://www.example.com/index.yml");
 		filename = packageMetadataService.computeFilename(urlResource);
 		assertThat(filename).isEqualTo("www.example.com_index.yml");
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/PackageServiceTests.java
@@ -114,7 +114,7 @@ public class PackageServiceTests extends AbstractIntegrationTest {
 		// Create throw away repository, treated to be a 'local' database repo by default for now.
 		Repository repository = new Repository();
 		repository.setName("database-repo");
-		repository.setUrl("http://example.com/repository/");
+		repository.setUrl("https://example.com/repository/");
 		this.repositoryRepository.save(repository);
 
 		// Package log 9.9.9 should not exist, since it hasn't been uploaded yet.

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseAnalyzerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseAnalyzerTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Ilayaperumal Gopinathan
  */
 @ActiveProfiles("repo-test")
-@TestPropertySource(properties = { "maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot" })
+@TestPropertySource(properties = { "maven.remote-repositories.repo1.url=https://repo.spring.io/libs-snapshot" })
 public class ReleaseAnalyzerTests extends AbstractIntegrationTest {
 
 	private final Logger logger = LoggerFactory.getLogger(ReleaseAnalyzerTests.class);

--- a/spring-cloud-skipper-server-core/src/test/resources/org/springframework/cloud/skipper/server/service/ticktock-1.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/org/springframework/cloud/skipper/server/service/ticktock-1.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: ticktock
 version: 1.0.0
 packageSourceUrl: https://example.com/dataflow/ticktock
-packageHomeUrl: http://example.com/dataflow/ticktock
+packageHomeUrl: https://example.com/dataflow/ticktock
 tags: stream, time, log
 maintainer: https://github.com/markpollack
 description: The ticktock stream sends a time stamp and logs the value.

--- a/spring-cloud-skipper-server-core/src/test/resources/org/springframework/cloud/skipper/server/service/ticktock-1.0.0/packages/log/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/org/springframework/cloud/skipper/server/service/ticktock-1.0.0/packages/log/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/org/springframework/cloud/skipper/server/service/ticktock-1.0.0/packages/time/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/org/springframework/cloud/skipper/server/service/ticktock-1.0.0/packages/time/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: time
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: time, source
 maintainer: https://github.com/sobychacko
 description: The time source periodically emits a timestamp string.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/binaries/test/index.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/binaries/test/index.yml
@@ -6,7 +6,7 @@ origin: samples-package-repository
 name: log
 version: 1.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RC1
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.
@@ -18,7 +18,7 @@ origin: samples-package-repository
 name: log
 version: 1.1.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.
@@ -30,7 +30,7 @@ origin: samples-package-repository
 name: log
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.
@@ -42,7 +42,7 @@ origin: samples-package-repository
 name: time
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: time, source
 maintainer: https://github.com/sobychacko
 description: The time source periodically emits a timestamp string.
@@ -54,7 +54,7 @@ origin: samples-package-repository
 name: ticktock
 version: 1.0.0
 packageSourceUrl: https://example.com/dataflow/ticktock
-packageHomeUrl: http://example.com/dataflow/ticktock
+packageHomeUrl: https://example.com/dataflow/ticktock
 tags: stream, time, log
 maintainer: https://github.com/markpollack
 description: The ticktock stream sends a time stamp and logs the value.
@@ -66,7 +66,7 @@ origin: samples-package-repository
 name: log-docker
 version: 1.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.1.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: Docker version of the log sink application
@@ -78,7 +78,7 @@ origin: samples-package-repository
 name: log-docker
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: Docker version of the log sink application
@@ -90,7 +90,7 @@ origin: samples-package-repository
 name: helloworld-docker
 version: 1.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.1.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: helloworld
 maintainer: https://github.com/markpollack
 description: The hello world app says hello.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/helloworld/helloworld-docker-1.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/helloworld/helloworld-docker-1.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: helloworld-docker
 version: 1.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.1.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: helloworld
 maintainer: https://github.com/markpollack
 description: The hello world app says hello.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-1.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-1.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log
 version: 1.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RC1
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-1.1.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-1.1.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log
 version: 1.1.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.3.0.M1
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-2.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-2.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-docker-1.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-docker-1.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log-docker
 version: 1.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.1.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-docker-2.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/log-docker-2.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log-docker
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/logcf-1.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/logcf-1.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: logcf
 version: 1.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RC1
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/logcf-1.0.1/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/log/logcf-1.0.1/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: logcf
 version: 1.0.1
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RC1
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/python/python-printer-1.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/python/python-printer-1.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: python-printer
 version: 1.0.0
 packageSourceUrl: https://testing
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, printer
 maintainer: https://github.com/ilayaperumalg
 description: The python printer app that says hello.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/python/python-printer-1.0.1/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/python/python-printer-1.0.1/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: python-printer
 version: 1.0.1
 packageSourceUrl: https://testing
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, printer
 maintainer: https://github.com/ilayaperumalg
 description: The python printer app that greets in tamil.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: ticktock
 version: 1.0.0
 packageSourceUrl: https://example.com/dataflow/ticktock
-packageHomeUrl: http://example.com/dataflow/ticktock
+packageHomeUrl: https://example.com/dataflow/ticktock
 tags: stream, time, log
 maintainer: https://github.com/markpollack
 description: The ticktock stream sends a time stamp and logs the value.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/log/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/log/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/time/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/time/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: time
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: time, source
 maintainer: https://github.com/sobychacko
 description: The time source periodically emits a timestamp string.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: ticktock
 version: 1.0.1
 packageSourceUrl: https://example.com/dataflow/ticktock
-packageHomeUrl: http://example.com/dataflow/ticktock
+packageHomeUrl: https://example.com/dataflow/ticktock
 tags: stream, time, log
 maintainer: https://github.com/markpollack
 description: The ticktock stream sends a time stamp and logs the value.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/log/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/log/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/time/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.1/packages/time/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: time
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: time, source
 maintainer: https://github.com/sobychacko
 description: The time source periodically emits a timestamp string.

--- a/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/time/time-2.0.0/package.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/repositories/sources/test/time/time-2.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: time
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: time, source
 maintainer: https://github.com/sobychacko
 description: The time source periodically emits a timestamp string.

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/io/PackageReaderTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/io/PackageReaderTests.java
@@ -54,7 +54,7 @@ public class PackageReaderTests {
 		assertThat(metadata.getName()).isEqualTo("ticktock");
 		assertThat(metadata.getVersion()).isEqualTo("1.0.0");
 		assertThat(metadata.getPackageSourceUrl()).isEqualTo("https://example.com/dataflow/ticktock");
-		assertThat(metadata.getPackageHomeUrl()).isEqualTo("http://example.com/dataflow/ticktock");
+		assertThat(metadata.getPackageHomeUrl()).isEqualTo("https://example.com/dataflow/ticktock");
 		Set<String> tagSet = convertToSet(metadata.getTags());
 		assertThat(tagSet).hasSize(3).contains("stream", "time", "log");
 		assertThat(metadata.getMaintainer()).isEqualTo("https://github.com/markpollack");
@@ -87,7 +87,7 @@ public class PackageReaderTests {
 		assertThat(metadata.getVersion()).isEqualTo("2.0.0");
 		assertThat(metadata.getPackageSourceUrl())
 				.isEqualTo("https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE");
-		assertThat(metadata.getPackageHomeUrl()).isEqualTo("http://cloud.spring.io/spring-cloud-stream-app-starters/");
+		assertThat(metadata.getPackageHomeUrl()).isEqualTo("https://cloud.spring.io/spring-cloud-stream-app-starters/");
 		Set<String> tagSet = convertToSet(metadata.getTags());
 		assertThat(tagSet).hasSize(2).contains("logging", "sink");
 		assertThat(metadata.getMaintainer()).isEqualTo("https://github.com/sobychacko");
@@ -103,7 +103,7 @@ public class PackageReaderTests {
 		assertThat(metadata.getVersion()).isEqualTo("2.0.0");
 		assertThat(metadata.getPackageSourceUrl())
 				.isEqualTo("https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE");
-		assertThat(metadata.getPackageHomeUrl()).isEqualTo("http://cloud.spring.io/spring-cloud-stream-app-starters/");
+		assertThat(metadata.getPackageHomeUrl()).isEqualTo("https://cloud.spring.io/spring-cloud-stream-app-starters/");
 		Set<String> tagSet = convertToSet(metadata.getTags());
 		assertThat(tagSet).hasSize(2).contains("time", "source");
 		assertThat(metadata.getMaintainer()).isEqualTo("https://github.com/sobychacko");

--- a/spring-cloud-skipper/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/package.yml
+++ b/spring-cloud-skipper/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: ticktock
 version: 1.0.0
 packageSourceUrl: https://example.com/dataflow/ticktock
-packageHomeUrl: http://example.com/dataflow/ticktock
+packageHomeUrl: https://example.com/dataflow/ticktock
 tags: stream, time, log
 maintainer: https://github.com/markpollack
 description: The ticktock stream sends a time stamp and logs the value.

--- a/spring-cloud-skipper/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/log/package.yml
+++ b/spring-cloud-skipper/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/log/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: log
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/log/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: logging, sink
 maintainer: https://github.com/sobychacko
 description: The log sink uses the application logger to output the data for inspection.

--- a/spring-cloud-skipper/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/time/package.yml
+++ b/spring-cloud-skipper/src/test/resources/repositories/sources/test/ticktock/ticktock-1.0.0/packages/time/package.yml
@@ -3,7 +3,7 @@ kind: SkipperPackageMetadata
 name: time
 version: 2.0.0
 packageSourceUrl: https://github.com/spring-cloud-stream-app-starters/time/tree/v1.2.0.RELEASE
-packageHomeUrl: http://cloud.spring.io/spring-cloud-stream-app-starters/
+packageHomeUrl: https://cloud.spring.io/spring-cloud-stream-app-starters/
 tags: time, source
 maintainer: https://github.com/sobychacko
 description: The time source periodically emits a timestamp string.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://stateless.co/hal_specification.html (200) with 1 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).
* [ ] http://www.gilligansisle.com/images/a1.gif (200) with 6 occurrences could not be migrated:  
   ([https](https://www.gilligansisle.com/images/a1.gif) result SSLHandshakeException).
* [ ] http://www.gilligansisle.com/images/a2.gif (200) with 4 occurrences could not be migrated:  
   ([https](https://www.gilligansisle.com/images/a2.gif) result SSLHandshakeException).
* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://192.168.0.2:8443 (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://192.168.0.2:8443 ([https](https://192.168.0.2:8443) result ConnectTimeoutException).
* [ ] http://10.55.13.45:7577 (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://10.55.13.45:7577 ([https](https://10.55.13.45:7577) result ConnectTimeoutException).
* [ ] http://192.168.0.1:8443 (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://192.168.0.1:8443 ([https](https://192.168.0.1:8443) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32123 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.99.100:32123 ([https](https://192.168.99.100:32123) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32123/about (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.99.100:32123/about ([https](https://192.168.99.100:32123/about) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32123/greeting (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.99.100:32123/greeting ([https](https://192.168.99.100:32123/greeting) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32124/about (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://192.168.99.100:32124/about ([https](https://192.168.99.100:32124/about) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32124/greeting (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://192.168.99.100:32124/greeting ([https](https://192.168.99.100:32124/greeting) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32125/about (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.99.100:32125/about ([https](https://192.168.99.100:32125/about) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32125/greeting (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.99.100:32125/greeting ([https](https://192.168.99.100:32125/greeting) result ConnectTimeoutException).
* [ ] http://example.com/app/hello-world (404) with 1 occurrences migrated to:  
  https://example.com/app/hello-world ([https](https://example.com/app/hello-world) result 404).
* [ ] http://example.com/app/hello-world-1.0.0.RELEASE.jar (404) with 1 occurrences migrated to:  
  https://example.com/app/hello-world-1.0.0.RELEASE.jar ([https](https://example.com/app/hello-world-1.0.0.RELEASE.jar) result 404).
* [ ] http://example.com/dataflow/ticktock (404) with 6 occurrences migrated to:  
  https://example.com/dataflow/ticktock ([https](https://example.com/dataflow/ticktock) result 404).
* [ ] http://example.com/repository/ (404) with 1 occurrences migrated to:  
  https://example.com/repository/ ([https](https://example.com/repository/) result 404).
* [ ] http://helloworldpcf.cfapps.io/about (404) with 4 occurrences migrated to:  
  https://helloworldpcf.cfapps.io/about ([https](https://helloworldpcf.cfapps.io/about) result 404).
* [ ] http://helloworldpcf.cfapps.io/greeting (404) with 4 occurrences migrated to:  
  https://helloworldpcf.cfapps.io/greeting ([https](https://helloworldpcf.cfapps.io/greeting) result 404).
* [ ] http://skipper-repository.cfapps.io/repository/experimental (404) with 5 occurrences migrated to:  
  https://skipper-repository.cfapps.io/repository/experimental ([https](https://skipper-repository.cfapps.io/repository/experimental) result 404).
* [ ] http://www.example.com/index.yml (404) with 1 occurrences migrated to:  
  https://www.example.com/index.yml ([https](https://www.example.com/index.yml) result 404).
* [ ] http://www.example.com/skipper/repository/ (404) with 1 occurrences migrated to:  
  https://www.example.com/skipper/repository/ ([https](https://www.example.com/skipper/repository/) result 404).
* [ ] http://www.example.com/skipper/repository/stable (404) with 2 occurrences migrated to:  
  https://www.example.com/skipper/repository/stable ([https](https://www.example.com/skipper/repository/stable) result 404).
* [ ] http://www.example.com/skipper/repository/unstable (404) with 2 occurrences migrated to:  
  https://www.example.com/skipper/repository/unstable ([https](https://www.example.com/skipper/repository/unstable) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-static/spring-cloud-config/1.3.3.RELEASE/multi/multi__spring_cloud_config_server.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/spring-cloud-config/1.3.3.RELEASE/multi/multi__spring_cloud_config_server.html ([https](https://cloud.spring.io/spring-cloud-static/spring-cloud-config/1.3.3.RELEASE/multi/multi__spring_cloud_config_server.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-stream-app-starters/ with 30 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream-app-starters/ ([https](https://cloud.spring.io/spring-cloud-stream-app-starters/) result 200).
* [ ] http://docs.spring.io/spring-cloud-skipper/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-skipper/docs/ ([https](https://docs.spring.io/spring-cloud-skipper/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-skipper/docs/current-SNAPSHOT/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-skipper/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-skipper/docs/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html ([https](https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html) result 200).
* [ ] http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://projects.spring.io/spring-security-oauth/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-security-oauth/ ([https](https://projects.spring.io/spring-security-oauth/) result 200).
* [ ] http://repo.spring.io/libs-release/org/springframework/cloud/stream/app/ with 2 occurrences migrated to:  
  https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/ ([https](https://repo.spring.io/libs-release/org/springframework/cloud/stream/app/) result 200).
* [ ] http://skipper-repository.cfapps.io/repository/experimental/helloworld/helloworld-1.0.0.zip with 1 occurrences migrated to:  
  https://skipper-repository.cfapps.io/repository/experimental/helloworld/helloworld-1.0.0.zip ([https](https://skipper-repository.cfapps.io/repository/experimental/helloworld/helloworld-1.0.0.zip) result 200).
* [ ] http://skipper-repository.cfapps.io/repository/experimental/index.yml with 2 occurrences migrated to:  
  https://skipper-repository.cfapps.io/repository/experimental/index.yml ([https](https://skipper-repository.cfapps.io/repository/experimental/index.yml) result 200).
* [ ] http://stackoverflow.com with 2 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/tags/spring-cloud-skipper with 2 occurrences migrated to:  
  https://stackoverflow.com/tags/spring-cloud-skipper ([https](https://stackoverflow.com/tags/spring-cloud-skipper) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://waffle.io/spring-cloud/spring-cloud-skipper with 2 occurrences migrated to:  
  https://waffle.io/spring-cloud/spring-cloud-skipper ([https](https://waffle.io/spring-cloud/spring-cloud-skipper) result 200).
* [ ] http://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html ([https](https://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html) result 200).
* [ ] http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html with 4 occurrences migrated to:  
  https://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html ([https](https://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html) result 200).
* [ ] http://repo.springsource.org/libs-milestone with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* [ ] http://repo.springsource.org/libs-release with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* [ ] http://repo.springsource.org/libs-snapshot with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* [ ] http://repo.spring.io/ with 2 occurrences migrated to:  
  https://repo.spring.io/ ([https](https://repo.spring.io/) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 3 occurrences
* http://127.0.0.1:9999/me with 1 occurrences
* http://127.0.0.1:9999/oauth/authorize with 1 occurrences
* http://127.0.0.1:9999/oauth/token with 1 occurrences
* http://d4d6d1b6-c7e5-4226-69ec-01d4:7577 with 2 occurrences
* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost with 2 occurrences
* http://localhost/api/package/install/1 with 2 occurrences
* http://localhost/api/package/install/2 with 2 occurrences
* http://localhost:7577 with 9 occurrences
* http://localhost:7577/ with 2 occurrences
* http://localhost:7577/api with 3 occurrences
* http://localhost:8080/path/not/there with 1 occurrences
* http://localhost:8081/index.yml with 1 occurrences
* http://localhost:8099/about with 2 occurrences
* http://localhost:8099/greeting with 3 occurrences
* http://localhost:8100/about with 1 occurrences
* http://localhost:8100/greeting with 2 occurrences
* http://localhost:9123/api with 4 occurrences
* http://localhost:9393/login with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 3 occurrences
* http://some-mypackage-project/ with 1 occurrences
* http://test with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 7 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences