### PR TITLE
Add new api to request multiple stream statuses

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,6 +136,22 @@ public class DefaultSkipperClient implements SkipperClient {
 						typeReference,
 						uriVariables);
 		return resourceResponseEntity.getBody();
+	}
+
+	@Override
+	public Map<String, Info> statuses(String... releaseNames) {
+		ParameterizedTypeReference<Map<String, Info>> typeReference =
+			new ParameterizedTypeReference<Map<String, Info>>() { };
+
+		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(baseUri + "/release/statuses");
+		builder.queryParam("names", StringUtils.arrayToCommaDelimitedString(releaseNames));
+
+		ResponseEntity<Map<String, Info>> responseEntity =
+				restTemplate.exchange(builder.toUriString(),
+						HttpMethod.GET,
+						null,
+						typeReference);
+		return responseEntity.getBody();
 	}
 
 	@Override

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.CancelRequest;
 import org.springframework.cloud.skipper.domain.CancelResponse;
@@ -147,6 +148,22 @@ public class DefaultSkipperClient implements SkipperClient {
 		builder.queryParam("names", StringUtils.arrayToCommaDelimitedString(releaseNames));
 
 		ResponseEntity<Map<String, Info>> responseEntity =
+				restTemplate.exchange(builder.toUriString(),
+						HttpMethod.GET,
+						null,
+						typeReference);
+		return responseEntity.getBody();
+	}
+
+	@Override
+	public Map<String, Map<String, DeploymentState>> states(String... releaseNames) {
+		ParameterizedTypeReference<Map<String, Map<String, DeploymentState>>> typeReference =
+				new ParameterizedTypeReference<Map<String, Map<String, DeploymentState>>>() { };
+
+		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(baseUri + "/release/states");
+		builder.queryParam("names", StringUtils.arrayToCommaDelimitedString(releaseNames));
+
+		ResponseEntity<Map<String, Map<String, DeploymentState>>> responseEntity =
 				restTemplate.exchange(builder.toUriString(),
 						HttpMethod.GET,
 						null,

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.CancelRequest;
 import org.springframework.cloud.skipper.domain.CancelResponse;
@@ -175,6 +176,15 @@ public interface SkipperClient {
 	 * @return the status info of a releases
 	 */
 	Map<String, Info> statuses(String... releaseNames);
+
+
+	/**
+	 * Return the deployment state of a last known releases mapped back to release names.
+	 *
+	 * @param releaseNames the release names
+	 * @return the deployment state of a releases
+	 */
+	Map<String, Map<String, DeploymentState>> states(String... releaseNames);
 
 	/**
 	 * Return a status info of a release version.

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.cloud.skipper.client;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.cloud.skipper.domain.AboutResource;
 import org.springframework.cloud.skipper.domain.CancelRequest;
@@ -166,6 +167,14 @@ public interface SkipperClient {
 	 * @return the status info of a release
 	 */
 	Info status(String releaseName);
+
+	/**
+	 * Return a status info of a last known releases mapped back to release names.
+	 *
+	 * @param releaseNames the release names
+	 * @return the status info of a releases
+	 */
+	Map<String, Info> statuses(String... releaseNames);
 
 	/**
 	 * Return a status info of a release version.

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -29,6 +29,7 @@ import org.cloudfoundry.operations.applications.PushApplicationManifestRequest;
 import org.cloudfoundry.operations.applications.ScaleApplicationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
@@ -157,6 +158,12 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 		release.getInfo().getStatus().setPlatformStatusAsAppStatusList(
 				Collections.singletonList(this.cfManifestApplicationDeployer.status(release)));
 		return release;
+	}
+
+	@Override
+	public Mono<Release> statusReactive(Release release) {
+		// TODO: should convert to full reactive chain
+		return Mono.defer(() -> Mono.just(status(release)));
 	}
 
 	public Release delete(Release release) {

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -161,7 +161,7 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 		return release;
 	}
 
-	public Map<String, Map<String, DeploymentState>> deploymentState(List<Release> releases) {
+	public Mono<Map<String, Map<String, DeploymentState>>> deploymentState(List<Release> releases) {
 		//todo:
 		return null;
 	}

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.ScaleRequest;
@@ -158,6 +159,11 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 		release.getInfo().getStatus().setPlatformStatusAsAppStatusList(
 				Collections.singletonList(this.cfManifestApplicationDeployer.status(release)));
 		return release;
+	}
+
+	public Map<String, Map<String, DeploymentState>> deploymentState(List<Release> releases) {
+		//todo:
+		return null;
 	}
 
 	@Override

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -22,6 +22,14 @@
 			<version>2.4.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor.addons</groupId>
+			<artifactId>reactor-extra</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
 		</dependency>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -26,10 +26,6 @@
 			<artifactId>caffeine</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>io.projectreactor.addons</groupId>
-			<artifactId>reactor-extra</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
 		</dependency>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
@@ -114,6 +115,12 @@ public class ReleaseController {
 	@ResponseStatus(HttpStatus.OK)
 	public Mono<Map<String, Info>> statuses(@RequestParam("names") String[] names) {
 		return this.releaseService.statusReactive(names);
+	}
+
+	@RequestMapping(path = "/states", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public Map<String, Map<String, DeploymentState>> states(@RequestParam("names") String[] names) {
+		return this.releaseService.states(names);
 	}
 
 	@RequestMapping(path = "/status/{name}", method = RequestMethod.GET)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 package org.springframework.cloud.skipper.server.controller;
 
 import java.util.List;
+import java.util.Map;
+
+import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.skipper.PackageDeleteException;
@@ -47,6 +50,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -105,6 +109,12 @@ public class ReleaseController {
 	}
 
 	// Release commands
+
+	@RequestMapping(path = "/statuses", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public Mono<Map<String, Info>> statuses(@RequestParam("names") String[] names) {
+		return this.releaseService.statusReactive(names);
+	}
 
 	@RequestMapping(path = "/status/{name}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -119,7 +119,7 @@ public class ReleaseController {
 
 	@RequestMapping(path = "/states", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	public Map<String, Map<String, DeploymentState>> states(@RequestParam("names") String[] names) {
+	public Mono<Map<String, Map<String, DeploymentState>>> states(@RequestParam("names") String[] names) {
 		return this.releaseService.states(names);
 	}
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
@@ -257,53 +258,73 @@ public class DefaultReleaseManager implements ReleaseManager {
 		deploymentPropertiesMap.put(SPRING_CLOUD_DEPLOYER_COUNT, appsCount);
 	}
 
-	public Map<String, Map<String, DeploymentState>> deploymentState(List<Release> releases) {
-		Map<String, DeploymentState> deploymentIdsMap = new HashMap<>();
-		Map<AppDeployer, List<String>> appDeployerDeploymentIds = new HashMap<>();
-		Map<String, List<String>> releaseDeploymentIds = new HashMap<>();
-		for (Release release: releases) {
-			List<String> deploymentIds = null;
-			if (!release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
-				AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
-						.getAppDeployer();
-				AppDeployerData appDeployerData = this.appDeployerDataRepository
-						.findByReleaseNameAndReleaseVersion(release.getName(), release.getVersion());
-				if (appDeployerData == null) {
-					logger.warn(String.format("Could not get status for release %s-v%s.  No app deployer data found.",
-							release.getName(), release.getVersion()));
-				}
-				deploymentIds = appDeployerData.getDeploymentIds();
-				if (appDeployerDeploymentIds.containsKey(appDeployer)) {
-					appDeployerDeploymentIds.get(appDeployer).addAll(deploymentIds);
-				}
-				else {
-					appDeployerDeploymentIds.put(appDeployer, new ArrayList(deploymentIds));
-				}
-				releaseDeploymentIds.put(release.getName(), new ArrayList(deploymentIds));
-			}
-		}
-		for (Map.Entry<AppDeployer, List<String>> entry : appDeployerDeploymentIds.entrySet()) {
-			AppDeployer appDeployerToUse = entry.getKey();
-			if (appDeployerToUse instanceof MultiStateAppDeployer) {
-				//todo: make use of the cache
-				deploymentIdsMap.putAll(((MultiStateAppDeployer) appDeployerToUse)
-						.states(entry.getValue().toArray(new String[0])));
-			}
-			else {
-				for (String deploymentId : entry.getValue()) {
-					deploymentIdsMap.put(deploymentId, appDeployerToUse.status(deploymentId).getState());
+	public Mono<Map<String, Map<String, DeploymentState>>> deploymentState(List<Release> releases) {
+
+		Mono<Tuple2<Map<AppDeployer, List<String>>, Map<String, List<String>>>> deploymentIdTuple = Mono.defer(() -> {
+			Map<AppDeployer, List<String>> appDeployerDeploymentIds = new HashMap<>();
+			Map<String, List<String>> releaseDeploymentIds = new HashMap<>();
+			for (Release release: releases) {
+				List<String> deploymentIds = null;
+				if (!release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
+					AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
+							.getAppDeployer();
+					AppDeployerData appDeployerData = this.appDeployerDataRepository
+							.findByReleaseNameAndReleaseVersion(release.getName(), release.getVersion());
+					if (appDeployerData == null) {
+						logger.warn(String.format("Could not get status for release %s-v%s.  No app deployer data found.",
+								release.getName(), release.getVersion()));
+					}
+					deploymentIds = appDeployerData.getDeploymentIds();
+					if (appDeployerDeploymentIds.containsKey(appDeployer)) {
+						appDeployerDeploymentIds.get(appDeployer).addAll(deploymentIds);
+					}
+					else {
+						appDeployerDeploymentIds.put(appDeployer, new ArrayList<>(deploymentIds));
+					}
+					releaseDeploymentIds.put(release.getName(), new ArrayList<>(deploymentIds));
 				}
 			}
-		}
-		Map<String, Map<String, DeploymentState>> releasesDeploymentStates = new HashMap<>();
-		for (Release release: releases) {
-			Map<String, DeploymentState> deploymentStates = new HashMap<>();
-			for (String deploymentId: releaseDeploymentIds.get(release.getName())) {
-				deploymentStates.put(deploymentId, deploymentIdsMap.get(deploymentId));
+			return Mono.zip(Mono.just(appDeployerDeploymentIds), Mono.just(releaseDeploymentIds));
+		});
+
+
+		Mono<Tuple2<Map<String, DeploymentState>, Map<String, List<String>>>> deploymentStateTuple = deploymentIdTuple.flatMap(t -> {
+
+			Mono<Map<String, DeploymentState>> deploymentStates = Flux.fromIterable(t.getT1().entrySet())
+					.flatMap(e -> {
+						Mono<Map<String, DeploymentState>> mono2 = Flux.fromIterable(e.getValue())
+								.flatMap(ee -> {
+									return e.getKey().statusReactive(ee);
+								})
+								.collectMap(eee -> eee.getDeploymentId(), eee -> eee.getState())
+								;
+						Mono<Map<String, DeploymentState>> cachedEntry = cache.get(CacheKey.of(e.getValue(), e.getKey()));
+						return cachedEntry.switchIfEmpty(mono2);
+					})
+					.reduce(new HashMap<String, DeploymentState>(), (a, tt) -> {
+						a.putAll(tt);
+						return a;
+					});
+			return Mono.zip(deploymentStates, Mono.just(t.getT2()));
+
+		});
+
+		Mono<Map<String, Map<String, DeploymentState>>> releasesDeploymentStatesMap = deploymentStateTuple.map(m -> {
+			Map<String, DeploymentState> deploymentIdsMap = m.getT1();
+			Map<String, List<String>> releaseDeploymentIds = m.getT2();
+			Map<String, Map<String, DeploymentState>> releasesDeploymentStates = new HashMap<>();
+			for (Release release: releases) {
+				Map<String, DeploymentState> deploymentStates = new HashMap<>();
+				if (releaseDeploymentIds.get(release.getName()) != null) {
+					for (String deploymentId: releaseDeploymentIds.get(release.getName())) {
+						deploymentStates.put(deploymentId, deploymentIdsMap.get(deploymentId));
+					}
+				}
+				releasesDeploymentStates.put(release.getName(), deploymentStates);
 			}
-			releasesDeploymentStates.put(release.getName(), deploymentStates);
-		}
-		return releasesDeploymentStates;
+			return releasesDeploymentStates;
+		});
+		return releasesDeploymentStatesMap;
 	}
 
 	public Mono<Release> statusReactive(Release release) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
@@ -54,6 +59,7 @@ import org.springframework.cloud.skipper.server.repository.map.DeployerRepositor
 import org.springframework.cloud.skipper.server.util.ArgumentSanitizer;
 import org.springframework.cloud.skipper.server.util.ConfigValueUtils;
 import org.springframework.cloud.skipper.server.util.ManifestUtils;
+import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
@@ -85,6 +91,19 @@ public class DefaultReleaseManager implements ReleaseManager {
 	private final AppDeploymentRequestFactory appDeploymentRequestFactory;
 
 	private final SpringCloudDeployerApplicationManifestReader applicationManifestReader;
+
+	private final LoadingCache<CacheKey, Mono<Map<String, DeploymentState>>> cache = Caffeine.newBuilder()
+			.expireAfterWrite(60, TimeUnit.SECONDS)
+			.build(k -> {
+				logger.debug("Building new deploymentStateMap mono");
+				if (k.getAppDeployer() instanceof MultiStateAppDeployer) {
+					MultiStateAppDeployer multiAppDeployer = (MultiStateAppDeployer) k.getAppDeployer();
+					return multiAppDeployer.statesReactive(k.getDeploymentIds().toArray(new String[0])).cache();
+				}
+				// it wasn't MultiStateAppDeployer so we just return empty
+				return Mono.empty();
+			});
+
 
 	public DefaultReleaseManager(ReleaseRepository releaseRepository,
 			AppDeployerDataRepository appDeployerDataRepository, DeployerRepository deployerRepository,
@@ -238,6 +257,70 @@ public class DefaultReleaseManager implements ReleaseManager {
 		deploymentPropertiesMap.put(SPRING_CLOUD_DEPLOYER_COUNT, appsCount);
 	}
 
+	public Mono<Release> statusReactive(Release release) {
+		return Mono.defer(() -> {
+			if (release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
+				return Mono.just(release);
+			}
+			AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
+					.getAppDeployer();
+			AppDeployerData appDeployerData = this.appDeployerDataRepository
+				.findByReleaseNameAndReleaseVersion(release.getName(), release.getVersion());
+			if (appDeployerData == null) {
+				logger.warn(String.format("Could not get status for release %s-v%s.  No app deployer data found.",
+					release.getName(), release.getVersion()));
+				return Mono.just(release);
+			}
+			List<String> deploymentIds = appDeployerData.getDeploymentIds();
+			logger.info("Getting status for {} using deploymentIds {}", release,
+					StringUtils.collectionToCommaDelimitedString(deploymentIds));
+
+			if (!deploymentIds.isEmpty()) {
+				Map<String, String> appNameDeploymentIdMap = appDeployerData.getDeploymentDataAsMap();
+				return Flux.fromIterable(appNameDeploymentIdMap.entrySet())
+					.flatMap(nameDeploymentId -> {
+						String deploymentId = nameDeploymentId.getValue();
+						return appDeployer.statusReactive(deploymentId);
+					})
+					.map(appStatus -> copyStatus(appStatus))
+					.flatMap(appStatus -> {
+						return Mono.zip(Mono.just(appStatus), cache.get(CacheKey.of(deploymentIds, appDeployer)));
+					})
+					.map(zip -> {
+						AppStatus appStatus = zip.getT1();
+						Map<String, DeploymentState> deploymentStateMap = zip.getT2();
+						Collection<AppInstanceStatus> instanceStatuses = appStatus.getInstances().values();
+						for (AppInstanceStatus instanceStatus : instanceStatuses) {
+								instanceStatus.getAttributes().put(SKIPPER_APPLICATION_NAME_ATTRIBUTE,
+										appStatus.getDeploymentId());
+								instanceStatus.getAttributes().put(SKIPPER_RELEASE_NAME_ATTRIBUTE, release.getName());
+								instanceStatus.getAttributes().put(SKIPPER_RELEASE_VERSION_ATTRIBUTE,
+										"" + release.getVersion());
+							}
+						if (deploymentStateMap != null) {
+							if (appStatus.getState().equals(DeploymentState.failed)
+									|| appStatus.getState().equals(DeploymentState.error)) {
+								// check if we have 'early' status computed via multiStateAppDeployer
+								String deploymentId = appStatus.getDeploymentId();
+								if (deploymentStateMap.containsKey(deploymentId)) {
+									appStatus = AppStatus.of(deploymentId)
+											.generalState(deploymentStateMap.get(deploymentId)).build();
+								}
+							}
+						}
+						return appStatus;
+					})
+					.collectList()
+					.map(appStatusList -> {
+						release.getInfo().getStatus().setPlatformStatusAsAppStatusList(appStatusList);
+						return release;
+					});
+			}
+			return Mono.just(release);
+		});
+	}
+
+
 	public Release status(Release release) {
 		if (release.getInfo().getStatus().getStatusCode().equals(StatusCode.DELETED)) {
 			return release;
@@ -262,18 +345,24 @@ public class DefaultReleaseManager implements ReleaseManager {
 			int deployedCount = 0;
 			int unknownCount = 0;
 			Map<String, DeploymentState> deploymentStateMap = new HashMap<>();
+			logger.debug("Used appDeployer {}", appDeployer);
 			if (appDeployer instanceof MultiStateAppDeployer) {
 				MultiStateAppDeployer multiStateAppDeployer = (MultiStateAppDeployer) appDeployer;
+				logger.debug("Calling multiStateAppDeployer states {}", deploymentIds);
 				deploymentStateMap = multiStateAppDeployer.states(StringUtils.toStringArray(deploymentIds));
+				logger.debug("Calling multiStateAppDeployer states end {}", deploymentIds);
 			}
 			List<AppStatus> appStatusList = new ArrayList<>();
 			// Key = app name, value = deploymentId
 			Map<String, String> appNameDeploymentIdMap = appDeployerData.getDeploymentDataAsMap();
+
 			for (Map.Entry<String, String> nameDeploymentId : appNameDeploymentIdMap.entrySet()) {
 				String appName = nameDeploymentId.getKey();
 				String deploymentId = nameDeploymentId.getValue();
 				// Copy the status to allow instance attribute mutation.
+				logger.debug("Calling appDeployer status {}", deploymentId);
 				AppStatus appStatus = copyStatus(appDeployer.status(deploymentId));
+				logger.debug("Calling appDeployer status end {} {}", deploymentId, appStatus.getState());
 				Collection<AppInstanceStatus> instanceStatuses = appStatus.getInstances().values();
 				for (AppInstanceStatus instanceStatus : instanceStatuses) {
 					instanceStatus.getAttributes().put(SKIPPER_APPLICATION_NAME_ATTRIBUTE, appName);
@@ -286,6 +375,7 @@ public class DefaultReleaseManager implements ReleaseManager {
 					if (deploymentStateMap.containsKey(deploymentId)) {
 						appStatus = AppStatus.of(deploymentId).generalState(deploymentStateMap.get(deploymentId))
 								.build();
+						logger.debug("Set from deploymentStateMap {} {}", deploymentId, appStatus.getState());
 					}
 				}
 				logger.debug("App Deployer for deploymentId {} gives status {}", deploymentId, appStatus);
@@ -440,6 +530,64 @@ public class DefaultReleaseManager implements ReleaseManager {
 		@Override
 		public Map<String, String> getAttributes() {
 			return this.attributes;
+		}
+	}
+
+	/**
+	 * Used as a cache key with Caffeine and actual key is a 'key'. Deployement ids
+	 * and app deployer is just used with this key class so that cache can build
+	 * entry as it need those two to create cf operation.
+	 */
+	private static class CacheKey {
+		private final List<String> deploymentIds;
+		private final AppDeployer appDeployer;
+		private final String key;
+
+		CacheKey(List<String> deploymentIds, AppDeployer appDeployer) {
+			Assert.notNull(deploymentIds, "'deploymentIds' cannot be null");
+			Assert.notNull(appDeployer, "'appDeployer' cannot be null");
+			this.deploymentIds = deploymentIds;
+			this.appDeployer = appDeployer;
+			List<String> keyList = new ArrayList<>(deploymentIds);
+			Collections.sort(keyList);
+			this.key = StringUtils.collectionToCommaDelimitedString(keyList);
+		}
+
+		static CacheKey of(List<String> deploymentIds, AppDeployer appDeployer) {
+			return new CacheKey(deploymentIds, appDeployer);
+		}
+
+		public List<String> getDeploymentIds() {
+			return deploymentIds;
+		}
+
+		public AppDeployer getAppDeployer() {
+			return appDeployer;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((key == null) ? 0 : key.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			CacheKey other = (CacheKey) obj;
+			if (key == null) {
+				if (other.key != null)
+					return false;
+			} else if (!key.equals(other.key))
+				return false;
+			return true;
 		}
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -17,9 +17,11 @@ package org.springframework.cloud.skipper.server.deployer;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import reactor.core.publisher.Mono;
 
+import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.ScaleRequest;
@@ -89,6 +91,8 @@ public interface ReleaseManager {
 	 * @return the updated release
 	 */
 	Mono<Release> statusReactive(Release release);
+
+	Map<String, Map<String, DeploymentState>> deploymentState(List<Release> releases);
 
 	/**
 	 * Get the logs of the applications inside the release.

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -92,7 +92,7 @@ public interface ReleaseManager {
 	 */
 	Mono<Release> statusReactive(Release release);
 
-	Map<String, Map<String, DeploymentState>> deploymentState(List<Release> releases);
+	Mono<Map<String, Map<String, DeploymentState>>> deploymentState(List<Release> releases);
 
 	/**
 	 * Get the logs of the applications inside the release.

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/ReleaseManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,12 @@ package org.springframework.cloud.skipper.server.deployer;
 import java.util.Collection;
 import java.util.List;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
 import org.springframework.cloud.skipper.domain.ScaleRequest;
+
 
 /**
  * Manages the lifecycle of a releases.
@@ -76,6 +79,16 @@ public interface ReleaseManager {
 	 * @return the updated release
 	 */
 	Release status(Release release);
+
+	/**
+	 * Get the status of the release, by querying the database. The
+	 * {@link org.springframework.cloud.skipper.server.service.ReleaseStateUpdateService} is
+	 * scheduled ot update the state in the database periodically.
+	 *
+	 * @param release the release to update state for
+	 * @return the updated release
+	 */
+	Mono<Release> statusReactive(Release release);
 
 	/**
 	 * Get the logs of the applications inside the release.

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/Status.java
@@ -98,7 +98,7 @@ public class Status extends NonVersionedAbstractEntity {
 		for (AppStatus appStatus : appStatusList) {
 			statusMsg.append("[" + appStatus.getDeploymentId() + "]");
 			if (appStatus.getInstances().isEmpty()) {
-				statusMsg.append(", State = [" + appStatus.getState() + "]");
+				statusMsg.append(", State = [" + appStatus.getState() + "]\n");
 			}
 			else {
 				statusMsg.append(", State = [");


### PR DESCRIPTION
- ReleaseController now has a new method /statuses
  which returns a map of statuses wrapped in a mono
  and subscription is then handled by framework itself.
- ReleaseManager has a new method to request status reactively
  with a Release.
- SkipperClient has a new statuses method for dataflow to request
  info for multiple releases at a same time.
- DefaultReleaseManager now tries to use reactive methods for statuses
  and doesn't a bit of caching so that we don't ddos our own server.
- ReleaseStatUpdateService now also uses reactive methods so that update
  is faster by not doing things sequentially. There's also a little fix
  to do update immediately when server starts(via initial polling flag).
- Fixes #940