### PR TITLE
Add proper mariadb support

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/SkipperFlywayConfigurationCustomizer.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/SkipperFlywayConfigurationCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
 import org.springframework.boot.jdbc.DatabaseDriver;
 import org.springframework.cloud.skipper.server.db.migration.db2.Db2BeforeBaseline;
-import org.springframework.cloud.skipper.server.db.migration.mysql.MysqlBeforeBaseline;
+import org.springframework.cloud.skipper.server.db.migration.mysql.MariadbBeforeBaseline;
 import org.springframework.cloud.skipper.server.db.migration.oracle.OracleBeforeBaseline;
 import org.springframework.cloud.skipper.server.db.migration.postgresql.PostgresBeforeBaseline;
 import org.springframework.cloud.skipper.server.db.migration.sqlserver.MsSqlBeforeBaseline;
@@ -52,8 +52,8 @@ public class SkipperFlywayConfigurationCustomizer implements FlywayConfiguration
 		if (databaseDriver == DatabaseDriver.POSTGRESQL) {
 			configuration.callbacks(new PostgresBeforeBaseline());
 		}
-		else if (databaseDriver == DatabaseDriver.MYSQL || databaseDriver == DatabaseDriver.MARIADB) {
-			configuration.callbacks(new MysqlBeforeBaseline());
+		else if (databaseDriver == DatabaseDriver.MARIADB) {
+			configuration.callbacks(new MariadbBeforeBaseline());
 		}
 		else if (databaseDriver == DatabaseDriver.SQLSERVER) {
 			configuration.callbacks(new MsSqlBeforeBaseline());

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/mysql/MariadbBeforeBaseline.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/mysql/MariadbBeforeBaseline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ import org.springframework.cloud.skipper.server.db.migration.AbstractBaselineCal
  * @author Janne Valkealahti
  *
  */
-public class MysqlBeforeBaseline extends AbstractBaselineCallback {
+public class MariadbBeforeBaseline extends AbstractBaselineCallback {
 
 	/**
 	 * Instantiates a new mysql before baseline.
 	 */
-	public MysqlBeforeBaseline() {
+	public MariadbBeforeBaseline() {
 		super(new V1__Initial_Setup());
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/mysql/V1__Initial_Setup.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/db/migration/mysql/V1__Initial_Setup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,15 +23,8 @@ import org.springframework.cloud.skipper.server.db.migration.AbstractInitialSetu
 
 public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 
-	public final static String CREATE_HIBERNATE_SEQUENCE_TABLE =
-			"create table if not exists hibernate_sequence (\n" +
-			"    next_val bigint\n" +
-			")";
-
-	public final static String INSERT_HIBERNATE_SEQUENCE_TABLE =
-			"insert into hibernate_sequence (next_val)\n" +
-			"    select * from (select 1 as next_val) as temp\n" +
-			"    where not exists(select * from hibernate_sequence)";
+	public final static String CREATE_HIBERNATE_SEQUENCE =
+			"create sequence if not exists hibernate_sequence start 1 increment 1";
 
 	public final static String CREATE_SKIPPER_APP_DEPLOYER_DATA_TABLE =
 			"create table skipper_app_deployer_data (\n" +
@@ -342,8 +335,7 @@ public class V1__Initial_Setup extends AbstractInitialSetupMigration {
 	@Override
 	public List<SqlCommand> createHibernateSequence() {
 		return Arrays.asList(
-				SqlCommand.from(CREATE_HIBERNATE_SEQUENCE_TABLE),
-				SqlCommand.from(INSERT_HIBERNATE_SEQUENCE_TABLE));
+				SqlCommand.from(CREATE_HIBERNATE_SEQUENCE));
 	}
 
 	@Override


### PR DESCRIPTION
- Essentially moving existing mysql integration into mariadb
- We target mariadb 10.3+ so for hibernate_sequence use
  a real sequence due to hibernate dialect.
- Keep classes in classpath under `mysql` due to
  https://github.com/spring-projects/spring-boot/issues/28728
- Fixes #1018