### PR TITLE
Fix Skipper exception handling on upgrade

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientResponseErrorHandler.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClientResponseErrorHandler.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.ReleaseUpgradeException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.Assert;
@@ -72,6 +73,9 @@ public class SkipperClientResponseErrorHandler extends DefaultResponseErrorHandl
 		else if (ObjectUtils.nullSafeEquals(exceptionClazz, PackageDeleteException.class.getName())) {
 			handlePackageDeleteException(map);
 		}
+		else if (ObjectUtils.nullSafeEquals(exceptionClazz, ReleaseUpgradeException.class.getName())) {
+			handleReleaseUpgradeException(map);
+		}
 		else if (ObjectUtils.nullSafeEquals(exceptionClazz, SkipperException.class.getName())) {
 			handleSkipperException(map);
 		}
@@ -97,6 +101,11 @@ public class SkipperClientResponseErrorHandler extends DefaultResponseErrorHandl
 				throw new ReleaseNotFoundException(releaseName);
 			}
 		}
+	}
+
+	private void handleReleaseUpgradeException(Map<String, String> map) {
+		String message = map.get("message");
+		throw new ReleaseUpgradeException(StringUtils.hasText(message) ? message : "");
 	}
 
 	private void handlePackageDeleteException(Map<String, String> map) {

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/ReleaseController.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
+import org.springframework.cloud.skipper.ReleaseUpgradeException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.CancelRequest;
 import org.springframework.cloud.skipper.domain.CancelResponse;
@@ -242,6 +243,12 @@ public class ReleaseController {
 	@ResponseStatus(value = HttpStatus.CONFLICT, reason = "Package deletion error")
 	@ExceptionHandler(PackageDeleteException.class)
 	public void handlePackageDeleteException() {
+		// needed for server not to log 500 errors
+	}
+
+	@ResponseStatus(value = HttpStatus.CONFLICT, reason = "Release upgrade exception")
+	@ExceptionHandler(ReleaseUpgradeException.class)
+	public void handleReleaseUpgradeException() {
 		// needed for server not to log 500 errors
 	}
 

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperErrorAttributes.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/controller/SkipperErrorAttributes.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.skipper.server.controller;
 import java.util.Map;
 
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/deployer/DefaultReleaseManager.java
@@ -40,6 +40,7 @@ import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.deployer.spi.app.MultiStateAppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
+import org.springframework.cloud.skipper.ReleaseUpgradeException;
 import org.springframework.cloud.skipper.SkipperException;
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Manifest;
@@ -187,8 +188,7 @@ public class DefaultReleaseManager implements ReleaseManager {
 				.analyze(existingRelease, replacingRelease, isForceUpdate, appNamesToUpgrade);
 		List<String> applicationNamesToUpgrade = releaseAnalysisReport.getApplicationNamesToUpgrade();
 		if (releaseAnalysisReport.getReleaseDifference().areEqual() && !isForceUpdate) {
-			throw new SkipperException(
-					"Package to upgrade has no difference than existing deployed/deleted package. Not upgrading.");
+			throw new ReleaseUpgradeException("Package to upgrade has no difference than existing deployed/deleted package. Not upgrading.");
 		}
 		AppDeployerData existingAppDeployerData = this.appDeployerDataRepository
 				.findByReleaseNameAndReleaseVersionRequired(

--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -29,6 +29,8 @@ management:
         enabled: false
 server:
   port: 7577
+  error:
+    include-message: always
 spring:
   main:
     banner-mode: "off"

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/ReleaseUpgradeException.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/ReleaseUpgradeException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.skipper;
+
+/**
+ * Thrown if an attempt to upgrade a release encounters an issue.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class ReleaseUpgradeException extends SkipperException {
+
+	public ReleaseUpgradeException(String message) {
+		super(message);
+	}
+
+	public ReleaseUpgradeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}


### PR DESCRIPTION
 - Fix server error message to be included by setting explicit property
 - Add ReleaseUpgradeException to handle the exceptions thrown when performing the release upgrade
 - Add test

Resolves #997