### PR TITLE
Use ${spring-security-oauth2.version} uniformly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 			<dependency>
 				<groupId>org.springframework.security.oauth.boot</groupId>
 				<artifactId>spring-security-oauth2-autoconfigure</artifactId>
-				<version>${spring-security-oauth2-autoconfigure.version}</version>
+				<version>${spring-security-oauth2.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
The property `${spring-security-oauth2-autoconfigure.version}` is undefined either in this POM or its ancestry, making this dependency management dependency unusable I think.

I suppose it would be useful to align the version of `spring-security-oauth2-autoconfigure` to any other module in `spring-security-oauth2`, so rather than defining another property just used the existing one.