### PR TITLE
Add deployer properties metadata filtering

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
@@ -35,13 +35,13 @@ import org.springframework.util.StringUtils;
 public class SkipperServerPlatformConfiguration {
 
 	@Bean
-	public DeployerConfigurationMetadataResolver deployerConfigurationMetadataResolver() {
-		return new DeployerConfigurationMetadataResolver();
+	public DeployerConfigurationMetadataResolver deployerConfigurationMetadataResolver(
+			SkipperServerProperties skipperServerProperties) {
+		return new DeployerConfigurationMetadataResolver(skipperServerProperties.getDeployerProperties());
 	}
 
 	@Bean
-	public DeployerInitializationService deployerInitializationService(
-			DeployerRepository deployerRepository,
+	public DeployerInitializationService deployerInitializationService(DeployerRepository deployerRepository,
 			List<Platform> platforms, DeployerConfigurationMetadataResolver resolver) {
 		return new DeployerInitializationService(deployerRepository, platforms, resolver);
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerProperties.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerProperties.java
@@ -46,6 +46,8 @@ public class SkipperServerProperties {
 	 */
 	private boolean enableReleaseStateUpdateService;
 
+	private DeployerProperties deployerProperties = new DeployerProperties();
+
 	public Map<String, PackageRepository> getPackageRepositories() {
 		return packageRepositories;
 	}
@@ -68,6 +70,14 @@ public class SkipperServerProperties {
 
 	public void setEnableReleaseStateUpdateService(boolean enableReleaseStateUpdateService) {
 		this.enableReleaseStateUpdateService = enableReleaseStateUpdateService;
+	}
+
+	public DeployerProperties getDeployerProperties() {
+		return deployerProperties;
+	}
+
+	public void setDeployerProperties(DeployerProperties deployerProperties) {
+		this.deployerProperties = deployerProperties;
 	}
 
 	public static class PackageRepository {
@@ -116,6 +126,46 @@ public class SkipperServerProperties {
 
 		public void setRepoOrder(Integer repoOrder) {
 			this.repoOrder = repoOrder;
+		}
+	}
+
+	public static class DeployerProperties {
+
+		private String[] propertyIncludes = new String[0];
+		private String[] groupIncludes = new String[0];
+		private String[] propertyExcludes = new String[0];
+		private String[] groupExcludes = new String[0];
+
+		public String[] getPropertyIncludes() {
+			return propertyIncludes;
+		}
+
+		public void setPropertyIncludes(String[] propertyIncludes) {
+			this.propertyIncludes = propertyIncludes;
+		}
+
+		public String[] getGroupIncludes() {
+			return groupIncludes;
+		}
+
+		public void setGroupIncludes(String[] groupIncludes) {
+			this.groupIncludes = groupIncludes;
+		}
+
+		public String[] getPropertyExcludes() {
+			return propertyExcludes;
+		}
+
+		public void setPropertyExcludes(String[] propertyExcludes) {
+			this.propertyExcludes = propertyExcludes;
+		}
+
+		public String[] getGroupExcludes() {
+			return groupExcludes;
+		}
+
+		public void setGroupExcludes(String[] groupExcludes) {
+			this.groupExcludes = groupExcludes;
 		}
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolver.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolver.java
@@ -17,23 +17,33 @@ package org.springframework.cloud.skipper.server.deployer.metadata;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.springframework.beans.BeansException;
+import org.springframework.boot.configurationmetadata.ConfigurationMetadataGroup;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepository;
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataRepositoryJsonBuilder;
 import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.server.config.SkipperServerProperties.DeployerProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.io.Resource;
+import org.springframework.util.ObjectUtils;
 
 public class DeployerConfigurationMetadataResolver implements ApplicationContextAware {
 
 	private static final String CONFIGURATION_METADATA_PATTERN = "classpath*:/META-INF/spring-configuration-metadata.json";
 	private static final String KEY_PREFIX = "spring.cloud.deployer.";
 	private ApplicationContext applicationContext;
+	private final DeployerProperties deployerProperties;
+
+	public DeployerConfigurationMetadataResolver(DeployerProperties deployerProperties) {
+		this.deployerProperties = deployerProperties;
+	}
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
@@ -58,12 +68,47 @@ public class DeployerConfigurationMetadataResolver implements ApplicationContext
 			throw new SkipperException("Unable to read configuration metadata", e);
 		}
 		ConfigurationMetadataRepository metadataRepository = builder.build();
-		Map<String, ConfigurationMetadataProperty> properties = metadataRepository.getAllProperties();
-		properties.entrySet().stream().forEach(e -> {
-			if (e.getKey().startsWith(KEY_PREFIX)) {
-				metadataProperties.add(e.getValue());
-			}
-		});
+		Map<String, ConfigurationMetadataGroup> groups = metadataRepository.getAllGroups();
+		// 1. go through all groups and their properties
+		// 2. filter 'spring.cloud.deployer.' properties
+		// 3. pass in only group includes, empty passes through all
+		// 4. pass in group excludes
+		// 5. same logic for properties for includes and excludes
+		// 6. what's left is white/black listed props
+		groups.values().stream()
+			.filter(g -> g.getId().startsWith(KEY_PREFIX))
+			.filter(groupEmptyOrAnyMatch(deployerProperties.getGroupIncludes()))
+			.filter(groupNoneMatch(deployerProperties.getGroupExcludes()))
+			.forEach(g -> {
+				g.getProperties().values().stream()
+					.filter(propertyEmptyOrAnyMatch(deployerProperties.getPropertyIncludes()))
+					.filter(propertyNoneMatch(deployerProperties.getPropertyExcludes()))
+					.forEach(p -> {
+						metadataProperties.add(p);
+					});
+			});
 		return metadataProperties;
+	}
+
+	private Predicate<ConfigurationMetadataProperty> propertyEmptyOrAnyMatch(String[] matches) {
+		if (ObjectUtils.isEmpty(matches)) {
+			return p -> true;
+		}
+		return p -> Arrays.stream(matches).anyMatch(p.getId()::equals);
+	}
+
+	private Predicate<ConfigurationMetadataProperty> propertyNoneMatch(String[] matches) {
+		return p -> Arrays.stream(matches).noneMatch(p.getId()::equals);
+	}
+
+	private Predicate<ConfigurationMetadataGroup> groupEmptyOrAnyMatch(String[] matches) {
+		if (ObjectUtils.isEmpty(matches)) {
+			return g -> true;
+		}
+		return g -> Arrays.stream(matches).anyMatch(g.getId()::equals);
+	}
+
+	private Predicate<ConfigurationMetadataGroup> groupNoneMatch(String[] matches) {
+		return g -> Arrays.stream(matches).noneMatch(g.getId()::equals);
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -42,6 +42,9 @@ spring:
             local: true
             description: Default local database backed repository
             repoOrder: 1
+        deployer-properties:
+          group-excludes:
+            - spring.cloud.deployer.kubernetes.fabric8
       security:
         authorization:
           enabled: true

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
@@ -20,22 +20,128 @@ import java.util.List;
 import org.junit.Test;
 
 import org.springframework.boot.configurationmetadata.ConfigurationMetadataProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.skipper.server.config.SkipperServerProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DeployerConfigurationMetadataResolverTests {
 
-	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withUserConfiguration(Config.class);
 
 	@Test
-	public void testDeployerConfigurationMetadata() {
+	public void testNoFiltersFindsAll() {
 		this.contextRunner
 			.run((context) -> {
-				DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver();
-				resolver.setApplicationContext(context);
+				SkipperServerProperties skipperServerProperties = context.getBean(SkipperServerProperties.class);
+					DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver(
+							skipperServerProperties.getDeployerProperties());
+					resolver.setApplicationContext(context);
 				List<ConfigurationMetadataProperty> data = resolver.resolve();
-				assertThat(data.size()).isGreaterThan(0);
+				assertThat(data.size()).isEqualTo(9);
 			});
+	}
+
+	@Test
+	public void testExcludeGroup() {
+		this.contextRunner
+			.withPropertyValues(
+					"spring.cloud.skipper.server.deployer-properties.group-excludes=spring.cloud.deployer.local.port-range"
+					)
+			.run((context) -> {
+				SkipperServerProperties skipperServerProperties = context.getBean(SkipperServerProperties.class);
+					DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver(
+							skipperServerProperties.getDeployerProperties());
+					resolver.setApplicationContext(context);
+				List<ConfigurationMetadataProperty> data = resolver.resolve();
+				assertThat(data.size()).isEqualTo(7);
+			});
+	}
+
+	@Test
+	public void testExcludeProperty() {
+		this.contextRunner
+			.withPropertyValues(
+					"spring.cloud.skipper.server.deployer-properties.property-excludes=spring.cloud.deployer.local.port-range.low"
+					)
+			.run((context) -> {
+				SkipperServerProperties skipperServerProperties = context.getBean(SkipperServerProperties.class);
+					DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver(
+							skipperServerProperties.getDeployerProperties());
+					resolver.setApplicationContext(context);
+				List<ConfigurationMetadataProperty> data = resolver.resolve();
+				assertThat(data.size()).isEqualTo(8);
+			});
+	}
+
+	@Test
+	public void testIncludeGroup() {
+		this.contextRunner
+			.withPropertyValues(
+					"spring.cloud.skipper.server.deployer-properties.group-includes=spring.cloud.deployer.local.port-range"
+					)
+			.run((context) -> {
+				SkipperServerProperties skipperServerProperties = context.getBean(SkipperServerProperties.class);
+					DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver(
+							skipperServerProperties.getDeployerProperties());
+					resolver.setApplicationContext(context);
+				List<ConfigurationMetadataProperty> data = resolver.resolve();
+				assertThat(data.size()).isEqualTo(2);
+			});
+	}
+
+	@Test
+	public void testIncludeProperty() {
+		this.contextRunner
+			.withPropertyValues(
+					"spring.cloud.skipper.server.deployer-properties.property-includes=spring.cloud.deployer.local.port-range.low"
+					)
+			.run((context) -> {
+				SkipperServerProperties skipperServerProperties = context.getBean(SkipperServerProperties.class);
+					DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver(
+							skipperServerProperties.getDeployerProperties());
+					resolver.setApplicationContext(context);
+				List<ConfigurationMetadataProperty> data = resolver.resolve();
+				assertThat(data.size()).isEqualTo(1);
+			});
+	}
+
+	@Test
+	public void testIncludeMultipleProperty() {
+		this.contextRunner
+			.withPropertyValues(
+					"spring.cloud.skipper.server.deployer-properties.property-includes=spring.cloud.deployer.local.port-range.low,spring.cloud.deployer.local.port-range.high"
+					)
+			.run((context) -> {
+				SkipperServerProperties skipperServerProperties = context.getBean(SkipperServerProperties.class);
+					DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver(
+							skipperServerProperties.getDeployerProperties());
+					resolver.setApplicationContext(context);
+				List<ConfigurationMetadataProperty> data = resolver.resolve();
+				assertThat(data.size()).isEqualTo(2);
+			});
+	}
+
+	@Test
+	public void testIncludeGroupExcludeProperty() {
+		this.contextRunner
+			.withPropertyValues(
+					"spring.cloud.skipper.server.deployer-properties.group-includes=spring.cloud.deployer.local.port-range",
+					"spring.cloud.skipper.server.deployer-properties.property-excludes=spring.cloud.deployer.local.port-range.low"
+					)
+			.run((context) -> {
+				SkipperServerProperties skipperServerProperties = context.getBean(SkipperServerProperties.class);
+					DeployerConfigurationMetadataResolver resolver = new DeployerConfigurationMetadataResolver(
+							skipperServerProperties.getDeployerProperties());
+					resolver.setApplicationContext(context);
+				List<ConfigurationMetadataProperty> data = resolver.resolve();
+				assertThat(data.size()).isEqualTo(1);
+			});
+	}
+
+	@EnableConfigurationProperties({ SkipperServerProperties.class })
+	private static class Config {
 	}
 }


### PR DESCRIPTION
- Essentially adding 4 new server properties with string array type;
  spring.cloud.skipper.server.deployer-properties.group-excludes,
  spring.cloud.skipper.server.deployer-properties.property-excludes,
  spring.cloud.skipper.server.deployer-properties.group-includes,
  spring.cloud.skipper.server.deployer-properties.property-includes.
- DeployerConfigurationMetadataResolver will use these properties
  to white/black list resolved properties which are prefixed with
  spring.cloud.deployer..
- Add one excluded group `spring.cloud.deployer.kubernetes.fabric8` to
  a server configuration as those keys are expected to come from k8s
  deployer when its metadata polish PR is merged.