### PR TITLE
Use the initialized deployment properties

### DIFF
--- a/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/CloudFoundryPlatformAutoConfiguration.java
+++ b/spring-cloud-skipper-autoconfigure/src/main/java/org/springframework/cloud/skipper/server/autoconfigure/CloudFoundryPlatformAutoConfiguration.java
@@ -126,7 +126,7 @@ public class CloudFoundryPlatformAutoConfiguration {
 					.dopplerClient(dopplerClient)
 					.space(connectionProperties.getSpace()).build();
 			CloudFoundryAppNameGenerator appNameGenerator = new CloudFoundryAppNameGenerator(
-					cloudFoundryProperties.getDeployment());
+					deploymentProperties);
 			appNameGenerator.afterPropertiesSet();
 			CloudFoundryAppDeployer cfAppDeployer = new CloudFoundryAppDeployer(
 					appNameGenerator, deploymentProperties, cloudFoundryOperations,


### PR DESCRIPTION
 - When saving the CF deployer, use the non-null deployment properties

Resolves #902