### PR TITLE
Avoid NPE in AppDeployerData

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeleteStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeleteStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.deployer.strategies;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +55,8 @@ public class DeleteStep {
 		AppDeployer appDeployer = this.deployerRepository.findByNameRequired(release.getPlatformName())
 				.getAppDeployer();
 
-		Map<String, String> appNamesAndDeploymentIds = existingAppDeployerData.getDeploymentDataAsMap();
+		Map<String, String> appNamesAndDeploymentIds = (existingAppDeployerData!= null) ?
+				existingAppDeployerData.getDeploymentDataAsMap() : Collections.EMPTY_MAP;
 
 		for (Map.Entry<String, String> appNameAndDeploymentId : appNamesAndDeploymentIds.entrySet()) {
 			if (applicationNamesToDelete.contains(appNameAndDeploymentId.getKey())) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeployAppStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/DeployAppStep.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.skipper.server.deployer.strategies;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +106,8 @@ public class DeployAppStep {
 		AppDeployerData existingAppDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(
 						existingRelease.getName(), existingRelease.getVersion());
-		Map<String, String> existingAppNamesAndDeploymentIds = existingAppDeployerData.getDeploymentDataAsMap();
+		Map<String, String> existingAppNamesAndDeploymentIds = (existingAppDeployerData != null) ?
+				existingAppDeployerData.getDeploymentDataAsMap() : Collections.EMPTY_MAP;
 
 		for (Map.Entry<String, String> existingEntry : existingAppNamesAndDeploymentIds.entrySet()) {
 			String existingName = existingEntry.getKey();

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckStep.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/strategies/HealthCheckStep.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cloud.skipper.server.deployer.strategies;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -53,7 +54,8 @@ public class HealthCheckStep {
 		AppDeployerData replacingAppDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(
 						replacingRelease.getName(), replacingRelease.getVersion());
-		Map<String, String> appNamesAndDeploymentIds = replacingAppDeployerData.getDeploymentDataAsMap();
+		Map<String, String> appNamesAndDeploymentIds = (replacingAppDeployerData!= null) ?
+				replacingAppDeployerData.getDeploymentDataAsMap() : Collections.EMPTY_MAP;
 		AppDeployer appDeployer = this.deployerRepository
 				.findByNameRequired(replacingRelease.getPlatformName())
 				.getAppDeployer();

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/AppDeployerData.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/domain/AppDeployerData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.cloud.skipper.server.domain;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -86,7 +87,8 @@ public class AppDeployerData extends AbstractEntity {
 			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 			TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {
 			};
-			return mapper.readValue(this.deploymentData, typeRef);
+			return (this.deploymentData != null) ? mapper.readValue(this.deploymentData, typeRef) :
+					Collections.EMPTY_MAP;
 		}
 		catch (Exception e) {
 			throw new SkipperException("Could not parse appNameDeploymentIdMap JSON:" + this.deploymentData, e);


### PR DESCRIPTION
 - Though the `AppDeployerData` is expected to be non-null, we have seen some scenarios where NPEs are thrown when retrieving the AppDeployerData.
   Hence, added null check at all the places where `AppDeployerData` is used.

Resolves #957