### PR TITLE
Add LogInfo domain model to represent release logs

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -33,6 +33,7 @@ import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Manifest;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
@@ -158,13 +159,13 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public String getLog(String releaseName) {
-		ParameterizedTypeReference<String> typeReference =
-				new ParameterizedTypeReference<String>() { };
+	public LogInfo getLog(String releaseName) {
+		ParameterizedTypeReference<LogInfo> typeReference =
+				new ParameterizedTypeReference<LogInfo>() { };
 		Map<String, String> uriVariables = new HashMap<String, String>();
 		uriVariables.put("releaseName", releaseName);
 
-		ResponseEntity<String> resourceResponseEntity =
+		ResponseEntity<LogInfo> resourceResponseEntity =
 				restTemplate.exchange(baseUri + "/release/logs/{releaseName}",
 						HttpMethod.GET,
 						null,
@@ -174,14 +175,14 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public String getLog(String releaseName, String appName) {
-		ParameterizedTypeReference<String> typeReference =
-				new ParameterizedTypeReference<String>() { };
+	public LogInfo getLog(String releaseName, String appName) {
+		ParameterizedTypeReference<LogInfo> typeReference =
+				new ParameterizedTypeReference<LogInfo>() { };
 		Map<String, String> uriVariables = new HashMap<String, String>();
 		uriVariables.put("releaseName", releaseName);
 		uriVariables.put("appName", appName);
 
-		ResponseEntity<String> resourceResponseEntity =
+		ResponseEntity<LogInfo> resourceResponseEntity =
 				restTemplate.exchange(baseUri + "/release/logs/{releaseName}/{appName}",
 						HttpMethod.GET,
 						null,

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -23,6 +23,7 @@ import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Repository;
@@ -216,7 +217,7 @@ public interface SkipperClient {
 	 * @param releaseName the release name
 	 * @return the log content
 	 */
-	String getLog(String releaseName);
+	LogInfo getLog(String releaseName);
 
 
 	/**
@@ -227,5 +228,5 @@ public interface SkipperClient {
 	 * @param appName the application name
 	 * @return the log content
 	 */
-	String getLog(String releaseName, String appName);
+	LogInfo getLog(String releaseName, String appName);
 }

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -156,7 +157,7 @@ public class DefaultSkipperClientTests {
 		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
 		mockServer.expect(requestTo("/release/logs/mylog")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-		String logContent = skipperClient.getLog("mylog");
+		LogInfo logContent = skipperClient.getLog("mylog");
 		mockServer.verify();
 
 		assertThat(logContent).isNotNull();
@@ -170,7 +171,7 @@ public class DefaultSkipperClientTests {
 		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
 		mockServer.expect(requestTo("/release/logs/mylog/app")).andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-		String logContent = skipperClient.getLog("mylog", "app");
+		LogInfo logContent = skipperClient.getLog("mylog", "app");
 		mockServer.verify();
 
 		assertThat(logContent).isNotNull();

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -25,6 +25,7 @@ import org.springframework.cloud.skipper.domain.CancelRequest;
 import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.Info;
+import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Manifest;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.RollbackRequest;
@@ -32,6 +33,7 @@ import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.controller.support.InfoResourceAssembler;
 import org.springframework.cloud.skipper.server.controller.support.ManifestResourceAssembler;
 import org.springframework.cloud.skipper.server.controller.support.ReleaseResourceAssembler;
+import org.springframework.cloud.skipper.server.controller.support.SimpleResourceAssembler;
 import org.springframework.cloud.skipper.server.service.ReleaseService;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService;
 import org.springframework.hateoas.Resource;
@@ -39,7 +41,6 @@ import org.springframework.hateoas.ResourceSupport;
 import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -118,14 +119,14 @@ public class ReleaseController {
 
 	@RequestMapping(path = "/logs/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<String> log(@PathVariable("name") String name) {
-		return new ResponseEntity<>(this.releaseService.getLog(name), HttpStatus.OK);
+	public Resource<LogInfo> log(@PathVariable("name") String name) {
+		return new SimpleResourceAssembler<LogInfo>().toResource(this.releaseService.getLog(name));
 	}
 
 	@RequestMapping(path = "/logs/{name}/{appName}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<String> log(@PathVariable("name") String name, @PathVariable("appName") String appName) {
-		return new ResponseEntity<>(this.releaseService.getLog(name, appName), HttpStatus.OK);
+	public Resource<LogInfo> log(@PathVariable("name") String name, @PathVariable("appName") String appName) {
+		return new SimpleResourceAssembler<LogInfo>().toResource(this.releaseService.getLog(name, appName));
 	}
 
 	@RequestMapping(path = "/manifest/{name}", method = RequestMethod.GET)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.deployer;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
 
 /**
@@ -81,7 +82,7 @@ public interface ReleaseManager {
 	 * @param release the release
 	 * @return the log content
 	 */
-	String getLog(Release release);
+	LogInfo getLog(Release release);
 
 	/**
 	 * Get the logs of a specific application inside the release.
@@ -90,6 +91,6 @@ public interface ReleaseManager {
 	 * @param appName the application name
 	 * @return the log content
 	 */
-	String getLog(Release release, String appName);
+	LogInfo getLog(Release release, String appName);
 
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Manifest;
 import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
@@ -270,12 +271,12 @@ public class ReleaseService {
 	}
 
 	@Transactional
-	public String getLog(String releaseName) {
+	public LogInfo getLog(String releaseName) {
 		return this.getLog(releaseName, null);
 	}
 
 	@Transactional
-	public String getLog(String releaseName, String appName) {
+	public LogInfo getLog(String releaseName, String appName) {
 		Release release = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
 		String kind = ManifestUtils.resolveKind(release.getManifest().getData());
 		ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/LogsDocumentation.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/LogsDocumentation.java
@@ -17,9 +17,11 @@
 package org.springframework.cloud.skipper.server.controller.docs;
 
 import java.nio.charset.Charset;
+import java.util.Collections;
 
 import org.junit.Test;
 
+import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.http.MediaType;
 
@@ -37,7 +39,7 @@ public class LogsDocumentation extends BaseDocumentation {
 	@Test
 	public void getLogsofRelease() throws Exception {
 		Release release = createTestRelease();
-		when(this.releaseService.getLog(release.getName())).thenReturn("Logs");
+		when(this.releaseService.getLog(release.getName())).thenReturn(new LogInfo(Collections.emptyMap()));
 		final MediaType contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
 				MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
@@ -53,7 +55,7 @@ public class LogsDocumentation extends BaseDocumentation {
 	@Test
 	public void getLogsofReleaseByAppName() throws Exception {
 		Release release = createTestRelease();
-		when(this.releaseService.getLog(release.getName(), "myapp")).thenReturn("Logs");
+		when(this.releaseService.getLog(release.getName(), "myapp")).thenReturn(new LogInfo(Collections.EMPTY_MAP));
 
 		this.mockMvc.perform(
 				get("/api/release/logs/{releaseName}/{appName}",

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ReleaseServiceTests.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.skipper.domain.ConfigValues;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
+import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
@@ -181,7 +182,7 @@ public class ReleaseServiceTests extends AbstractIntegrationTest {
 		installRequest.setPackageIdentifier(packageIdentifier);
 		assertThat(release).isNotNull();
 		assertThat(release.getPkg().getMetadata().getVersion()).isEqualTo("1.0.0");
-		String logContent = this.releaseService.getLog(releaseName);
+		LogInfo logContent = this.releaseService.getLog(releaseName);
 		assertThat(logContent).isNotNull();
 	}
 

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/LogInfo.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/LogInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Provides information about logs of a specific {@link Release}.
+ *
+ * @author Ilayaperumal Gopinathan
+ *
+ */
+public class LogInfo {
+
+	private Map<String, String> logs;
+
+	public LogInfo() {
+	}
+
+	public LogInfo(Map<String, String> logs) {
+		this.logs = logs;
+	}
+
+	@JsonProperty("logs")
+	public Map<String, String> getLogs() {
+		return logs;
+	}
+
+	public void setLogs(Map<String, String> logs) {
+		this.logs = logs;
+	}
+}


### PR DESCRIPTION
 - LogInfo represents a map of application logs
   - key being the application ID
   - value being the log value

 - Update ReleaseService, ReleaseManager and SkipperClient interfaces to update this
 - Update tests

Resolves #887