### PR TITLE
refactor: SLF4J logging statements shouldn't start with `String.format`.

### DIFF
--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryManifestApplicationDeployer.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryManifestApplicationDeployer.java
@@ -196,8 +196,7 @@ public class CloudFoundryManifestApplicationDeployer {
 			appStatus = getStatus(applicationName, release.getPlatformName())
 					.doOnSuccess(v -> logger.info("Successfully computed status [{}] for {}", v,
 							applicationName))
-					.doOnError(e -> logger.error(
-							String.format("Failed to compute status for %s", applicationName)))
+					.doOnError(e -> logger.error("Failed to compute status for {}", applicationName))
 					.block();
 		}
 		catch (Exception timeoutDueToBlock) {

--- a/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
+++ b/spring-cloud-skipper-platform-cloudfoundry/src/main/java/org/springframework/cloud/skipper/deployer/cloudfoundry/CloudFoundryReleaseManager.java
@@ -121,7 +121,7 @@ public class CloudFoundryReleaseManager implements ReleaseManager {
 						logger.warn("Unable to deploy application. It may have been destroyed before start completed: " + error.getMessage());
 					}
 					else {
-						logger.error(String.format("Failed to deploy %s", applicationName));
+						logger.error("Failed to deploy {}", applicationName);
 					}
 				})
 				.block();


### PR DESCRIPTION
Co-authored-by: Moderne <team@moderne.io>