### PR TITLE
Fix status after failed update

### DIFF
--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -221,6 +221,11 @@
 			<artifactId>spring-restdocs-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -293,10 +293,8 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 
 	@Bean
 	public HandleHealthCheckStep healthCheckAndDeleteStep(ReleaseRepository releaseRepository,
-			AppDeployerDataRepository appDeployerDataRepository, DeleteStep deleteStep,
-			ReleaseManagerFactory releaseManagerFactory) {
-		return new HandleHealthCheckStep(releaseRepository, appDeployerDataRepository, deleteStep,
-				releaseManagerFactory);
+			AppDeployerDataRepository appDeployerDataRepository, DeleteStep deleteStep) {
+		return new HandleHealthCheckStep(releaseRepository, appDeployerDataRepository, deleteStep);
 	}
 
 	@Bean(name = SKIPPER_EXECUTOR)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
@@ -70,7 +70,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  */
-@SuppressWarnings({ "unchecked", "deprecation" })
+@SuppressWarnings({ "unchecked" })
 public class DefaultReleaseManager implements ReleaseManager {
 
 	public static final String SPRING_CLOUD_DEPLOYER_COUNT = "spring.cloud.deployer.count";
@@ -548,13 +548,14 @@ public class DefaultReleaseManager implements ReleaseManager {
 		AppDeployerData appDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(release.getName(), release.getVersion());
 		List<String> deploymentIds = (appDeployerData != null) ? appDeployerData.getDeploymentIds() : Collections.EMPTY_LIST;
+		logger.debug("DeploymentIds to undeploy {}", deploymentIds);
 		if (!deploymentIds.isEmpty()) {
 			for (String deploymentId : deploymentIds) {
 				try {
 					appDeployer.undeploy(deploymentId);
 				}
 				catch (Exception e) {
-					this.logger.error(String.format("Exception undeploying the application with the deploymentId %s. "
+					logger.error(String.format("Exception undeploying the application with the deploymentId %s. "
 							+ "Exception message: %s", deploymentId, e.getMessage()));
 				}
 			}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/jpa/ReleaseRepository.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/repository/jpa/ReleaseRepository.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.repository.jpa;
 import java.util.List;
 
 import org.springframework.cloud.skipper.domain.Release;
+import org.springframework.cloud.skipper.domain.StatusCode;
 import org.springframework.data.keyvalue.repository.KeyValueRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
@@ -65,6 +66,11 @@ public interface ReleaseRepository extends KeyValueRepository<Release, Long>, Re
 	@Transactional(readOnly = true)
 	@RestResource(exported = false)
 	Release findTopByNameOrderByVersionDesc(@Param("name") String name);
+
+	@Transactional(readOnly = true)
+	@RestResource(exported = false)
+	Release findTopByNameAndInfoStatusStatusCodeNotOrderByVersionDesc(@Param("name") String name,
+		@Param("statusCode") StatusCode statusCode);
 
 	@Transactional(readOnly = true)
 	@RestResource(exported = false)

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageMetadataService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/PackageMetadataService.java
@@ -103,6 +103,10 @@ public class PackageMetadataService implements ResourceLoaderAware {
 			// Only keep latest release per release name.
 			Map<String, Release> latestReleaseMap = new HashMap<>();
 			for (Release release : releasesFromLocalRepositories) {
+				// Skip failed releases
+				if (release.getInfo().getStatus().getStatusCode() == StatusCode.FAILED) {
+					continue;
+				}
 				if (!latestReleaseMap.containsKey(release.getName())) {
 					latestReleaseMap.put(release.getName(), release);
 				}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCheckTargetAppsAction.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/statemachine/UpgradeCheckTargetAppsAction.java
@@ -79,7 +79,7 @@ public class UpgradeCheckTargetAppsAction extends AbstractUpgradeStartAction {
 			// missing cutoff, indicate exceed
 			return true;
 		}
-		log.debug("Testing cutOffTime {} to now {}", cutOffTime, now);
+		log.debug("Testing cutOffTime {} to now {} diff {}", cutOffTime, now, cutOffTime - now);
 		return now > cutOffTime;
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
@@ -156,8 +156,14 @@ public abstract class AbstractIntegrationTest extends AbstractAssertReleaseDeplo
 	}
 
 	protected Release upgrade(UpgradeRequest upgradeRequest) throws InterruptedException {
+		return upgrade(upgradeRequest, true);
+	}
+
+	protected Release upgrade(UpgradeRequest upgradeRequest, boolean doAssert) throws InterruptedException {
 		Release release = skipperStateMachineService.upgradeRelease(upgradeRequest);
-		assertReleaseIsDeployedSuccessfully(release.getName(), release.getVersion());
+		if (doAssert) {
+			assertReleaseIsDeployedSuccessfully(release.getName(), release.getVersion());
+		}
 		return release;
 	}
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ServerDependencies.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ServerDependencies.java
@@ -274,10 +274,8 @@ public class ServerDependencies implements AsyncConfigurer {
 
 	@Bean
 	public HandleHealthCheckStep healthCheckAndDeleteStep(ReleaseRepository releaseRepository,
-			AppDeployerDataRepository appDeployerDataRepository, DeleteStep deleteStep,
-			ReleaseManagerFactory releaseManagerFactory) {
-		return new HandleHealthCheckStep(releaseRepository, appDeployerDataRepository, deleteStep,
-				releaseManagerFactory);
+			AppDeployerDataRepository appDeployerDataRepository, DeleteStep deleteStep) {
+		return new HandleHealthCheckStep(releaseRepository, appDeployerDataRepository, deleteStep);
 	}
 
 	@Bean(name = SkipperServerConfiguration.SKIPPER_EXECUTOR)

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/deployer/metadata/DeployerConfigurationMetadataResolverTests.java
@@ -40,7 +40,7 @@ public class DeployerConfigurationMetadataResolverTests {
 							skipperServerProperties.getDeployerProperties());
 					resolver.setApplicationContext(context);
 				List<ConfigurationMetadataProperty> data = resolver.resolve();
-				assertThat(data.size()).isEqualTo(14);
+				assertThat(data.size()).isEqualTo(16);
 			});
 	}
 
@@ -56,7 +56,7 @@ public class DeployerConfigurationMetadataResolverTests {
 							skipperServerProperties.getDeployerProperties());
 					resolver.setApplicationContext(context);
 				List<ConfigurationMetadataProperty> data = resolver.resolve();
-				assertThat(data.size()).isEqualTo(12);
+				assertThat(data.size()).isEqualTo(14);
 			});
 	}
 
@@ -72,7 +72,7 @@ public class DeployerConfigurationMetadataResolverTests {
 							skipperServerProperties.getDeployerProperties());
 					resolver.setApplicationContext(context);
 				List<ConfigurationMetadataProperty> data = resolver.resolve();
-				assertThat(data.size()).isEqualTo(13);
+				assertThat(data.size()).isEqualTo(15);
 			});
 	}
 

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/repository/ReleaseRepositoryTests.java
@@ -370,7 +370,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 			assertThat(e.getMessage())
 					.contains("Can not delete Package Metadata [package2:1.0.1] in Repository [local]")
 					.contains("Not all releases of this package have the status DELETED.")
-					.contains("Active Releases [stableB,multipleRevisions1,multipleRevisions2,multipleRevisions3]");
+					.contains("Active Releases [multipleRevisions2,multipleRevisions3]");
 
 		}
 
@@ -386,7 +386,7 @@ public class ReleaseRepositoryTests extends AbstractIntegrationTest {
 			assertThat(e.getMessage())
 					.contains("Can not delete Package Metadata [package2:1.0.1] in Repository [local]")
 					.contains("Not all releases of this package have the status DELETED.")
-					.contains("Active Releases [multipleRevisions1,multipleRevisions2,multipleRevisions3]");
+					.contains("Active Releases [multipleRevisions2,multipleRevisions3]");
 
 		}
 	}


### PR DESCRIPTION
- Previously with failed update whole replacing release were
  deleted which wrongly delete app which weren't modified. Now
  simply deleting changed apps. (HandleHealthCheckStep)
- When checking health, check all apps in an replacing release
  instead of marking release healthy if one return true. (HealthCheckStep)
- Polish and add more debug.
- Now that failed update works correctly and after that we can
  again deploy stream again, one thing is left to another issue which
  is an annoying thing that stream is still showing failed as last
  status in a history.
- Fixes #966
- Fixes #964


To test, start skipper with 100s timeout as it defaults to 300s

```
--spring.cloud.skipper.server.strategies.healthcheck.timeout-in-millis=100000
```

Do deploy and fail `time` with update by using wrong probe path:
```
dataflow:>app import --uri https://dataflow.spring.io/rabbitmq-maven-latest
dataflow:>stream create --name s1 --definition "time|log"

dataflow:>stream deploy --name s1 --properties "app.log.server.port=8082,app.time.server.port=8081,deployer.log.local.startup-probe.path=/actuator/health,deployer.time.local.startup-probe.path=/actuator/health"

dataflow:>stream update --name s1 --properties "app.time.server.port=8083,deployer.time.local.startup-probe.path=/actuator/fake"
```

After deploy:
```
skipper:>release history --release-name s1
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│  Description   ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════╣
║1      │Mon Aug 24 13:05:42 BST 2020│DEPLOYED│s1          │1.0.0          │Install complete║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════╝

skipper:>release status --release-name s1
╔═══════════════╤═════════════════════════════════════════════════╗
║Last Deployed  │Mon Aug 24 13:05:42 BST 2020                     ║
║Status         │DEPLOYED                                         ║
║Platform Status│All applications have been successfully deployed.║
║               │[s1.log-v1], State = [s1.log-v1-0=deployed]      ║
║               │[s1.time-v1], State = [s1.time-v1-0=deployed]    ║
╚═══════════════╧═════════════════════════════════════════════════╝

skipper:>release list
╔════╤═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤═════════════╤═════════════════════════════════════════════╗
║Name│Version│        Last updated        │ Status │Package Name│Package Version│Platform Name│               Platform Status               ║
╠════╪═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪═════════════╪═════════════════════════════════════════════╣
║s1  │1      │Mon Aug 24 13:05:42 BST 2020│DEPLOYED│s1          │1.0.0          │default      │[s1.log-v1], State = [s1.log-v1-0=deployed]  ║
║    │       │                            │        │            │               │             │[s1.time-v1], State = [s1.time-v1-0=deployed]║
╚════╧═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧═════════════╧═════════════════════════════════════════════╝

$ ps -ef|grep java|grep rabbit
jvalkea+  5966  5459 36 13:05 ?        00:00:36 /usr/lib/jvm/java-8-oracle/jre/bin/java -jar /home/jvalkealahti/.m2/repository/org/springframework/cloud/stream/app/time-source-rabbit/2.1.3.RELEASE/time-source-rabbit-2.1.3.RELEASE.jar
jvalkea+  5979  5459 38 13:05 ?        00:00:37 /usr/lib/jvm/java-8-oracle/jre/bin/java -jar /home/jvalkealahti/.m2/repository/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.4.RELEASE/log-sink-rabbit-2.1.4.RELEASE.jar
```

During update you see:
```
$ ps -ef|grep java|grep rabbit
jvalkea+  5966  5459 36 13:05 ?        00:00:36 /usr/lib/jvm/java-8-oracle/jre/bin/java -jar /home/jvalkealahti/.m2/repository/org/springframework/cloud/stream/app/time-source-rabbit/2.1.3.RELEASE/time-source-rabbit-2.1.3.RELEASE.jar
jvalkea+  5979  5459 38 13:05 ?        00:00:37 /usr/lib/jvm/java-8-oracle/jre/bin/java -jar /home/jvalkealahti/.m2/repository/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.4.RELEASE/log-sink-rabbit-2.1.4.RELEASE.jar
jvalkea+  6312  5459 99 13:07 ?        00:00:23 /usr/lib/jvm/java-8-oracle/jre/bin/java -jar /home/jvalkealahti/.m2/repository/org/springframework/cloud/stream/app/time-source-rabbit/2.1.3.RELEASE/time-source-rabbit-2.1.3.RELEASE.jar
```

After failed update:

```
skipper:>release history --release-name s1
╔═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤════════════════════════════════════════════════════════════════════╗
║Version│        Last updated        │ Status │Package Name│Package Version│                            Description                             ║
╠═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪════════════════════════════════════════════════════════════════════╣
║2      │Mon Aug 24 13:07:14 BST 2020│FAILED  │s1          │1.0.0          │Did not detect apps in replacing release as healthy after 100000 ms.║
║1      │Mon Aug 24 13:05:42 BST 2020│DEPLOYED│s1          │1.0.0          │Install complete                                                    ║
╚═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧════════════════════════════════════════════════════════════════════╝

skipper:>release status --release-name s1
╔═══════════════╤═══════════════════════════════════════════╗
║Last Deployed  │Mon Aug 24 13:07:14 BST 2020               ║
║Status         │FAILED                                     ║
║Platform Status│The applications are being deployed.       ║
║               │[s1.log-v1], State = [s1.log-v1-0=deployed]║
║               │[s1.time-v2], State = [unknown]            ║
╚═══════════════╧═══════════════════════════════════════════╝

skipper:>release list
╔════╤═══════╤════════════════════════════╤════════╤════════════╤═══════════════╤═════════════╤═════════════════════════════════════════════╗
║Name│Version│        Last updated        │ Status │Package Name│Package Version│Platform Name│               Platform Status               ║
╠════╪═══════╪════════════════════════════╪════════╪════════════╪═══════════════╪═════════════╪═════════════════════════════════════════════╣
║s1  │1      │Mon Aug 24 13:05:42 BST 2020│DEPLOYED│s1          │1.0.0          │default      │[s1.log-v1], State = [s1.log-v1-0=deployed]  ║
║    │       │                            │        │            │               │             │[s1.time-v1], State = [s1.time-v1-0=deployed]║
║s1  │2      │Mon Aug 24 13:07:14 BST 2020│FAILED  │s1          │1.0.0          │default      │[s1.log-v1], State = [s1.log-v1-0=deployed]  ║
║    │       │                            │        │            │               │             │[s1.time-v2], State = [unknown]              ║
╚════╧═══════╧════════════════════════════╧════════╧════════════╧═══════════════╧═════════════╧═════════════════════════════════════════════╝

$ ps -ef|grep java|grep rabbit
jvalkea+  5966  5459 36 13:05 ?        00:00:36 /usr/lib/jvm/java-8-oracle/jre/bin/java -jar /home/jvalkealahti/.m2/repository/org/springframework/cloud/stream/app/time-source-rabbit/2.1.3.RELEASE/time-source-rabbit-2.1.3.RELEASE.jar
jvalkea+  5979  5459 38 13:05 ?        00:00:37 /usr/lib/jvm/java-8-oracle/jre/bin/java -jar /home/jvalkealahti/.m2/repository/org/springframework/cloud/stream/app/log-sink-rabbit/2.1.4.RELEASE/log-sink-rabbit-2.1.4.RELEASE.jar

```