### PR TITLE
Change MultiStateAppDeployer caching key

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
@@ -626,7 +626,7 @@ public class DefaultReleaseManager implements ReleaseManager {
 		public int hashCode() {
 			final int prime = 31;
 			int result = 1;
-			result = prime * result + ((key == null) ? 0 : key.hashCode());
+			result = prime * result + ((appDeployer == null) ? 0 : appDeployer.hashCode());
 			return result;
 		}
 
@@ -639,10 +639,10 @@ public class DefaultReleaseManager implements ReleaseManager {
 			if (getClass() != obj.getClass())
 				return false;
 			CacheKey other = (CacheKey) obj;
-			if (key == null) {
-				if (other.key != null)
+			if (appDeployer == null) {
+				if (other.appDeployer != null)
 					return false;
-			} else if (!key.equals(other.key))
+			} else if (!appDeployer.equals(other.appDeployer))
 				return false;
 			return true;
 		}


### PR DESCRIPTION
- In DefaultReleaseManager we used to cache states by requested deployment id's,
  for example `s0-log-v6,s0-time-v6` which would differ per stream. This was chosen
  because `MultiStateAppDeployer.statesReactive` takes this same list meaning it
  was only natural working cache key. However as `CloudFoundryAppDeployer` is only
  user of that interface and it simply requests everything from org/space totally
  disregarding used deployement id's, as a short term fix we can just use existing
  MultiStateAppDeployer as a cache key(basically objects hashkey aka same instance).