### PR TITLE
Fix changes in cloud 2020.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
 		<spring-cloud-deployer-local.version>2.6.0-SNAPSHOT</spring-cloud-deployer-local.version>
 		<spring-cloud-deployer-cloudfoundry.version>2.6.0-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
 
-		<kubernetes-client.version>4.10.2</kubernetes-client.version>
 		<spring-cloud-deployer-kubernetes.version>2.6.0-SNAPSHOT</spring-cloud-deployer-kubernetes.version>
 
 		<zeroturnaround.version>1.13</zeroturnaround.version>
@@ -163,11 +162,6 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-skipper-platform-kubernetes</artifactId>
 				<version>2.7.0-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>io.fabric8</groupId>
-				<artifactId>kubernetes-client</artifactId>
-				<version>${kubernetes-client.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.pivotal.cfenv</groupId>

--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -50,10 +50,6 @@
 			<artifactId>HikariCP</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
@@ -168,14 +164,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-resource-support</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.pivotal.spring.cloud</groupId>
-			<artifactId>spring-cloud-services-starter-config-client</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.pivotal.cfenv</groupId>

--- a/spring-cloud-skipper-server/pom.xml
+++ b/spring-cloud-skipper-server/pom.xml
@@ -42,6 +42,10 @@
 			<artifactId>spring-cloud-starter-config</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.pivotal.spring.cloud</groupId>
+			<artifactId>spring-cloud-services-starter-config-client</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
- Remove dep handling of fabric8
- Move config-client starters from core packages into
  server module. This fixes testing issues and let
  those runtime deps to be in fatjars.
- Fixes #992
- Fixes #993