### PR TITLE
Implement scaling for request flows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,14 @@
 		<spring-cloud.version>Hoxton.M3</spring-cloud.version>
 
 		<java-cfenv-boot.version>1.1.1.RELEASE</java-cfenv-boot.version>
-		<spring-cloud-deployer.version>2.1.0.M2</spring-cloud-deployer.version>
-		<spring-cloud-deployer-local.version>2.1.0.M2</spring-cloud-deployer-local.version>
+		<spring-cloud-deployer.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-deployer.version>
+		<spring-cloud-deployer-local.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-deployer-local.version>
 		<!-- note - check version of reactor at deployer-cf/cf-java-client uses -->
-		<spring-cloud-deployer-cloudfoundry.version>2.1.0.M2</spring-cloud-deployer-cloudfoundry.version>
+		<spring-cloud-deployer-cloudfoundry.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
 		<reactor.version>3.2.0.RELEASE</reactor.version>
 
 		<kubernetes-client.version>4.1.0</kubernetes-client.version>
-		<spring-cloud-deployer-kubernetes.version>2.1.0.M2</spring-cloud-deployer-kubernetes.version>
+		<spring-cloud-deployer-kubernetes.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-deployer-kubernetes.version>
 
 		<dockerfile-maven-plugin.version>1.4.9</dockerfile-maven-plugin.version>
 		<zeroturnaround.version>1.13</zeroturnaround.version>

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -212,21 +212,8 @@ public class DefaultSkipperClient implements SkipperClient {
 	}
 
 	@Override
-	public Release scale(String releaseName, String appName, int count) {
-		ParameterizedTypeReference<EntityModel<Release>> typeReference =
-				new ParameterizedTypeReference<EntityModel<Release>>() { };
-		Map<String, String> uriVariables = new HashMap<String, String>();
-		uriVariables.put("releaseName", releaseName);
-		uriVariables.put("appName", appName);
-		uriVariables.put("count", Integer.toString(count));
-
-		ResponseEntity<EntityModel<Release>> resourceResponseEntity =
-				restTemplate.exchange(baseUri + "/release/scale/{releaseName}/{appName}/{count}",
-						HttpMethod.POST,
-						null,
-						typeReference,
-						uriVariables);
-		return resourceResponseEntity.getBody().getContent();
+	public Release scale(String releaseName, String appName, int count, Map<String, String> properties) {
+		return scale(releaseName, ScaleRequest.of(appName, count, properties));
 	}
 
 	@Override

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -194,6 +194,7 @@ public class DefaultSkipperClient implements SkipperClient {
 		return resourceResponseEntity.getBody();
 	}
 
+	@Override
 	public Release scale(String releaseName, ScaleRequest scaleRequest) {
 		ParameterizedTypeReference<EntityModel<Release>> typeReference =
 				new ParameterizedTypeReference<EntityModel<Release>>() { };
@@ -210,6 +211,7 @@ public class DefaultSkipperClient implements SkipperClient {
 		return resourceResponseEntity.getBody().getContent();
 	}
 
+	@Override
 	public Release scale(String releaseName, String appName, int count) {
 		ParameterizedTypeReference<EntityModel<Release>> typeReference =
 				new ParameterizedTypeReference<EntityModel<Release>>() { };

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Repository;
 import org.springframework.cloud.skipper.domain.RollbackRequest;
+import org.springframework.cloud.skipper.domain.ScaleRequest;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
@@ -63,6 +64,7 @@ import org.springframework.web.client.RestTemplate;
  *
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author Janne Valkealahti
  */
 public class DefaultSkipperClient implements SkipperClient {
 
@@ -190,6 +192,39 @@ public class DefaultSkipperClient implements SkipperClient {
 						typeReference,
 						uriVariables);
 		return resourceResponseEntity.getBody();
+	}
+
+	public Release scale(String releaseName, ScaleRequest scaleRequest) {
+		ParameterizedTypeReference<EntityModel<Release>> typeReference =
+				new ParameterizedTypeReference<EntityModel<Release>>() { };
+		Map<String, String> uriVariables = new HashMap<String, String>();
+		uriVariables.put("releaseName", releaseName);
+
+		HttpEntity<ScaleRequest> httpEntity = new HttpEntity<>(scaleRequest);
+		ResponseEntity<EntityModel<Release>> resourceResponseEntity =
+				restTemplate.exchange(baseUri + "/release/scale/{releaseName}",
+						HttpMethod.POST,
+						httpEntity,
+						typeReference,
+						uriVariables);
+		return resourceResponseEntity.getBody().getContent();
+	}
+
+	public Release scale(String releaseName, String appName, int count) {
+		ParameterizedTypeReference<EntityModel<Release>> typeReference =
+				new ParameterizedTypeReference<EntityModel<Release>>() { };
+		Map<String, String> uriVariables = new HashMap<String, String>();
+		uriVariables.put("releaseName", releaseName);
+		uriVariables.put("appName", appName);
+		uriVariables.put("count", Integer.toString(count));
+
+		ResponseEntity<EntityModel<Release>> resourceResponseEntity =
+				restTemplate.exchange(baseUri + "/release/scale/{releaseName}/{appName}/{count}",
+						HttpMethod.POST,
+						null,
+						typeReference,
+						uriVariables);
+		return resourceResponseEntity.getBody().getContent();
 	}
 
 	@Override

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.Repository;
 import org.springframework.cloud.skipper.domain.RollbackRequest;
+import org.springframework.cloud.skipper.domain.ScaleRequest;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
@@ -229,4 +230,23 @@ public interface SkipperClient {
 	 * @return the log content
 	 */
 	LogInfo getLog(String releaseName, String appName);
+
+	/**
+	 * Scale an application within a release by a new count.
+	 *
+	 * @param releaseName the release name
+	 * @param appName the application name
+	 * @param count the new desired count
+	 * @return the status info of a release
+	 */
+	Release scale(String releaseName, String appName, int count);
+
+	/**
+	 * Scale a release with a given scale request.
+	 *
+	 * @param releaseName the release name
+	 * @param scaleRequest the scale request
+	 * @return the status info of a release
+	 */
+	Release scale(String releaseName, ScaleRequest scaleRequest);
 }

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.skipper.client;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.CancelRequest;
@@ -236,10 +237,11 @@ public interface SkipperClient {
 	 *
 	 * @param releaseName the release name
 	 * @param appName the application name
-	 * @param count the new desired count
+	 * @param count the count
+	 * @param properties the properties
 	 * @return the status info of a release
 	 */
-	Release scale(String releaseName, String appName, int count);
+	Release scale(String releaseName, String appName, int count, Map<String, String> properties);
 
 	/**
 	 * Scale a release with a given scale request.

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -16,8 +16,6 @@
 package org.springframework.cloud.skipper.client;
 
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
@@ -183,22 +181,6 @@ public class DefaultSkipperClientTests {
 	}
 
 	@Test
-	public void testScaleByReleaseAndAppNameAndCount() {
-		RestTemplate restTemplate = new RestTemplate();
-		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
-
-		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
-		mockServer
-			.expect(requestTo("/release/scale/mylog/app/2"))
-			.andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
-
-		Release release = skipperClient.scale("mylog", "app", 2);
-		mockServer.verify();
-
-		assertThat(release).isNotNull();
-	}
-
-	@Test
 	public void testScaleByReleaseAndScaleRequest() {
 		RestTemplate restTemplate = new RestTemplate();
 		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
@@ -206,13 +188,10 @@ public class DefaultSkipperClientTests {
 		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
 		mockServer
 			.expect(requestTo("/release/scale/mylog"))
-			.andExpect(content().json("{counts:{app:2}}"))
+			.andExpect(content().json("{\"scale\":[{\"name\":\"app\",\"count\":2,\"properties\":{}}]}"))
 			.andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-		ScaleRequest scaleRequest = new ScaleRequest();
-		Map<String, Integer> counts = new HashMap<>();
-		counts.put("app", 2);
-		scaleRequest.setCounts(counts);
+		ScaleRequest scaleRequest = ScaleRequest.of("app", 2);
 		Release release = skipperClient.scale("mylog", scaleRequest);
 		mockServer.verify();
 

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.ScaleRequest;
 import org.springframework.cloud.skipper.domain.SkipperManifestKind;
 import org.springframework.cloud.skipper.domain.Status;
 import org.springframework.cloud.skipper.domain.StatusCode;
@@ -189,4 +190,9 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 		return new LogInfo(logMap);
 	}
 
+	@Override
+	public Release scale(Release release, ScaleRequest scaleRequest) {
+		// TODO: implement for cf
+		throw new UnsupportedOperationException();
+	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -152,13 +152,13 @@ public class ReleaseController {
 		return this.releaseResourceAssembler.toModel(release);
 	}
 
-	@RequestMapping(path = "/scale/{name}/{appName}", method = RequestMethod.POST)
+	@RequestMapping(path = "/scale/{name}/{appName}/{count}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public EntityModel<Release> scale(@PathVariable("name") String name, @PathVariable("appName") String appName,
-			int desiredCount) {
+			@PathVariable("count") int count) {
 		ScaleRequest scaleRequest = new ScaleRequest();
 		Map<String, Integer> counts = new HashMap<>();
-		counts.put(appName, desiredCount);
+		counts.put(appName, count);
 		scaleRequest.setCounts(counts);
 		Release release = this.skipperStateMachineService.scaleRelease(name, scaleRequest);
 		return this.releaseResourceAssembler.toModel(release);

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -15,9 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.controller;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.PackageDeleteException;
@@ -148,18 +146,6 @@ public class ReleaseController {
 	@RequestMapping(path = "/scale/{name}", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public EntityModel<Release> scale(@PathVariable("name") String name, @RequestBody ScaleRequest scaleRequest) {
-		Release release = this.skipperStateMachineService.scaleRelease(name, scaleRequest);
-		return this.releaseResourceAssembler.toModel(release);
-	}
-
-	@RequestMapping(path = "/scale/{name}/{appName}/{count}", method = RequestMethod.POST)
-	@ResponseStatus(HttpStatus.CREATED)
-	public EntityModel<Release> scale(@PathVariable("name") String name, @PathVariable("appName") String appName,
-			@PathVariable("count") int count) {
-		ScaleRequest scaleRequest = new ScaleRequest();
-		Map<String, Integer> counts = new HashMap<>();
-		counts.put(appName, count);
-		scaleRequest.setCounts(counts);
 		Release release = this.skipperStateMachineService.scaleRelease(name, scaleRequest);
 		return this.releaseResourceAssembler.toModel(release);
 	}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.cloud.skipper.server.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.PackageDeleteException;
@@ -29,6 +31,7 @@ import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Manifest;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.RollbackRequest;
+import org.springframework.cloud.skipper.domain.ScaleRequest;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.controller.support.InfoResourceAssembler;
 import org.springframework.cloud.skipper.server.controller.support.ManifestResourceAssembler;
@@ -140,6 +143,25 @@ public class ReleaseController {
 	public EntityModel<Manifest> manifest(@PathVariable("name") String name,
 			@PathVariable("version") Integer version) {
 		return this.manifestResourceAssembler.toModel(this.releaseService.manifest(name, version));
+	}
+
+	@RequestMapping(path = "/scale/{name}", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	public EntityModel<Release> scale(@PathVariable("name") String name, @RequestBody ScaleRequest scaleRequest) {
+		Release release = this.skipperStateMachineService.scaleRelease(name, scaleRequest);
+		return this.releaseResourceAssembler.toModel(release);
+	}
+
+	@RequestMapping(path = "/scale/{name}/{appName}", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	public EntityModel<Release> scale(@PathVariable("name") String name, @PathVariable("appName") String appName,
+			int desiredCount) {
+		ScaleRequest scaleRequest = new ScaleRequest();
+		Map<String, Integer> counts = new HashMap<>();
+		counts.put(appName, desiredCount);
+		scaleRequest.setCounts(counts);
+		Release release = this.skipperStateMachineService.scaleRelease(name, scaleRequest);
+		return this.releaseResourceAssembler.toModel(release);
 	}
 
 	@RequestMapping(path = "/upgrade", method = RequestMethod.POST)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.ScaleRequest;
 
 /**
  * Manages the lifecycle of a releases.
@@ -93,4 +94,12 @@ public interface ReleaseManager {
 	 */
 	LogInfo getLog(Release release, String appName);
 
+	/**
+	 * Scale a release and return an original release.
+	 *
+	 * @param release
+	 * @param scaleRequest
+	 * @return the original release
+	 */
+	Release scale(Release release, ScaleRequest scaleRequest);
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ReleaseService.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.skipper.domain.Package;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
 import org.springframework.cloud.skipper.domain.PackageMetadata;
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.ScaleRequest;
 import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.cloud.skipper.server.deployer.ReleaseAnalysisReport;
 import org.springframework.cloud.skipper.server.deployer.ReleaseManager;
@@ -281,6 +282,14 @@ public class ReleaseService {
 		String kind = ManifestUtils.resolveKind(release.getManifest().getData());
 		ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);
 		return releaseManager.getLog(release, appName);
+	}
+
+	@Transactional
+	public Release scale(String releaseName, ScaleRequest scaleRequest) {
+		Release release = this.releaseRepository.findTopByNameOrderByVersionDesc(releaseName);
+		String kind = ManifestUtils.resolveKind(release.getManifest().getData());
+		ReleaseManager releaseManager = this.releaseManagerFactory.getReleaseManager(kind);
+		return releaseManager.scale(release, scaleRequest);
 	}
 
 	/**

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ResetVariablesAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ResetVariablesAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import org.springframework.cloud.skipper.domain.DeleteProperties;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.RollbackRequest;
+import org.springframework.cloud.skipper.domain.ScaleRequest;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
 import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
@@ -90,6 +91,13 @@ public class ResetVariablesAction implements Action<SkipperStates, SkipperEvents
 		if (deleteProperties != null) {
 			context.getExtendedState().getVariables().put(SkipperEventHeaders.RELEASE_DELETE_PROPERTIES,
 					deleteProperties);
+		}
+
+		// for scale
+		ScaleRequest scaleRequest = context.getMessageHeaders().get(SkipperEventHeaders.SCALE_REQUEST,
+				ScaleRequest.class);
+		if (scaleRequest != null) {
+			context.getExtendedState().getVariables().put(SkipperEventHeaders.SCALE_REQUEST, scaleRequest);
 		}
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ScaleScaleAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/ScaleScaleAction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.server.statemachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.ScaleRequest;
+import org.springframework.cloud.skipper.server.service.ReleaseService;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEventHeaders;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperEvents;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperStates;
+import org.springframework.cloud.skipper.server.statemachine.SkipperStateMachineService.SkipperVariables;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+import org.springframework.util.Assert;
+
+/**
+ * StateMachine {@link Action} handling scale with a {@link ReleaseService}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class ScaleScaleAction extends AbstractAction {
+
+	private static final Logger log = LoggerFactory.getLogger(DeleteDeleteAction.class);
+
+	private final ReleaseService releaseService;
+
+	/**
+	 * Instantiates a new scale scale action.
+	 *
+	 * @param releaseService the release service
+	 */
+	public ScaleScaleAction(ReleaseService releaseService) {
+		super();
+		Assert.notNull(releaseService, "'releaseService' must be set");
+		this.releaseService = releaseService;
+	}
+
+	@Override
+	protected void executeInternal(StateContext<SkipperStates, SkipperEvents> context) {
+		log.debug("Starting action " + context);
+		String releaseName = context.getMessageHeaders().get(SkipperEventHeaders.RELEASE_NAME, String.class);
+		log.info("About to scale {}", releaseName);
+		ScaleRequest scaleRequest = context.getExtendedState().get(SkipperEventHeaders.SCALE_REQUEST,
+				ScaleRequest.class);
+		Assert.notNull(scaleRequest, "'scaleRequest' not known to the system in extended state");
+		Release release = this.releaseService.scale(releaseName, scaleRequest);
+		context.getExtendedState().getVariables().put(SkipperVariables.RELEASE, release);
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ScaleRequest.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ScaleRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Janne Valkealahti
+ */
+public class ScaleRequest {
+
+	private Map<String, Integer> counts = new HashMap<>();
+
+	public void setCounts(Map<String, Integer> desiredCounts) {
+		this.counts = desiredCounts;
+	}
+
+	public Map<String, Integer> getCounts() {
+		return counts;
+	}
+}

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ScaleRequest.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ScaleRequest.java
@@ -25,8 +25,8 @@ public class ScaleRequest {
 
 	private Map<String, Integer> counts = new HashMap<>();
 
-	public void setCounts(Map<String, Integer> desiredCounts) {
-		this.counts = desiredCounts;
+	public void setCounts(Map<String, Integer> counts) {
+		this.counts = counts;
 	}
 
 	public Map<String, Integer> getCounts() {

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ScaleRequest.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ScaleRequest.java
@@ -15,21 +15,108 @@
  */
 package org.springframework.cloud.skipper.domain;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
+ * Payload in a scaling request.
+ *
  * @author Janne Valkealahti
  */
 public class ScaleRequest {
 
-	private Map<String, Integer> counts = new HashMap<>();
+	private List<ScaleRequestItem> scale = new ArrayList<>();
 
-	public void setCounts(Map<String, Integer> counts) {
-		this.counts = counts;
+	public ScaleRequest() {
 	}
 
-	public Map<String, Integer> getCounts() {
-		return counts;
+	public ScaleRequest(List<ScaleRequestItem> scale) {
+		if (scale != null) {
+			this.scale = scale;
+		}
+	}
+
+	public List<ScaleRequestItem> getScale() {
+		return scale;
+	}
+
+	public void setScale(List<ScaleRequestItem> scale) {
+		this.scale = scale;
+	}
+
+	/**
+	 * Create a {@code ScaleRequest} having one app with its count.
+	 *
+	 * @param name the app name
+	 * @param count the app count
+	 * @return the scale request
+	 */
+	public static ScaleRequest of(String name, Integer count) {
+		return new ScaleRequest(Arrays.asList(new ScaleRequestItem(name, count, null)));
+	}
+
+	/**
+	 * Create a {@code ScaleRequest} having one app with its count and properties.
+	 *
+	 * @param name the app name
+	 * @param count the app count
+	 * @param properties the app properties
+	 * @return the scale request
+	 */
+	public static ScaleRequest of(String name, Integer count, Map<String, String> properties) {
+		return new ScaleRequest(Arrays.asList(new ScaleRequestItem(name, count, properties)));
+	}
+
+	/**
+	 * As {@link ScaleRequest} can contain multiple requests for multiple app, this
+	 * class represents one of those.
+	 */
+	public static class ScaleRequestItem {
+
+		private String name;
+		private Integer count;
+		private Map<String, String> properties = new HashMap<>();
+
+		public ScaleRequestItem() {
+		}
+
+		public ScaleRequestItem(String name, Integer count) {
+			this(name, count, null);
+		}
+
+		public ScaleRequestItem(String name, Integer count, Map<String, String> properties) {
+			this.name = name;
+			this.count = count;
+			if (properties != null) {
+				this.properties = properties;
+			}
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Integer getCount() {
+			return count;
+		}
+
+		public void setCount(Integer count) {
+			this.count = count;
+		}
+
+		public Map<String, String> getProperties() {
+			return properties;
+		}
+
+		public void setProperties(Map<String, String> properties) {
+			this.properties = properties;
+		}
 	}
 }


### PR DESCRIPTION
- Basically adding a new state flow `SCALE` via statemachine
  which as a simple passthrough dispatches to deployer scale method.
- 2 new rest methods for single app and multi app scaling.
- Needed SkipperClient changes are left for #910
- Fixes #909

For now, you can test this i.e. with existing `ticktock` with this rest call:
```
POST http://localhost:7577/api/release/scale/ticktock
Content-Type: application/json

{
    "counts": {
        "time": "2",
        "log": "2"
    }
}
```