### PR TITLE
Instrument metrics collection for Skipper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 		<ant-nodeps.version>1.8.1</ant-nodeps.version>
 		<antelopetasks.version>3.2.10</antelopetasks.version>
 		<build-helper-maven-plugin>1.9.1</build-helper-maven-plugin>
+		<prometheus-rsocket-spring.version>1.0.0</prometheus-rsocket-spring.version>
 	</properties>
 
 	<modules>
@@ -105,6 +106,11 @@
 				<version>${spring-cloud-deployer.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.micrometer.prometheus</groupId>
+				<artifactId>prometheus-rsocket-spring</artifactId>
+				<version>${prometheus-rsocket-spring.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -22,6 +22,22 @@
 			<version>2.6.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-wavefront</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-influx</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer.prometheus</groupId>
+			<artifactId>prometheus-rsocket-spring</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-common-flyway</artifactId>
 		</dependency>

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -8,11 +8,6 @@ management:
     roles: MANAGE
   context-path: /actuator
   metrics:
-    distribution:
-      # Enable percentile-based histogram for http requests
-      percentiles-histogram.http.server.requests: true
-      # Additional HTTP SLO histogram buckets
-      slo.http.server.requests: 100ms, 150ms, 250ms, 500ms, 1s
     tags:
       application: "@project.artifactId@"
       application.version: "@project.version@"
@@ -20,7 +15,8 @@ management:
       server:
         request:
           autotime:
-            enabled: true
+            enabled: true # true is default to Boot 2.3.2 at least.
+            percentiles-histogram: true
     export:
       influx:
         enabled: false

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -43,7 +43,8 @@ spring:
     properties:
       hibernate:
         id.new_generator_mappings: true
-        generate_statistics: true
+        # Statistics generation is required for publishing JPA micrometer metrics.
+        # generate_statistics: true
   cloud:
     skipper:
       server:

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -7,6 +7,29 @@ management:
   security:
     roles: MANAGE
   context-path: /actuator
+  metrics:
+    distribution:
+      # Enable percentile-based histogram for http requests
+      percentiles-histogram.http.server.requests: true
+      # Additional HTTP SLO histogram buckets
+      slo.http.server.requests: 100ms, 150ms, 250ms, 500ms, 1s
+    tags:
+      application: "@project.artifactId@"
+      application.version: "@project.version@"
+    web:
+      server:
+        request:
+          autotime:
+            enabled: true
+    export:
+      influx:
+        enabled: false
+      prometheus:
+        enabled: false
+        rsocket:
+          enabled: false
+      wavefront:
+        enabled: false
 server:
   port: 7577
 spring:
@@ -18,7 +41,9 @@ spring:
   jpa:
     generate-ddl: false
     properties:
-      hibernate.id.new_generator_mappings: true
+      hibernate:
+        id.new_generator_mappings: true
+        generate_statistics: true
   cloud:
     skipper:
       server:


### PR DESCRIPTION
  - Add prometheus, influx and wavefront metric registry pom dependencies.
  - Disable all metric registries by default. Set in spring-cloud-skipper-server-core/applicaiton.yml.
    To enable a metric registry one need to use the management.metrics.export.<registry>.enabled=true property.
  - Add two common metrics Tags: application and application.version containing the values of the project artifactId and the version.
  - Enable JPA/Hibernate metrics statistics: spring.jpa.properties.hibernate.generate_statistics=true
  - Enable percentiles histogram metrics for Sippers HTTP/REST requests.

Resolve #969