### PR TITLE
Remove hateoas from a SkipperClient

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,13 @@
             "mainClass": "org.springframework.cloud.skipper.server.app.SkipperServerApplication",
             "projectName": "spring-cloud-skipper-server",
             "args": "--spring.config.additional-location=etc/config/skipper-mysql.yml"
+        },
+        {
+            "type": "java",
+            "name": "SKIPPER SHELL",
+            "request": "launch",
+            "mainClass": "org.springframework.cloud.skipper.shell.ShellApplication",
+            "projectName": "spring-cloud-skipper-shell"
         }
     ]
 }

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.skipper.client;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.cloud.skipper.domain.AboutResource;
@@ -32,7 +33,6 @@ import org.springframework.cloud.skipper.domain.ScaleRequest;
 import org.springframework.cloud.skipper.domain.Template;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.domain.UploadRequest;
-import org.springframework.hateoas.CollectionModel;
 
 /**
  * The main client side interface to communicate with the Skipper Server.
@@ -64,7 +64,7 @@ public interface SkipperClient {
 	 * @param details boolean flag to fetch all the metadata
 	 * @return the package metadata with the projection set to summary
 	 */
-	CollectionModel<PackageMetadata> search(String name, boolean details);
+	Collection<PackageMetadata> search(String name, boolean details);
 
 	/**
 	 * Install the package
@@ -143,38 +143,21 @@ public interface SkipperClient {
 	 * @param releaseName the release name of the release to search for
 	 * @return the list of all releases by the given name
 	 */
-	CollectionModel<Release> history(String releaseName);
-
-	/**
-	 * Add a new Package Repository.
-	 *
-	 * @param name the name of the repository
-	 * @param rootUrl the root URL for the package
-	 * @param sourceUrl the source URL for the packages
-	 * @return the newly added Repository
-	 */
-	Repository addRepository(String name, String rootUrl, String sourceUrl);
-
-	/**
-	 * Delete a Package Repository.
-	 *
-	 * @param name the name of the repository
-	 */
-	void deleteRepository(String name);
+	Collection<Release> history(String releaseName);
 
 	/**
 	 * List Package Repositories.
 	 *
 	 * @return the list of package repositories
 	 */
-	CollectionModel<Repository> listRepositories();
+	Collection<Repository> listRepositories();
 
 	/**
 	 * List Platform Deployers
 	 *
 	 * @return the list of platforms deployers
 	 */
-	CollectionModel<Deployer> listDeployers();
+	Collection<Deployer> listDeployers();
 
 	/**
 	 * Return a status info of a last known release.

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/PackageCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/PackageCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,6 @@ import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.UploadRequest;
 import org.springframework.cloud.skipper.shell.command.support.TableUtils;
 import org.springframework.cloud.skipper.shell.command.support.YmlUtils;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.standard.ShellOption;
@@ -74,13 +74,13 @@ public class PackageCommands extends AbstractSkipperCommand {
 			@ShellOption(help = "wildcard expression to search for the package name", defaultValue = NULL) String name,
 			@ShellOption(help = "boolean to set for more detailed package metadata") boolean details)
 			throws Exception {
-		CollectionModel<PackageMetadata> resources = skipperClient.search(name, details);
+		Collection<PackageMetadata> resources = skipperClient.search(name, details);
 		if (!details) {
 			LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 			headers.put("name", "Name");
 			headers.put("version", "Version");
 			headers.put("description", "Description");
-			TableModel model = new BeanListTableModel<>(resources.getContent(), headers);
+			TableModel model = new BeanListTableModel<>(resources, headers);
 			TableBuilder tableBuilder = new TableBuilder(model);
 			TableUtils.applyStyle(tableBuilder);
 			return tableBuilder.build();
@@ -88,9 +88,9 @@ public class PackageCommands extends AbstractSkipperCommand {
 		else {
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-			PackageMetadata[] packageMetadataResources = resources.getContent().toArray(new PackageMetadata[0]);
+			PackageMetadata[] packageMetadataResources = resources.toArray(new PackageMetadata[0]);
 			List<Table> tableList = new ArrayList<>();
-			for (int i = 0; i < resources.getContent().size(); i++) {
+			for (int i = 0; i < resources.size(); i++) {
 				String json = mapper.writeValueAsString(packageMetadataResources[i]);
 				Map<String, String> map = mapper.readValue(json, new TypeReference<Map<String, String>>() {
 				});

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/PlatformCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/PlatformCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package org.springframework.cloud.skipper.shell.command;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.Deployer;
 import org.springframework.cloud.skipper.shell.command.support.TableUtils;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.table.BeanListTableModel;
@@ -45,12 +45,12 @@ public class PlatformCommands extends AbstractSkipperCommand {
 
 	@ShellMethod(key = "platform list", value = "List platforms")
 	public Table list() {
-		CollectionModel<Deployer> repositoryResources = this.skipperClient.listDeployers();
+		Collection<Deployer> repositoryResources = this.skipperClient.listDeployers();
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("name", "Name");
 		headers.put("type", "Type");
 		headers.put("description", "Description");
-		TableModel model = new BeanListTableModel<>(repositoryResources.getContent(), headers);
+		TableModel model = new BeanListTableModel<>(repositoryResources, headers);
 		TableBuilder tableBuilder = new TableBuilder(model);
 		return TableUtils.applyStyle(tableBuilder).build();
 	}

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/ReleaseCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -261,7 +261,7 @@ public class ReleaseCommands extends AbstractSkipperCommand {
 	public Table history(
 			@ShellOption(help = "wildcard expression to search by release name") @NotNull String releaseName) {
 		Collection<Release> releases;
-		releases = this.skipperClient.history(releaseName).getContent();
+		releases = this.skipperClient.history(releaseName);
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("version", "Version");
 		headers.put("info.lastDeployed", "Last updated");

--- a/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/RepositoryCommands.java
+++ b/spring-cloud-skipper-shell-commands/src/main/java/org/springframework/cloud/skipper/shell/command/RepositoryCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package org.springframework.cloud.skipper.shell.command;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.skipper.client.SkipperClient;
 import org.springframework.cloud.skipper.domain.Repository;
 import org.springframework.cloud.skipper.shell.command.support.TableUtils;
-import org.springframework.hateoas.CollectionModel;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.table.BeanListTableModel;
@@ -45,13 +45,13 @@ public class RepositoryCommands extends AbstractSkipperCommand {
 
 	@ShellMethod(key = "repo list", value = "List package repositories")
 	public Table list() {
-		CollectionModel<Repository> repositoryResources = this.skipperClient.listRepositories();
+		Collection<Repository> repositoryResources = this.skipperClient.listRepositories();
 		LinkedHashMap<String, Object> headers = new LinkedHashMap<>();
 		headers.put("name", "Name");
 		headers.put("url", "URL");
 		headers.put("local", "Local");
 		headers.put("repoOrder", "Order");
-		TableModel model = new BeanListTableModel<>(repositoryResources.getContent(), headers);
+		TableModel model = new BeanListTableModel<>(repositoryResources, headers);
 		TableBuilder tableBuilder = new TableBuilder(model);
 		return TableUtils.applyStyle(tableBuilder).build();
 	}


### PR DESCRIPTION
NOTE: There is a companion PR on a dataflow side for this https://github.com/spring-cloud/spring-cloud-dataflow/pull/3579

- As hateoas configuration currently doesn't work outside
  of a servlet environment(as shell is running), fixing
  this issue by removing hateoas.
- Basically removing hateoas wrappers and changing api
  signatures to contain plain java classes.
- As this is basically SkipperClient api polish, also
  remove add/remove methods for repository which were
  never used or supported anyway.
- Fixes #913