### PR TITLE
Implement Release log retrieval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,10 @@
 		<spring-cloud.version>Greenwich.SR1</spring-cloud.version>
 
 		<java-cfenv-boot.version>1.0.1.RELEASE</java-cfenv-boot.version>
-		<spring-cloud-deployer.version>2.0.2.BUILD-SNAPSHOT</spring-cloud-deployer.version>
+		<spring-cloud-deployer.version>2.0.3.BUILD-SNAPSHOT</spring-cloud-deployer.version>
 		<spring-cloud-deployer-local.version>2.0.4.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
 		<!-- note - check version of reactor at deployer-cf/cf-java-client uses -->
-		<spring-cloud-deployer-cloudfoundry.version>2.0.4.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
+		<spring-cloud-deployer-cloudfoundry.version>2.0.6.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
 		<reactor.version>3.2.0.RELEASE</reactor.version>
 		<kubernetes-client.version>4.0.4</kubernetes-client.version>
 		<spring-cloud-deployer-kubernetes.version>2.0.3.BUILD-SNAPSHOT</spring-cloud-deployer-kubernetes.version>

--- a/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/CloudFoundryPlatformAutoConfiguration.java
+++ b/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/CloudFoundryPlatformAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.DefaultConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
 import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
+import org.cloudfoundry.reactor.doppler.ReactorDopplerClient;
 import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,9 +116,14 @@ public class CloudFoundryPlatformAutoConfiguration {
 					.addPlatformSpecificInfo("API Endpoint",
 							connectionProperties.getUrl().toString())
 					.build();
+			ReactorDopplerClient dopplerClient = ReactorDopplerClient.builder()
+					.connectionContext(connectionContext)
+					.tokenProvider(tokenProvider)
+					.build();
 			CloudFoundryOperations cloudFoundryOperations = DefaultCloudFoundryOperations
 					.builder().cloudFoundryClient(cloudFoundryClient)
 					.organization(connectionProperties.getOrg())
+					.dopplerClient(dopplerClient)
 					.space(connectionProperties.getSpace()).build();
 			CloudFoundryAppNameGenerator appNameGenerator = new CloudFoundryAppNameGenerator(
 					cloudFoundryProperties.getDeployment());

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,6 +150,39 @@ public class DefaultSkipperClient implements SkipperClient {
 		uriVariables.put("releaseVersion", Integer.toString(releaseVersion));
 		ResponseEntity<Resource<Info>> resourceResponseEntity =
 				restTemplate.exchange(baseUri + "/release/status/{releaseName}/{releaseVersion}",
+						HttpMethod.GET,
+						null,
+						typeReference,
+						uriVariables);
+		return resourceResponseEntity.getBody().getContent();
+	}
+
+	@Override
+	public Release getLog(String releaseName) {
+		ParameterizedTypeReference<Resource<Release>> typeReference =
+				new ParameterizedTypeReference<Resource<Release>>() { };
+		Map<String, String> uriVariables = new HashMap<String, String>();
+		uriVariables.put("releaseName", releaseName);
+
+		ResponseEntity<Resource<Release>> resourceResponseEntity =
+				restTemplate.exchange(baseUri + "/release/logs/{releaseName}",
+						HttpMethod.GET,
+						null,
+						typeReference,
+						uriVariables);
+		return resourceResponseEntity.getBody().getContent();
+	}
+
+	@Override
+	public Release getLog(String releaseName, String appName) {
+		ParameterizedTypeReference<Resource<Release>> typeReference =
+				new ParameterizedTypeReference<Resource<Release>>() { };
+		Map<String, String> uriVariables = new HashMap<String, String>();
+		uriVariables.put("releaseName", releaseName);
+		uriVariables.put("appName", appName);
+
+		ResponseEntity<Resource<Release>> resourceResponseEntity =
+				restTemplate.exchange(baseUri + "/release/logs/{releaseName}/{appName}",
 						HttpMethod.GET,
 						null,
 						typeReference,

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -158,36 +158,36 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Release getLog(String releaseName) {
-		ParameterizedTypeReference<Resource<Release>> typeReference =
-				new ParameterizedTypeReference<Resource<Release>>() { };
+	public String getLog(String releaseName) {
+		ParameterizedTypeReference<String> typeReference =
+				new ParameterizedTypeReference<String>() { };
 		Map<String, String> uriVariables = new HashMap<String, String>();
 		uriVariables.put("releaseName", releaseName);
 
-		ResponseEntity<Resource<Release>> resourceResponseEntity =
+		ResponseEntity<String> resourceResponseEntity =
 				restTemplate.exchange(baseUri + "/release/logs/{releaseName}",
 						HttpMethod.GET,
 						null,
 						typeReference,
 						uriVariables);
-		return resourceResponseEntity.getBody().getContent();
+		return resourceResponseEntity.getBody();
 	}
 
 	@Override
-	public Release getLog(String releaseName, String appName) {
-		ParameterizedTypeReference<Resource<Release>> typeReference =
-				new ParameterizedTypeReference<Resource<Release>>() { };
+	public String getLog(String releaseName, String appName) {
+		ParameterizedTypeReference<String> typeReference =
+				new ParameterizedTypeReference<String>() { };
 		Map<String, String> uriVariables = new HashMap<String, String>();
 		uriVariables.put("releaseName", releaseName);
 		uriVariables.put("appName", appName);
 
-		ResponseEntity<Resource<Release>> resourceResponseEntity =
+		ResponseEntity<String> resourceResponseEntity =
 				restTemplate.exchange(baseUri + "/release/logs/{releaseName}/{appName}",
 						HttpMethod.GET,
 						null,
 						typeReference,
 						uriVariables);
-		return resourceResponseEntity.getBody().getContent();
+		return resourceResponseEntity.getBody();
 	}
 
 	@Override

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -214,9 +214,9 @@ public interface SkipperClient {
 	 * Fetch the logs of the latest release identified by the given name.
 	 *
 	 * @param releaseName the release name
-	 * @return the release
+	 * @return the log content
 	 */
-	Release getLog(String releaseName);
+	String getLog(String releaseName);
 
 
 	/**
@@ -225,7 +225,7 @@ public interface SkipperClient {
 	 *
 	 * @param releaseName the release name
 	 * @param appName the application name
-	 * @return the release
+	 * @return the log content
 	 */
-	Release getLog(String releaseName, String appName);
+	String getLog(String releaseName, String appName);
 }

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,4 +208,24 @@ public interface SkipperClient {
 	 * @return the manifest info of a release
 	 */
 	String manifest(String releaseName, int releaseVersion);
+
+
+	/**
+	 * Fetch the logs of the latest release identified by the given name.
+	 *
+	 * @param releaseName the release name
+	 * @return the release
+	 */
+	Release getLog(String releaseName);
+
+
+	/**
+	 * Fetch the logs of the latest release identified by the given release name
+	 * and a specific application name inside the release.
+	 *
+	 * @param releaseName the release name
+	 * @param appName the application name
+	 * @return the release
+	 */
+	Release getLog(String releaseName, String appName);
 }

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -24,7 +24,6 @@ import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.Info;
-import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -157,10 +156,10 @@ public class DefaultSkipperClientTests {
 		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
 		mockServer.expect(requestTo("/release/logs/mylog")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-		Release release = skipperClient.getLog("mylog");
+		String logContent = skipperClient.getLog("mylog");
 		mockServer.verify();
 
-		assertThat(release).isNotNull();
+		assertThat(logContent).isNotNull();
 	}
 
 	@Test
@@ -171,9 +170,9 @@ public class DefaultSkipperClientTests {
 		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
 		mockServer.expect(requestTo("/release/logs/mylog/app")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-		Release release = skipperClient.getLog("mylog", "app");
+		String logContent = skipperClient.getLog("mylog", "app");
 		mockServer.verify();
 
-		assertThat(release).isNotNull();
+		assertThat(logContent).isNotNull();
 	}
 }

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -146,5 +147,33 @@ public class DefaultSkipperClientTests {
 		mockServer.expect(requestTo("/release/release1/package"))
 				.andRespond(withStatus(HttpStatus.CONFLICT).body(ERROR3).contentType(MediaType.APPLICATION_JSON));
 		skipperClient.delete("release1", true);
+	}
+
+	@Test
+	public void testLogByReleaseName() {
+		RestTemplate restTemplate = new RestTemplate();
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer.expect(requestTo("/release/logs/mylog")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+		Release release = skipperClient.getLog("mylog");
+		mockServer.verify();
+
+		assertThat(release).isNotNull();
+	}
+
+	@Test
+	public void testLogByReleaseAndAppNames() {
+		RestTemplate restTemplate = new RestTemplate();
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer.expect(requestTo("/release/logs/mylog/app")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+		Release release = skipperClient.getLog("mylog", "app");
+		mockServer.verify();
+
+		assertThat(release).isNotNull();
 	}
 }

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -170,12 +170,12 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 	}
 
 	@Override
-	public Release getLog(Release release) {
+	public String getLog(Release release) {
 		return getLog(release, null);
 	}
 
 	@Override
-	public Release getLog(Release release, String appName) {
+	public String getLog(Release release, String appName) {
 		logger.info("Checking application status for the release: " + release.getName());
 		ApplicationManifest applicationManifest = CloudFoundryApplicationManifestUtils.updateApplicationName(release);
 		String applicationName = applicationManifest.getName();
@@ -190,13 +190,12 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 		// Avoids serializing objects such as OutputStreams in LocalDeployer.
 		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 		try {
-			release.setLogs(objectMapper.writeValueAsString(logMessage));
+			return objectMapper.writeValueAsString(logMessage);
 		}
 		catch (JsonProcessingException e) {
 			// TODO replace with SkipperException when it moves to domain module.
 			throw new IllegalArgumentException("Could not serialize logs", e);
 		}
-		return release;
 	}
 
 }

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.skipper.deployer.cloudfoundry;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -22,7 +23,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.cloudfoundry.operations.applications.ApplicationManifest;
+import org.cloudfoundry.operations.applications.LogsRequest;
 import org.cloudfoundry.operations.applications.PushApplicationManifestRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +43,7 @@ import org.springframework.cloud.skipper.server.repository.jpa.AppDeployerDataRe
 import org.springframework.cloud.skipper.server.repository.jpa.ReleaseRepository;
 import org.springframework.cloud.skipper.server.util.ArgumentSanitizer;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.skipper.deployer.cloudfoundry.CloudFoundryManifestApplicationDeployer.PUSH_REQUEST_TIMEOUT;
 import static org.springframework.cloud.skipper.deployer.cloudfoundry.CloudFoundryManifestApplicationDeployer.STAGING_TIMEOUT;
@@ -53,7 +59,7 @@ import static org.springframework.cloud.skipper.deployer.cloudfoundry.CloudFound
  */
 public class CloudFoundryReleaseManager implements ReleaseManager {
 
-	public static final String SPRING_CLOUD_DEPLOYER_COUNT = "spring.cloud.deployer.count";
+	public static final Duration API_TIMEOUT = Duration.ofSeconds(30L);
 
 	private static final Logger logger = LoggerFactory.getLogger(CloudFoundryReleaseManager.class);
 
@@ -160,6 +166,36 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 
 	public Release delete(Release release) {
 		this.releaseRepository.save(this.cfManifestApplicationDeployer.delete(release));
+		return release;
+	}
+
+	@Override
+	public Release getLog(Release release) {
+		return getLog(release, null);
+	}
+
+	@Override
+	public Release getLog(Release release, String appName) {
+		logger.info("Checking application status for the release: " + release.getName());
+		ApplicationManifest applicationManifest = CloudFoundryApplicationManifestUtils.updateApplicationName(release);
+		String applicationName = applicationManifest.getName();
+		if (StringUtils.hasText(appName)) {
+			Assert.isTrue(applicationName.equalsIgnoreCase(appName),
+					String.format("Application name % is different from the CF manifest: %", appName, applicationName));
+		}
+		String logMessage = this.platformCloudFoundryOperations.getCloudFoundryOperations(release.getPlatformName()).applications()
+				.logs(LogsRequest.builder().name(applicationName).build())
+				.blockFirst(Duration.ofMillis(API_TIMEOUT.toMillis())).getMessage();
+		ObjectMapper objectMapper = new ObjectMapper();
+		// Avoids serializing objects such as OutputStreams in LocalDeployer.
+		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+		try {
+			release.setLogs(objectMapper.writeValueAsString(logMessage));
+		}
+		catch (JsonProcessingException e) {
+			// TODO replace with SkipperException when it moves to domain module.
+			throw new IllegalArgumentException("Could not serialize logs", e);
+		}
 		return release;
 	}
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -39,6 +39,7 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -117,14 +118,14 @@ public class ReleaseController {
 
 	@RequestMapping(path = "/logs/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public String log(@PathVariable("name") String name) {
-		return this.releaseService.getLog(name);
+	public ResponseEntity<String> log(@PathVariable("name") String name) {
+		return new ResponseEntity<>(this.releaseService.getLog(name), HttpStatus.OK);
 	}
 
 	@RequestMapping(path = "/logs/{name}/{appName}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public String log(@PathVariable("name") String name, @PathVariable("appName") String appName) {
-		return this.releaseService.getLog(name, appName);
+	public ResponseEntity<String> log(@PathVariable("name") String name, @PathVariable("appName") String appName) {
+		return new ResponseEntity<>(this.releaseService.getLog(name, appName), HttpStatus.OK);
 	}
 
 	@RequestMapping(path = "/manifest/{name}", method = RequestMethod.GET)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,18 @@ public class ReleaseController {
 	@ResponseStatus(HttpStatus.OK)
 	public Resource<Info> status(@PathVariable("name") String name, @PathVariable("version") Integer version) {
 		return this.infoResourceAssembler.toResource(this.releaseService.status(name, version));
+	}
+
+	@RequestMapping(path = "/logs/{name}", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public Resource<Release> log(@PathVariable("name") String name) {
+		return this.releaseResourceAssembler.toResource(this.releaseService.getLog(name));
+	}
+
+	@RequestMapping(path = "/logs/{name}/{appName}", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public Resource<Release> log(@PathVariable("name") String name, @PathVariable("appName") String appName) {
+		return this.releaseResourceAssembler.toResource(this.releaseService.getLog(name, appName));
 	}
 
 	@RequestMapping(path = "/manifest/{name}", method = RequestMethod.GET)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -117,14 +117,14 @@ public class ReleaseController {
 
 	@RequestMapping(path = "/logs/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public Resource<Release> log(@PathVariable("name") String name) {
-		return this.releaseResourceAssembler.toResource(this.releaseService.getLog(name));
+	public String log(@PathVariable("name") String name) {
+		return this.releaseService.getLog(name);
 	}
 
 	@RequestMapping(path = "/logs/{name}/{appName}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public Resource<Release> log(@PathVariable("name") String name, @PathVariable("appName") String appName) {
-		return this.releaseResourceAssembler.toResource(this.releaseService.getLog(name, appName));
+	public String log(@PathVariable("name") String name, @PathVariable("appName") String appName) {
+		return this.releaseService.getLog(name, appName);
 	}
 
 	@RequestMapping(path = "/manifest/{name}", method = RequestMethod.GET)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
@@ -309,14 +309,14 @@ public class DefaultReleaseManager implements ReleaseManager {
 	}
 
 	@Override
-	public Release getLog(Release release) {
+	public String getLog(Release release) {
 		return getLog(release, null);
 	}
 
 	@Override
-	public Release getLog(Release release, String appName) {
+	public String getLog(Release release, String appName) {
 		if (release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
-			return release;
+			return "";
 		}
 		AppDeployerData appDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersion(release.getName(), release.getVersion());
@@ -342,13 +342,12 @@ public class DefaultReleaseManager implements ReleaseManager {
 		// Avoids serializing objects such as OutputStreams in LocalDeployer.
 		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 		try {
-			release.setLogs(objectMapper.writeValueAsString(logMap));
+			return objectMapper.writeValueAsString(logMap);
 		}
 		catch (JsonProcessingException e) {
 			// TODO replace with SkipperException when it moves to domain module.
 			throw new IllegalArgumentException("Could not serialize logs", e);
 		}
-		return release;
 	}
 
 	public Release delete(Release release) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -301,6 +304,49 @@ public class DefaultReleaseManager implements ReleaseManager {
 				}
 			}
 			release.getInfo().getStatus().setPlatformStatusAsAppStatusList(appStatusList);
+		}
+		return release;
+	}
+
+	@Override
+	public Release getLog(Release release) {
+		return getLog(release, null);
+	}
+
+	@Override
+	public Release getLog(Release release, String appName) {
+		if (release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
+			return release;
+		}
+		AppDeployerData appDeployerData = this.appDeployerDataRepository
+				.findByReleaseNameAndReleaseVersion(release.getName(), release.getVersion());
+		AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
+				.getAppDeployer();
+		Map<String, String> logMap = new HashMap<>();
+		Map<String, String> appNameDeploymentIdMap = appDeployerData.getDeploymentDataAsMap();
+		Map<String, String> logApps = new HashMap<>();
+		if (StringUtils.hasText(appName)) {
+			for (Map.Entry<String, String> nameDeploymentId : appNameDeploymentIdMap.entrySet()) {
+				if (appName.equalsIgnoreCase(nameDeploymentId.getValue())) {
+					logApps.put(nameDeploymentId.getKey(), nameDeploymentId.getValue());
+				}
+			}
+		}
+		else {
+			logApps = appNameDeploymentIdMap;
+		}
+		for (Map.Entry<String, String> deploymentIdEntry: logApps.entrySet()) {
+			logMap.put(deploymentIdEntry.getKey(), appDeployer.getLog(deploymentIdEntry.getValue()));
+		}
+		ObjectMapper objectMapper = new ObjectMapper();
+		// Avoids serializing objects such as OutputStreams in LocalDeployer.
+		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+		try {
+			release.setLogs(objectMapper.writeValueAsString(logMap));
+		}
+		catch (JsonProcessingException e) {
+			// TODO replace with SkipperException when it moves to domain module.
+			throw new IllegalArgumentException("Could not serialize logs", e);
 		}
 		return release;
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,5 +74,22 @@ public interface ReleaseManager {
 	 * @return the updated release
 	 */
 	Release status(Release release);
+
+	/**
+	 * Get the logs of the applications inside the release.
+	 *
+	 * @param release the release
+	 * @return release with the logs updated.
+	 */
+	Release getLog(Release release);
+
+	/**
+	 * Get the logs of a specific application inside the release.
+	 *
+	 * @param release the release
+	 * @param appName the application name
+	 * @return release with the logs updated.
+	 */
+	Release getLog(Release release, String appName);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -79,17 +79,17 @@ public interface ReleaseManager {
 	 * Get the logs of the applications inside the release.
 	 *
 	 * @param release the release
-	 * @return release with the logs updated.
+	 * @return the log content
 	 */
-	Release getLog(Release release);
+	String getLog(Release release);
 
 	/**
 	 * Get the logs of a specific application inside the release.
 	 *
 	 * @param release the release
 	 * @param appName the application name
-	 * @return release with the logs updated.
+	 * @return the log content
 	 */
-	Release getLog(Release release, String appName);
+	String getLog(Release release, String appName);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -267,6 +267,19 @@ public class ReleaseService {
 	@Transactional
 	public Info status(String releaseName, Integer version) {
 		return status(this.releaseRepository.findByNameAndVersion(releaseName, version)).getInfo();
+	}
+
+	@Transactional
+	public Release getLog(String releaseName) {
+		return this.getLog(releaseName, null);
+	}
+
+	@Transactional
+	public Release getLog(String releaseName, String appName) {
+		Release release = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
+		String kind = ManifestUtils.resolveKind(release.getManifest().getData());
+		ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);
+		return releaseManager.getLog(release, appName);
 	}
 
 	/**

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -270,12 +270,12 @@ public class ReleaseService {
 	}
 
 	@Transactional
-	public Release getLog(String releaseName) {
+	public String getLog(String releaseName) {
 		return this.getLog(releaseName, null);
 	}
 
 	@Transactional
-	public Release getLog(String releaseName, String appName) {
+	public String getLog(String releaseName, String appName) {
 		Release release = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
 		String kind = ManifestUtils.resolveKind(release.getManifest().getData());
 		ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfigurationTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfigurationTests.java
@@ -134,6 +134,11 @@ public class SkipperServerPlatformConfigurationTests {
 						public RuntimeEnvironmentInfo environmentInfo() {
 							return null;
 						}
+
+						@Override
+						public String getLog(String id) {
+							return null;
+						}
 					})));
 		}
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -103,13 +103,10 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 	public void getReleaseLogs() throws Exception {
 		// Deploy
 		String releaseName = "testLogs";
-		Release release = install("log", "1.0.0", releaseName);
-		assertThat(release.getLogs()).isNull();
-
+		install("log", "1.0.0", releaseName);
 		MvcResult result = mockMvc.perform(get("/api/release/logs/" + releaseName)).andDo(print())
 				.andExpect(status().isOk()).andReturn();
-		Release updatedRelease = convertContentToRelease(result.getResponse().getContentAsString());
-		assertThat(updatedRelease.getLogs()).isNotEmpty();
+		assertThat(result.getResponse().getContentAsString()).isNotEmpty();
 	}
 
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -100,6 +100,20 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 	}
 
 	@Test
+	public void getReleaseLogs() throws Exception {
+		// Deploy
+		String releaseName = "testLogs";
+		Release release = install("log", "1.0.0", releaseName);
+		assertThat(release.getLogs()).isNull();
+
+		MvcResult result = mockMvc.perform(get("/api/release/logs/" + releaseName)).andDo(print())
+				.andExpect(status().isOk()).andReturn();
+		Release updatedRelease = convertContentToRelease(result.getResponse().getContentAsString());
+		assertThat(updatedRelease.getLogs()).isNotEmpty();
+	}
+
+
+	@Test
 	public void checkDeleteReleaseWithPackage() throws Exception {
 
 		// Make the test repo Local

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,8 @@ public class DeleteDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"))));
+								fieldWithPath("platformName").description("Platform name of the release"),
+								fieldWithPath("logs").description("The logs of the release"))));
 	}
 
 	@Test
@@ -171,6 +172,7 @@ public class DeleteDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"))));
+								fieldWithPath("platformName").description("Platform name of the release"),
+								fieldWithPath("logs").description("The logs of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/DeleteDocumentation.java
@@ -103,8 +103,7 @@ public class DeleteDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"),
-								fieldWithPath("logs").description("The logs of the release"))));
+								fieldWithPath("platformName").description("Platform name of the release"))));
 	}
 
 	@Test
@@ -172,7 +171,6 @@ public class DeleteDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"),
-								fieldWithPath("logs").description("The logs of the release"))));
+								fieldWithPath("platformName").description("Platform name of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,6 +99,7 @@ public class HistoryDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.releases[].configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("_embedded.releases[].manifest.data").description("The manifest of the release"),
-								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"))));
+								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"),
+								fieldWithPath("_embedded.releases[].logs").description("The logs of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/HistoryDocumentation.java
@@ -99,7 +99,6 @@ public class HistoryDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.releases[].configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("_embedded.releases[].manifest.data").description("The manifest of the release"),
-								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"),
-								fieldWithPath("_embedded.releases[].logs").description("The logs of the release"))));
+								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,8 @@ public class InstallDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"),
+								fieldWithPath("logs").description("The logs of the release"))))
 				.andReturn();
 	}
 
@@ -197,7 +198,8 @@ public class InstallDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"),
+								fieldWithPath("logs").description("The logs of the release"))))
 				.andReturn();
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/InstallDocumentation.java
@@ -115,8 +115,7 @@ public class InstallDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"),
-								fieldWithPath("logs").description("The logs of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"))))
 				.andReturn();
 	}
 
@@ -198,8 +197,7 @@ public class InstallDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"),
-								fieldWithPath("logs").description("The logs of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"))))
 				.andReturn();
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,8 @@ public class ListDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.releases[].configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("_embedded.releases[].manifest.data").description("The manifest of the release"),
-								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"))
+								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"),
+								fieldWithPath("_embedded.releases[].logs").description("The logs of the release"))
 
 				));
 	}
@@ -171,6 +172,7 @@ public class ListDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.releases[].configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("_embedded.releases[].manifest.data").description("The manifest of the release"),
-								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"))));
+								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"),
+								fieldWithPath("_embedded.releases[].logs").description("The logs of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ListDocumentation.java
@@ -102,8 +102,7 @@ public class ListDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.releases[].configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("_embedded.releases[].manifest.data").description("The manifest of the release"),
-								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"),
-								fieldWithPath("_embedded.releases[].logs").description("The logs of the release"))
+								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"))
 
 				));
 	}
@@ -172,7 +171,6 @@ public class ListDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.releases[].configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("_embedded.releases[].manifest.data").description("The manifest of the release"),
-								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"),
-								fieldWithPath("_embedded.releases[].logs").description("The logs of the release"))));
+								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"))));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/LogsDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/LogsDocumentation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.server.controller.docs;
+
+import java.nio.charset.Charset;
+
+import org.junit.Test;
+
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.http.MediaType;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseBody;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+public class LogsDocumentation extends BaseDocumentation {
+
+	@Test
+	public void getLogsofRelease() throws Exception {
+		Release release = createTestRelease();
+		release.setLogs("Logs");
+		when(this.releaseService.getLog(release.getName())).thenReturn(release);
+		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
+				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+
+		this.mockMvc.perform(
+				get("/api/release/logs/{releaseName}", release.getName()).accept(MediaType.APPLICATION_JSON)
+						.contentType(contentType))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						responseBody()));
+	}
+
+	@Test
+	public void getLogsofReleaseByAppName() throws Exception {
+		Release release = createTestRelease();
+		release.setLogs("Logs");
+		when(this.releaseService.getLog(release.getName(), "myapp")).thenReturn(release);
+
+		this.mockMvc.perform(
+				get("/api/release/logs/{releaseName}/{appName}",
+						release.getName(), release.getVersion()))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andDo(this.documentationHandler.document(
+						responseBody()));
+	}
+}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/LogsDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/LogsDocumentation.java
@@ -37,8 +37,7 @@ public class LogsDocumentation extends BaseDocumentation {
 	@Test
 	public void getLogsofRelease() throws Exception {
 		Release release = createTestRelease();
-		release.setLogs("Logs");
-		when(this.releaseService.getLog(release.getName())).thenReturn(release);
+		when(this.releaseService.getLog(release.getName())).thenReturn("Logs");
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
@@ -54,8 +53,7 @@ public class LogsDocumentation extends BaseDocumentation {
 	@Test
 	public void getLogsofReleaseByAppName() throws Exception {
 		Release release = createTestRelease();
-		release.setLogs("Logs");
-		when(this.releaseService.getLog(release.getName(), "myapp")).thenReturn(release);
+		when(this.releaseService.getLog(release.getName(), "myapp")).thenReturn("Logs");
 
 		this.mockMvc.perform(
 				get("/api/release/logs/{releaseName}/{appName}",

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
@@ -104,8 +104,7 @@ public class ReleasesDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.releases[].configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("_embedded.releases[].manifest.data").description("The manifest of the release"),
-								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"),
-								fieldWithPath("_embedded.releases[].logs").description("The logs of the release")
+								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release")
 
 						).and(super.defaultLinkProperties)
 				));

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ReleasesDocumentation.java
@@ -104,7 +104,8 @@ public class ReleasesDocumentation extends BaseDocumentation {
 								fieldWithPath("_embedded.releases[].configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("_embedded.releases[].manifest.data").description("The manifest of the release"),
-								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release")
+								fieldWithPath("_embedded.releases[].platformName").description("Platform name of the release"),
+								fieldWithPath("_embedded.releases[].logs").description("The logs of the release")
 
 						).and(super.defaultLinkProperties)
 				));

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,8 @@ public class RollbackDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"),
+								fieldWithPath("logs").description("The logs of the release"))))
 				.andReturn();
 	}
 
@@ -174,7 +175,8 @@ public class RollbackDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"),
+								fieldWithPath("logs").description("The logs of the release"))))
 				.andReturn();
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/RollbackDocumentation.java
@@ -103,8 +103,7 @@ public class RollbackDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"),
-								fieldWithPath("logs").description("The logs of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"))))
 				.andReturn();
 	}
 
@@ -175,8 +174,7 @@ public class RollbackDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"),
-								fieldWithPath("logs").description("The logs of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"))))
 				.andReturn();
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
@@ -122,8 +122,7 @@ public class UpgradeDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"),
-								fieldWithPath("logs").description("The logs of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"))))
 				.andReturn();
 	}
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/UpgradeDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,8 @@ public class UpgradeDocumentation extends BaseDocumentation {
 								fieldWithPath("configValues.raw")
 										.description("The raw YAML string of configuration values"),
 								fieldWithPath("manifest.data").description("The manifest of the release"),
-								fieldWithPath("platformName").description("Platform name of the release"))))
+								fieldWithPath("platformName").description("Platform name of the release"),
+								fieldWithPath("logs").description("The logs of the release"))))
 				.andReturn();
 	}
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -181,10 +181,8 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		installRequest.setPackageIdentifier(packageIdentifier);
 		assertThat(release).isNotNull();
 		assertThat(release.getPkg().getMetadata().getVersion()).isEqualTo("1.0.0");
-		assertThat(release.getLogs()).isNull();
-		Release updatedRelease = this.releaseService.getLog(releaseName);
-		assertThat(updatedRelease).isNotNull();
-		assertThat(updatedRelease.getLogs()).isNotNull();
+		String logContent = this.releaseService.getLog(releaseName);
+		assertThat(logContent).isNotNull();
 	}
 
 	@Test

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
@@ -70,9 +69,6 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 
 	@Autowired
 	private AppDeployerDataRepository appDeployerDataRepository;
-
-	@Autowired
-	private DelegatingResourceLoader delegatingResourceLoader;
 
 	@Autowired
 	private RepositoryRepository repositoryRepository;
@@ -170,6 +166,25 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		assertThat(appInstanceState.getAttributes().get(DefaultReleaseManager.SKIPPER_RELEASE_NAME_ATTRIBUTE)).isEqualTo("logrelease");
 		assertThat(appInstanceState.getAttributes().get(DefaultReleaseManager.SKIPPER_RELEASE_VERSION_ATTRIBUTE)).isEqualTo("1");
 		assertThat(appInstanceState.getAttributes().get(DefaultReleaseManager.SKIPPER_APPLICATION_NAME_ATTRIBUTE)).isEqualTo("log");
+	}
+
+	@Test
+	public void testLogs() throws InterruptedException {
+		String releaseName = "myapp-release";
+		InstallRequest installRequest = new InstallRequest();
+		installRequest.setInstallProperties(createInstallProperties(releaseName));
+		PackageIdentifier packageIdentifier = new PackageIdentifier();
+		packageIdentifier.setPackageName("log");
+		packageIdentifier.setPackageVersion("1.0.0");
+		installRequest.setPackageIdentifier(packageIdentifier);
+		Release release = install(installRequest);
+		installRequest.setPackageIdentifier(packageIdentifier);
+		assertThat(release).isNotNull();
+		assertThat(release.getPkg().getMetadata().getVersion()).isEqualTo("1.0.0");
+		assertThat(release.getLogs()).isNull();
+		Release updatedRelease = this.releaseService.getLog(releaseName);
+		assertThat(updatedRelease).isNotNull();
+		assertThat(updatedRelease.getLogs()).isNotNull();
 	}
 
 	@Test

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
@@ -84,9 +84,6 @@ public class Release extends AbstractEntity {
 
 	private String platformName;
 
-	@Transient
-	private String logs;
-
 	public Release() {
 	}
 
@@ -178,14 +175,6 @@ public class Release extends AbstractEntity {
 
 	public void setPlatformName(String platformName) {
 		this.platformName = platformName;
-	}
-
-	public String getLogs() {
-		return logs;
-	}
-
-	public void setLogs(String logs) {
-		this.logs = logs;
 	}
 
 	@PostLoad

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Release.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Pollack
  * @author Gunnar Hillert
+ * @author Ilayaperumal Gopinathan
  */
 @Entity
 @Table(name = "SkipperRelease", indexes = @Index(name = "idx_rel_name", columnList = "name"))
@@ -82,6 +83,9 @@ public class Release extends AbstractEntity {
 	private Manifest manifest;
 
 	private String platformName;
+
+	@Transient
+	private String logs;
 
 	public Release() {
 	}
@@ -174,6 +178,14 @@ public class Release extends AbstractEntity {
 
 	public void setPlatformName(String platformName) {
 		this.platformName = platformName;
+	}
+
+	public String getLogs() {
+		return logs;
+	}
+
+	public void setLogs(String logs) {
+		this.logs = logs;
 	}
 
 	@PostLoad


### PR DESCRIPTION
 - Add REST endpoint to retrieve release logs by release name, application name
 - Add getLog() method in ReleaseManager
 - Implement getLog() on ReleaseManagers (Default and CF)
   - Use the corresponding app deployer implementations to retrieve logs
 - Add Skipper client methods to retrive logs from the REST endpoints
 - Update CF platform configuration to update DopplerClient to CF platform operations
 - Update documentation API
 - Add and update tests

Resolves #882
Resolves #883