### PR TITLE
Fix k8s config starter

### DIFF
--- a/spring-cloud-skipper-platform-kubernetes/pom.xml
+++ b/spring-cloud-skipper-platform-kubernetes/pom.xml
@@ -26,12 +26,12 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+			<artifactId>spring-cloud-starter-kubernetes-fabric8-config</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
- Change from spring-cloud-starter-kubernetes-config
  to spring-cloud-starter-kubernetes-fabric8-config.
- Add spring-context-support as issue
  spring-cloud/spring-cloud-commons#878
- Fixes #979