### PR TITLE
Fix changes in a local deployer

### DIFF
--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeployersDocumentation.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -65,14 +66,14 @@ public class DeployersDocumentation extends BaseDocumentation {
 										.description("Deployment property default value").optional(),
 								fieldWithPath("_embedded.deployers[].options[].hints")
 										.description("Object containing deployment property hints"),
-								fieldWithPath("_embedded.deployers[].options[].hints.keyHints")
+								subsectionWithPath("_embedded.deployers[].options[].hints.keyHints")
 										.description("Deployment property key hints"),
-								fieldWithPath("_embedded.deployers[].options[].hints.keyProviders")
-										.description("Deployment property key hints"),
-								fieldWithPath("_embedded.deployers[].options[].hints.valueHints")
-										.description("Deployment property key hints"),
-								fieldWithPath("_embedded.deployers[].options[].hints.valueProviders")
-										.description("Deployment property key hints"),
+								subsectionWithPath("_embedded.deployers[].options[].hints.keyProviders")
+										.description("Deployment property key hint providers"),
+								subsectionWithPath("_embedded.deployers[].options[].hints.valueHints")
+										.description("Deployment property value hints"),
+								subsectionWithPath("_embedded.deployers[].options[].hints.valueProviders")
+										.description("Deployment property value hint providers"),
 								fieldWithPath("_embedded.deployers[].options[].deprecation").description(""),
 								fieldWithPath("_embedded.deployers[].options[].deprecated").description(""),
 								fieldWithPath("_embedded.deployers[]._links.deployer.href").ignored())

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
@@ -40,7 +40,7 @@ public class DeployerConfigurationMetadataResolverTests {
 							skipperServerProperties.getDeployerProperties());
 					resolver.setApplicationContext(context);
 				List<ConfigurationMetadataProperty> data = resolver.resolve();
-				assertThat(data.size()).isEqualTo(9);
+				assertThat(data.size()).isEqualTo(12);
 			});
 	}
 
@@ -56,7 +56,7 @@ public class DeployerConfigurationMetadataResolverTests {
 							skipperServerProperties.getDeployerProperties());
 					resolver.setApplicationContext(context);
 				List<ConfigurationMetadataProperty> data = resolver.resolve();
-				assertThat(data.size()).isEqualTo(7);
+				assertThat(data.size()).isEqualTo(10);
 			});
 	}
 
@@ -72,7 +72,7 @@ public class DeployerConfigurationMetadataResolverTests {
 							skipperServerProperties.getDeployerProperties());
 					resolver.setApplicationContext(context);
 				List<ConfigurationMetadataProperty> data = resolver.resolve();
-				assertThat(data.size()).isEqualTo(8);
+				assertThat(data.size()).isEqualTo(11);
 			});
 	}
 


### PR DESCRIPTION
- We still depend on local deployer metadata and
  need to change tests to match what's expected.
- Essentially skip what might have in a boot's hint
  arrays as it's just noise.

NOTE: this is a fix for local deployer PR https://github.com/spring-cloud/spring-cloud-deployer-local/pull/161 what that gets merged.