### PR TITLE
Add a service metrics tag, for Boot WF integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<ant-nodeps.version>1.8.1</ant-nodeps.version>
 		<antelopetasks.version>3.2.10</antelopetasks.version>
 		<build-helper-maven-plugin>1.9.1</build-helper-maven-plugin>
-		<prometheus-rsocket-spring.version>1.0.0</prometheus-rsocket-spring.version>
+		<prometheus-rsocket-spring.version>1.2.1</prometheus-rsocket-spring.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -11,6 +11,7 @@ management:
     tags:
       application: "@project.artifactId@"
       application.version: "@project.version@"
+      service: "skipper server"
     web:
       server:
         request:


### PR DESCRIPTION
 - Add additional 'service' tag with fixed value to allow showing the Skipper metrics in the Spring Boot WF tile: https://vmware.wavefront.com/integration/springboot
 - Update the Prometheus RSocket Spring to 1.2.1

 Part of https://github.com/spring-cloud/spring-cloud-dataflow/issues/3965