### PR TITLE
Remove creation of copied default platform

### DIFF
--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfigurationTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfigurationTests.java
@@ -80,7 +80,7 @@ public class SkipperServerPlatformConfigurationTests {
 
 		@Test
 		public void singlePlatformsConfiguredTest() {
-			assertThat(platforms.get(0).getDeployers()).extracting("name").containsExactly("default", "test");
+			assertThat(platforms.get(0).getDeployers()).extracting("name").containsExactly("test");
 		}
 	}
 


### PR DESCRIPTION
- In case user defined a single platform not named as `default`, it
  was duplicated as `default` resulting two platforms. This commit
  simply removes this duplication.
- Internally we don't do any dance around platform names so that we'd
  silently switch to `default` if only one non `default` exists. This
  is because similar check is allready done on a dataflow side and this
  switch happens there. In skipper we use these platforms via repository
  and it would have added a complex changes to switch these names in
  multiple places, essentially doing platform switch in both skipper
  and dataflow. It's just better to fail on a skipper side if
  non-existing platform is used as that keeps logic simpler.
- Fixes #901