### PR TITLE
Add deployment properties to DeployerRepository

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.cloud.deployer.spi.local.LocalAppDeployer;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Platform;
+import org.springframework.cloud.skipper.server.deployer.metadata.DeployerConfigurationMetadataResolver;
 import org.springframework.cloud.skipper.server.repository.map.DeployerRepository;
 import org.springframework.cloud.skipper.server.service.DeployerInitializationService;
 import org.springframework.context.annotation.Bean;
@@ -34,10 +35,15 @@ import org.springframework.util.StringUtils;
 public class SkipperServerPlatformConfiguration {
 
 	@Bean
+	public DeployerConfigurationMetadataResolver deployerConfigurationMetadataResolver() {
+		return new DeployerConfigurationMetadataResolver();
+	}
+
+	@Bean
 	public DeployerInitializationService deployerInitializationService(
 			DeployerRepository deployerRepository,
-			List<Platform> platforms) {
-		return new DeployerInitializationService(deployerRepository, platforms);
+			List<Platform> platforms, DeployerConfigurationMetadataResolver resolver) {
+		return new DeployerInitializationService(deployerRepository, platforms, resolver);
 	}
 
 	@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolver.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolver.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer.metadata;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.BeansException;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepository;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepositoryJsonBuilder;
+import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.io.Resource;
+
+public class DeployerConfigurationMetadataResolver implements ApplicationContextAware {
+
+	private static final String CONFIGURATION_METADATA_PATTERN = "classpath*:/META-INF/spring-configuration-metadata.json";
+	private static final String KEY_PREFIX = "spring.cloud.deployer.";
+	private ApplicationContext applicationContext;
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	/**
+	 * Resolve all configuration metadata properties prefixed with {@code spring.cloud.deployer.}
+	 *
+	 * @return the list
+	 */
+	public List<ConfigurationMetadataProperty> resolve() {
+		List<ConfigurationMetadataProperty> metadataProperties = new ArrayList<>();
+		ConfigurationMetadataRepositoryJsonBuilder builder = ConfigurationMetadataRepositoryJsonBuilder.create();
+		try {
+			Resource[] resources = applicationContext.getResources(CONFIGURATION_METADATA_PATTERN);
+			for (Resource resource : resources) {
+				builder.withJsonResource(resource.getInputStream());
+			}
+		}
+		catch (IOException e) {
+			throw new SkipperException("Unable to read configuration metadata", e);
+		}
+		ConfigurationMetadataRepository metadataRepository = builder.build();
+		Map<String, ConfigurationMetadataProperty> properties = metadataRepository.getAllProperties();
+		properties.entrySet().stream().forEach(e -> {
+			if (e.getKey().startsWith(KEY_PREFIX)) {
+				metadataProperties.add(e.getValue());
+			}
+		});
+		return metadataProperties;
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
@@ -49,6 +49,32 @@ public class DeployersDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.deployers[].description")
 										.description("Description providing some deployer properties"),
 								fieldWithPath("_embedded.deployers[]._links.self.href").ignored(),
+								fieldWithPath("_embedded.deployers[].options")
+										.description("Array containing Deployer deployment properties"),
+								fieldWithPath("_embedded.deployers[].options[].id")
+										.description("Deployment property id"),
+								fieldWithPath("_embedded.deployers[].options[].name")
+										.description("Deployment property name"),
+								fieldWithPath("_embedded.deployers[].options[].type")
+										.description("Deployment property type").optional(),
+								fieldWithPath("_embedded.deployers[].options[].description")
+										.description("Deployment property description").optional(),
+								fieldWithPath("_embedded.deployers[].options[].shortDescription")
+										.description("Deployment property short description").optional(),
+								fieldWithPath("_embedded.deployers[].options[].defaultValue")
+										.description("Deployment property default value").optional(),
+								fieldWithPath("_embedded.deployers[].options[].hints")
+										.description("Object containing deployment property hints"),
+								fieldWithPath("_embedded.deployers[].options[].hints.keyHints")
+										.description("Deployment property key hints"),
+								fieldWithPath("_embedded.deployers[].options[].hints.keyProviders")
+										.description("Deployment property key hints"),
+								fieldWithPath("_embedded.deployers[].options[].hints.valueHints")
+										.description("Deployment property key hints"),
+								fieldWithPath("_embedded.deployers[].options[].hints.valueProviders")
+										.description("Deployment property key hints"),
+								fieldWithPath("_embedded.deployers[].options[].deprecation").description(""),
+								fieldWithPath("_embedded.deployers[].options[].deprecated").description(""),
 								fieldWithPath("_embedded.deployers[]._links.deployer.href").ignored())
 								.and(super.defaultLinkProperties),
 						super.linksForSkipper()));

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.deployer.metadata;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeployerConfigurationMetadataResolverTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+	@Test
+	public void testDeployerConfigurationMetadata() {
+		this.contextRunner
+			.run((context) -> {
+				DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver();
+				resolver.setApplicationContext(context);
+				List<ConfigurationMetadataProperty> data = resolver.resolve();
+				assertThat(data.size()).isGreaterThan(0);
+			});
+	}
+}

--- a/spring-cloud-skipper/pom.xml
+++ b/spring-cloud-skipper/pom.xml
@@ -65,5 +65,9 @@
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-metadata</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Deployer.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Deployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,16 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
+import org.springframework.cloud.skipper.domain.deployer.ConfigurationMetadataPropertyEntity;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.keyvalue.annotation.KeySpace;
+
 
 /**
  * @author Mark Pollack
@@ -38,6 +43,8 @@ public class Deployer {
 
 	@JsonIgnore
 	private AppDeployer appDeployer;
+
+	private List<ConfigurationMetadataPropertyEntity> options = new ArrayList<>();
 
 	Deployer() {
 	}
@@ -86,5 +93,13 @@ public class Deployer {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public List<ConfigurationMetadataPropertyEntity> getOptions() {
+		return options;
+	}
+
+	public void setOptions(List<ConfigurationMetadataPropertyEntity> options) {
+		this.options = options;
 	}
 }

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/deployer/ConfigurationMetadataPropertyEntity.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/deployer/ConfigurationMetadataPropertyEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/deployer/ConfigurationMetadataPropertyEntity.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/deployer/ConfigurationMetadataPropertyEntity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain.deployer;
+
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+
+/**
+ * This entity class is used to extend boot's {@link ConfigurationMetadataProperty} so that
+ * we can add our own constructor and not to explicitly import entity classes from boot.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public class ConfigurationMetadataPropertyEntity extends ConfigurationMetadataProperty {
+
+	public ConfigurationMetadataPropertyEntity() {
+		super();
+	}
+
+	public ConfigurationMetadataPropertyEntity(ConfigurationMetadataProperty from) {
+		super();
+		setId(from.getId());
+		setName(from.getName());
+		setType(from.getType());
+		setDescription(from.getDescription());
+		setShortDescription(from.getShortDescription());
+		setDefaultValue(from.getDefaultValue());
+		getHints().getKeyHints().addAll(from.getHints().getKeyHints());
+		getHints().getKeyProviders().addAll(from.getHints().getKeyProviders());
+		getHints().getValueHints().addAll(from.getHints().getValueHints());
+		getHints().getValueProviders().addAll(from.getHints().getValueProviders());
+		setDeprecation(from.getDeprecation());
+	}
+}


### PR DESCRIPTION
- Add options field to Deployer entity denoting possible
  deployment properties known to each deployer type.
- Read all known deployer related properties and update
  those to DeployerRepository during initialization phase.
- Fixes #858

New content is then shown in `http://localhost:7577/api/deployers`