### PR TITLE
Add ActuatorService and ReleaseController endpoints

### DIFF
--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.AboutResource;
+import org.springframework.cloud.skipper.domain.ActuatorPostRequest;
 import org.springframework.cloud.skipper.domain.CancelRequest;
 import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.Deployer;
@@ -62,6 +63,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  * @author Janne Valkealahti
+ * @author David Turanski
  */
 public class DefaultSkipperClient implements SkipperClient {
 
@@ -235,6 +237,43 @@ public class DefaultSkipperClient implements SkipperClient {
 						httpEntity,
 						typeReference,
 						uriVariables);
+		return resourceResponseEntity.getBody();
+	}
+
+	@Override
+	public String getFromActuator(String releaseName, String appName, String appId, String endpoint) {
+
+		Map<String, Object> uriVariables = new HashMap<>();
+		uriVariables.put("releaseName", releaseName);
+		uriVariables.put("appName", appName);
+		uriVariables.put("appId", appId);
+
+		ResponseEntity<String> resourceResponseEntity =
+				restTemplate.exchange(
+						baseUri + "/release/actuator/{releaseName}/{appName}/{appId}?endpoint=" + endpoint,
+						HttpMethod.GET,
+						null,
+						String.class,
+						uriVariables);
+
+		return resourceResponseEntity.getBody();
+	}
+
+	@Override
+	public Object postToActuator(String releaseName, String appName, String appId, ActuatorPostRequest request) {
+		Map<String, Object> uriVariables = new HashMap<>();
+		uriVariables.put("releaseName", releaseName);
+		uriVariables.put("appName", appName);
+		uriVariables.put("appId", appId);
+
+		HttpEntity<ActuatorPostRequest> httpEntity = new HttpEntity<>(request);
+		ResponseEntity<String> resourceResponseEntity =
+				restTemplate.exchange(baseUri + "/release/actuator/{releaseName}/{appName}/{appId}",
+						HttpMethod.POST,
+						httpEntity,
+						String.class,
+						uriVariables);
+
 		return resourceResponseEntity.getBody();
 	}
 

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/DefaultSkipperClient.java
@@ -267,11 +267,11 @@ public class DefaultSkipperClient implements SkipperClient {
 		uriVariables.put("appId", appId);
 
 		HttpEntity<ActuatorPostRequest> httpEntity = new HttpEntity<>(request);
-		ResponseEntity<String> resourceResponseEntity =
+		ResponseEntity<?> resourceResponseEntity =
 				restTemplate.exchange(baseUri + "/release/actuator/{releaseName}/{appName}/{appId}",
 						HttpMethod.POST,
 						httpEntity,
-						String.class,
+						Object.class,
 						uriVariables);
 
 		return resourceResponseEntity.getBody();

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -242,19 +242,21 @@ public interface SkipperClient {
 	Release scale(String releaseName, ScaleRequest scaleRequest);
 
 	/**
+	 * Access an actuator resource for a deployed app instance.
 	 *
 	 * @param releaseName the release name
 	 * @param appName the application name
 	 * @param appId the deployer assigned guid of the app instance
 	 * @param endpoint the relative actuator path, e.g., {@code /info}
-	 * @return the contents as JSON text.
+	 * @return the contents as JSON text
 	 */
 	String getFromActuator(String releaseName, String appName, String appId, String endpoint);
 
 	/**
+	 * Post to an actuator resource for a deployed app instance.
 	 *
 	 * @param releaseName the release name
-	 * @param appName the application name
+	 * @param appName the application name (deployment ID)
 	 * @param appId the deployer assigned guid of the app instance
 	 * @param request an {@link ActuatorPostRequest}
 	 */

--- a/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
+++ b/spring-cloud-skipper-client/src/main/java/org/springframework/cloud/skipper/client/SkipperClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
 import org.springframework.cloud.skipper.domain.AboutResource;
+import org.springframework.cloud.skipper.domain.ActuatorPostRequest;
 import org.springframework.cloud.skipper.domain.CancelRequest;
 import org.springframework.cloud.skipper.domain.CancelResponse;
 import org.springframework.cloud.skipper.domain.Deployer;
@@ -42,6 +43,7 @@ import org.springframework.cloud.skipper.domain.UploadRequest;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  * @author Janne Valkealahti
+ * @author David Turanski
  */
 public interface SkipperClient {
 
@@ -98,9 +100,9 @@ public interface SkipperClient {
 
 	/**
 	 * Delete a specific release.
-	 *  @param releaseName the release name
+	 * @param releaseName the release name
 	 * @param deletePackage delete package when deleting the release
-	 * */
+	 */
 	void delete(String releaseName, boolean deletePackage);
 
 	/**
@@ -177,7 +179,6 @@ public interface SkipperClient {
 	 */
 	Map<String, Info> statuses(String... releaseNames);
 
-
 	/**
 	 * Return the deployment state of a last known releases mapped back to release names.
 	 *
@@ -213,7 +214,6 @@ public interface SkipperClient {
 	 */
 	String manifest(String releaseName, int releaseVersion);
 
-
 	/**
 	 * Fetch the logs of the latest release identified by the given name.
 	 *
@@ -222,10 +222,9 @@ public interface SkipperClient {
 	 */
 	LogInfo getLog(String releaseName);
 
-
 	/**
-	 * Fetch the logs of the latest release identified by the given release name
-	 * and a specific application name inside the release.
+	 * Fetch the logs of the latest release identified by the given release name and a
+	 * specific application name inside the release.
 	 *
 	 * @param releaseName the release name
 	 * @param appName the application name
@@ -241,4 +240,23 @@ public interface SkipperClient {
 	 * @return the status info of a release
 	 */
 	Release scale(String releaseName, ScaleRequest scaleRequest);
+
+	/**
+	 *
+	 * @param releaseName the release name
+	 * @param appName the application name
+	 * @param appId the deployer assigned guid of the app instance
+	 * @param endpoint the relative actuator path, e.g., {@code /info}
+	 * @return the contents as JSON text.
+	 */
+	String getFromActuator(String releaseName, String appName, String appId, String endpoint);
+
+	/**
+	 *
+	 * @param releaseName the release name
+	 * @param appName the application name
+	 * @param appId the deployer assigned guid of the app instance
+	 * @param request an {@link ActuatorPostRequest}
+	 */
+	Object postToActuator(String releaseName, String appName, String appId, ActuatorPostRequest request);
 }

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -16,6 +16,7 @@
 package org.springframework.cloud.skipper.client;
 
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,6 +25,7 @@ import org.junit.Test;
 import org.springframework.cloud.skipper.PackageDeleteException;
 import org.springframework.cloud.skipper.ReleaseNotFoundException;
 import org.springframework.cloud.skipper.SkipperException;
+import org.springframework.cloud.skipper.domain.ActuatorPostRequest;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.LogInfo;
 import org.springframework.cloud.skipper.domain.Release;
@@ -35,6 +37,7 @@ import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -209,5 +212,39 @@ public class DefaultSkipperClientTests {
 
 		List<Release> list = skipperClient.list(null);
 		assertThat(list).isEmpty();
+	}
+
+	@Test
+	public void testActuatorGet() {
+		RestTemplate restTemplate = new RestTemplate();
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer
+				.expect(requestTo("/release/actuator/tiktok/log/tiktok-log-0?endpoint=/foo/bar"))
+				.andExpect(queryParam("endpoint","/foo/bar"))
+				.andRespond(withSuccess("{\"foo\":\"bar\"}", MediaType.APPLICATION_JSON));
+
+
+		String response = skipperClient.getFromActuator(
+				"tiktok","log", "tiktok-log-0","/foo/bar");
+		assertThat(response).isEqualTo("{\"foo\":\"bar\"}");
+	}
+
+	@Test
+	public void testActuatorPost() {
+		RestTemplate restTemplate = new RestTemplate();
+		SkipperClient skipperClient = new DefaultSkipperClient("", restTemplate);
+		ActuatorPostRequest actuatorPostRequest = ActuatorPostRequest.of("/bindings/input",
+				Collections.singletonMap("state","STOPPED"));
+		MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+		mockServer
+				.expect(requestTo("/release/actuator/tiktok/log/tiktok-log-0"))
+				.andExpect(content().json(
+						"{\"endpoint\":\"/bindings/input\",\"body\":{\"state\":\"STOPPED\"}}"))
+				.andRespond(withSuccess());
+
+		Object response = skipperClient.postToActuator(
+				"tiktok","log", "tiktok-log-0", actuatorPostRequest);
 	}
 }

--- a/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
+++ b/spring-cloud-skipper-client/src/test/java/org/springframework/cloud/skipper/client/DefaultSkipperClientTests.java
@@ -244,7 +244,8 @@ public class DefaultSkipperClientTests {
 						"{\"endpoint\":\"/bindings/input\",\"body\":{\"state\":\"STOPPED\"}}"))
 				.andRespond(withSuccess());
 
-		Object response = skipperClient.postToActuator(
+		//Don't care about the response here.
+		skipperClient.postToActuator(
 				"tiktok","log", "tiktok-log-0", actuatorPostRequest);
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.cloud.deployer.resource.docker.DockerResourceLoader;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.maven.MavenResourceLoader;
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
+import org.springframework.cloud.deployer.spi.app.ActuatorOperations;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.cloud.skipper.io.DefaultPackageReader;
 import org.springframework.cloud.skipper.io.DefaultPackageWriter;
@@ -71,6 +72,7 @@ import org.springframework.cloud.skipper.server.repository.jpa.PackageMetadataRe
 import org.springframework.cloud.skipper.server.repository.jpa.ReleaseRepository;
 import org.springframework.cloud.skipper.server.repository.jpa.RepositoryRepository;
 import org.springframework.cloud.skipper.server.repository.map.DeployerRepository;
+import org.springframework.cloud.skipper.server.service.ActuatorService;
 import org.springframework.cloud.skipper.server.service.PackageMetadataService;
 import org.springframework.cloud.skipper.server.service.PackageService;
 import org.springframework.cloud.skipper.server.service.ReleaseReportService;
@@ -87,6 +89,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.map.repository.config.EnableMapRepositories;
+import org.springframework.lang.Nullable;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -101,6 +104,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * @author Janne Valkealahti
  * @author Gunnar Hillert
  * @author Donovan Muller
+ * @author David Turanski
  */
 @Configuration
 @EnableConfigurationProperties({ SkipperServerProperties.class, VersionInfoProperties.class,
@@ -152,14 +156,20 @@ public class SkipperServerConfiguration implements AsyncConfigurer {
 
 	@Bean
 	public ReleaseController releaseController(ReleaseService releaseService,
-			SkipperStateMachineService skipperStateMachineService) {
-		return new ReleaseController(releaseService, skipperStateMachineService);
+			SkipperStateMachineService skipperStateMachineService,
+			ActuatorService actuatorService) {
+		return new ReleaseController(releaseService, skipperStateMachineService, actuatorService);
 	}
 
 	@Bean
 	public PackageController packageController(PackageService packageService,
 			PackageMetadataService packageMetadataService, SkipperStateMachineService skipperStateMachineService) {
 		return new PackageController(packageService, packageMetadataService, skipperStateMachineService);
+	}
+
+	@Bean
+	ActuatorService actuatorService(ReleaseService releaseService, @Nullable ActuatorOperations actuatorOperations) {
+		return new ActuatorService(releaseService, actuatorOperations);
 	}
 
 	@Bean

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.deployer.spi.app.ActuatorOperations;
+import org.springframework.cloud.deployer.spi.local.LocalActuatorTemplate;
 import org.springframework.cloud.deployer.spi.local.LocalAppDeployer;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
 import org.springframework.cloud.skipper.domain.Deployer;
@@ -28,8 +32,10 @@ import org.springframework.cloud.skipper.server.repository.map.DeployerRepositor
 import org.springframework.cloud.skipper.server.service.DeployerInitializationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class SkipperServerPlatformConfiguration {
@@ -46,36 +52,59 @@ public class SkipperServerPlatformConfiguration {
 		return new DeployerInitializationService(deployerRepository, platforms, resolver);
 	}
 
-	@Bean
 	@Profile("local")
-	public Platform localDeployers(LocalPlatformProperties localPlatformProperties) {
-		List<Deployer> deployers = new ArrayList<>();
-		Map<String, LocalDeployerProperties> localDeployerPropertiesMap = localPlatformProperties.getAccounts();
-		if (localDeployerPropertiesMap.isEmpty()) {
-			localDeployerPropertiesMap.put("default", new LocalDeployerProperties());
-		}
-		for (Map.Entry<String, LocalDeployerProperties> entry : localDeployerPropertiesMap
-				.entrySet()) {
-			LocalAppDeployer localAppDeployer = new LocalAppDeployer(entry.getValue());
-			Deployer deployer = new Deployer(entry.getKey(), "local", localAppDeployer);
-			deployer.setDescription(prettyPrintLocalDeployerProperties(entry.getValue()));
-			deployers.add(deployer);
+	@Configuration
+	static class LocalPlatformConfiguration {
+		@Bean
+		@Primary
+		public Platform localDeployers(LocalPlatformProperties localPlatformProperties) {
+			List<Deployer> deployers = new ArrayList<>();
+			Map<String, LocalDeployerProperties> localDeployerPropertiesMap = localPlatformProperties.getAccounts();
+			if (localDeployerPropertiesMap.isEmpty()) {
+				localDeployerPropertiesMap.put("default", new LocalDeployerProperties());
+			}
+			for (Map.Entry<String, LocalDeployerProperties> entry : localDeployerPropertiesMap
+					.entrySet()) {
+				LocalAppDeployer localAppDeployer = new LocalAppDeployer(entry.getValue());
+				Deployer deployer = new Deployer(entry.getKey(), "local", localAppDeployer);
+				deployer.setDescription(prettyPrintLocalDeployerProperties(entry.getValue()));
+				deployers.add(deployer);
+			}
+
+			return new Platform("Local", deployers);
 		}
 
-		return new Platform("Local", deployers);
-	}
-
-	private String prettyPrintLocalDeployerProperties(LocalDeployerProperties localDeployerProperties) {
-		StringBuilder builder = new StringBuilder();
-		if (localDeployerProperties.getJavaOpts() != null) {
-			builder.append("JavaOpts = [" + localDeployerProperties.getJavaOpts() + "], ");
+		@Bean
+		@ConditionalOnMissingBean
+		RestTemplate actuatorRestTemplate() {
+			return new RestTemplate();
 		}
-		builder.append("ShutdownTimeout = [" + localDeployerProperties.getShutdownTimeout() + "], ");
-		builder.append("EnvVarsToInherit = ["
-				+ StringUtils.arrayToCommaDelimitedString(localDeployerProperties.getEnvVarsToInherit()) + "], ");
-		builder.append("JavaCmd = [" + localDeployerProperties.getJavaCmd() + "], ");
-		builder.append("WorkingDirectoriesRoot = [" + localDeployerProperties.getWorkingDirectoriesRoot() + "], ");
-		builder.append("DeleteFilesOnExit = [" + localDeployerProperties.isDeleteFilesOnExit() + "]");
-		return builder.toString();
+
+		@Bean
+		@ConditionalOnMissingBean
+		ActuatorOperations actuatorOperations(RestTemplate actuatorRestTemplate, Platform platform) {
+			return new LocalActuatorTemplate(actuatorRestTemplate,
+					platform.getDeployers().stream()
+							.filter(deployer -> deployer.getType().equals("local"))
+							.map(deployer -> deployer.getAppDeployer())
+							.findFirst()
+							.orElseThrow(
+								()-> new BeanCreationException("Unable to resolve 'local' deployer for platform."))
+							);
+		}
+
+		private String prettyPrintLocalDeployerProperties(LocalDeployerProperties localDeployerProperties) {
+			StringBuilder builder = new StringBuilder();
+			if (localDeployerProperties.getJavaOpts() != null) {
+				builder.append("JavaOpts = [" + localDeployerProperties.getJavaOpts() + "], ");
+			}
+			builder.append("ShutdownTimeout = [" + localDeployerProperties.getShutdownTimeout() + "], ");
+			builder.append("EnvVarsToInherit = ["
+					+ StringUtils.arrayToCommaDelimitedString(localDeployerProperties.getEnvVarsToInherit()) + "], ");
+			builder.append("JavaCmd = [" + localDeployerProperties.getJavaCmd() + "], ");
+			builder.append("WorkingDirectoriesRoot = [" + localDeployerProperties.getWorkingDirectoriesRoot() + "], ");
+			builder.append("DeleteFilesOnExit = [" + localDeployerProperties.isDeleteFilesOnExit() + "]");
+			return builder.toString();
+		}
 	}
 }

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfiguration.java
@@ -56,6 +56,9 @@ public class SkipperServerPlatformConfiguration {
 	@Configuration
 	static class LocalPlatformConfiguration {
 		@Bean
+		/*
+		 * Force this platform instance for the "local" profile, so it may be injected into ActuatorOperations below.
+		 */
 		@Primary
 		public Platform localDeployers(LocalPlatformProperties localPlatformProperties) {
 			List<Deployer> deployers = new ArrayList<>();

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ActuatorService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ActuatorService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.server.service;
+
+import org.springframework.cloud.deployer.spi.app.ActuatorOperations;
+import org.springframework.cloud.skipper.domain.ActuatorPostRequest;
+
+/**
+ * Service used to access an actuator endpoint for a deployed instance.
+ *
+ * @author David Turanski
+ */
+public class ActuatorService {
+
+	private final ReleaseService releaseService;
+
+	private final ActuatorOperations actuatorOperations;
+
+	public ActuatorService(ReleaseService releaseService, ActuatorOperations actuatorOperations) {
+		this.releaseService = releaseService;
+		this.actuatorOperations = actuatorOperations;
+	}
+
+	/**
+	 *
+	 * @param releaseName the release name.
+	 * @param appName the deployment ID for the app
+	 * @param appId
+	 * @param endpoint
+	 * @return
+	 */
+	public String getFromActuator(String releaseName, String appName, String appId, String endpoint) {
+		return actuatorOperations.getFromActuator(deploymentId(releaseName, appName), appId, endpoint, String.class);
+	}
+
+	/**
+	 *
+	 * @param releaseName
+	 * @param appName
+	 * @param appId
+	 * @param postRequest
+	 * @return
+	 */
+	public Object postToActuator(String releaseName, String appName, String appId, ActuatorPostRequest postRequest) {
+		return actuatorOperations.postToActuator(deploymentId(releaseName, appName), appId, postRequest.getEndpoint(),
+			postRequest.getBody(), Object.class);
+	}
+
+	private String deploymentId(String releaseName, String appName) {
+		return this.releaseService.status(releaseName).getStatus().getAppStatusList().stream()
+				.filter(as -> appName.equals(as.getDeploymentId()))
+				.map(as -> as.getDeploymentId())
+				.findFirst().orElseThrow(() -> new IllegalArgumentException(
+						String.format("app %s is not found in release %s", appName, releaseName)));
+	}
+}

--- a/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ActuatorService.java
+++ b/spring-cloud-skipper-server-core/src/main/java/org/springframework/cloud/skipper/server/service/ActuatorService.java
@@ -37,11 +37,11 @@ public class ActuatorService {
 
 	/**
 	 *
-	 * @param releaseName the release name.
+	 * @param releaseName the release name
 	 * @param appName the deployment ID for the app
-	 * @param appId
-	 * @param endpoint
-	 * @return
+	 * @param appId the deployer assigned guid of the app instance
+	 * @param endpoint the relative actuator resource path, e.g., {@code /info}, preceding / is optional
+	 * @return JSON content as UTF-8 encoded string
 	 */
 	public String getFromActuator(String releaseName, String appName, String appId, String endpoint) {
 		return actuatorOperations.getFromActuator(deploymentId(releaseName, appName), appId, endpoint, String.class);
@@ -49,11 +49,11 @@ public class ActuatorService {
 
 	/**
 	 *
-	 * @param releaseName
-	 * @param appName
-	 * @param appId
-	 * @param postRequest
-	 * @return
+	 * @param releaseName the release name
+	 * @param appName the deployment ID for the app
+	 * @param appId the deployer assigned guid of the app instance
+	 * @param postRequest the request parameters {@link ActuatorPostRequest}
+	 * @return the response object, if any
 	 */
 	public Object postToActuator(String releaseName, String appName, String appId, ActuatorPostRequest postRequest) {
 		return actuatorOperations.postToActuator(deploymentId(releaseName, appName), appId, postRequest.getEndpoint(),

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/AbstractIntegrationTest.java
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfigurati
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.autoconfigure.ResourceLoadingAutoConfiguration;
+import org.springframework.cloud.deployer.spi.local.LocalDeployerAutoConfiguration;
 import org.springframework.cloud.skipper.domain.Info;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.Release;
@@ -187,7 +188,8 @@ public abstract class AbstractIntegrationTest extends AbstractAssertReleaseDeplo
 	@Configuration
 	@ImportAutoConfiguration(classes = { JacksonAutoConfiguration.class, EmbeddedDataSourceConfiguration.class,
 			HibernateJpaAutoConfiguration.class, StateMachineJpaRepositoriesAutoConfiguration.class,
-			SkipperServerPlatformConfiguration.class, ResourceLoadingAutoConfiguration.class })
+			SkipperServerPlatformConfiguration.class, ResourceLoadingAutoConfiguration.class,
+			LocalDeployerAutoConfiguration.class})
 	@Import(SkipperServerConfiguration.class)
 	@EnableWebMvc
 	static class TestConfig {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/PlatformPropertiesTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/PlatformPropertiesTests.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = PlatformPropertiesTests.TestConfig.class,
 		properties = "spring.main.allow-bean-definition-overriding=true")
-@ActiveProfiles("platform-properties")
+@ActiveProfiles({"platform-properties", "local"})
 public class PlatformPropertiesTests {
 
 	@Autowired
@@ -62,7 +62,8 @@ public class PlatformPropertiesTests {
 
 	@Configuration
 	@ImportAutoConfiguration(classes = { EmbeddedDataSourceConfiguration.class, HibernateJpaAutoConfiguration.class,
-			StateMachineJpaRepositoriesAutoConfiguration.class, ResourceLoadingAutoConfiguration.class })
+			StateMachineJpaRepositoriesAutoConfiguration.class, ResourceLoadingAutoConfiguration.class,
+			SkipperServerPlatformConfiguration.class })
 	@Import(SkipperServerConfiguration.class)
 	static class TestConfig {
 	}

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfigurationTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/config/SkipperServerPlatformConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ import org.springframework.cloud.skipper.domain.Platform;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.statemachine.boot.autoconfigure.StateMachineJpaRepositoriesAutoConfiguration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -47,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Donovan Muller
  * @author Ilayaperumal Gopinathan
+ * @author David Turanski
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -111,7 +111,6 @@ public class SkipperServerPlatformConfigurationTests {
 	static class TestPlatformAutoConfiguration {
 
 		@Bean
-		@Primary
 		public Platform testPlatform() {
 			return new Platform("Test", Collections.singletonList(
 					new Deployer("test", "test", new AppDeployer() {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/ReleaseControllerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,11 @@ import javax.servlet.ServletContext;
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cloud.deployer.spi.app.AppInstanceStatus;
 import org.springframework.cloud.deployer.spi.app.AppStatus;
 import org.springframework.cloud.deployer.spi.app.DeploymentState;
+import org.springframework.cloud.skipper.domain.ActuatorPostRequest;
 import org.springframework.cloud.skipper.domain.InstallProperties;
 import org.springframework.cloud.skipper.domain.InstallRequest;
 import org.springframework.cloud.skipper.domain.PackageIdentifier;
@@ -38,6 +40,7 @@ import org.springframework.cloud.skipper.domain.UpgradeProperties;
 import org.springframework.cloud.skipper.domain.UpgradeRequest;
 import org.springframework.cloud.skipper.server.deployer.DefaultReleaseManager;
 import org.springframework.cloud.skipper.server.repository.jpa.RepositoryRepository;
+import org.springframework.cloud.skipper.server.service.ActuatorService;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -46,6 +49,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -56,10 +62,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  * @author Christian Tzolov
+ * @author David Turanski
  */
 @ActiveProfiles({"repo-test", "local"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class ReleaseControllerTests extends AbstractControllerTests {
+
+	@MockBean
+	private ActuatorService actuatorService;
 
 	@Autowired
 	private RepositoryRepository repositoryRepository;
@@ -304,6 +314,33 @@ public class ReleaseControllerTests extends AbstractControllerTests {
 		assertThat(appStatusCopy.getInstances().get("instance666").getAttributes().size()).isEqualTo(2);
 		assertThat(appStatusCopy.getInstances().get("instance666").getAttributes().get("key2")).isEqualTo("value2");
 
+	}
+
+	@Test
+	public void getFromAndPostToActuator() throws Exception {
+		install("ticktock", "1.0.0", "myTicker");
+		assertReleaseIsDeployedSuccessfully("myTicker", 1);
+
+		mockMvc
+				.perform(get("/api/release/actuator/myTicker/myTicker.log-v1/myTicker.log-v1-0?endpoint=info"))
+				.andExpect(status().isOk()).andReturn();
+
+		verify(actuatorService, times(1))
+			.getFromActuator("myTicker", "myTicker.log-v1", "myTicker.log-v1-0","info");
+
+
+		reset(actuatorService);
+		ActuatorPostRequest actuatorPostRequest = ActuatorPostRequest.of("bindings/input",
+				Collections.singletonMap("state", "STOPPED"));
+
+		mockMvc
+				.perform(post("/api/release/actuator/myTicker/myTicker.log-v1/myTicker.log-v1-0")
+						.content(convertObjectToJson(actuatorPostRequest)))
+				.andExpect(status().isOk()).andReturn();
+
+		verify(actuatorService, times(1))
+				.postToActuator("myTicker", "myTicker.log-v1", "myTicker.log-v1-0",
+						actuatorPostRequest);
 	}
 
 	private class ErrorDispatcher implements RequestBuilder {

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ServerDependencies.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/controller/docs/ServerDependencies.java
@@ -42,6 +42,7 @@ import org.springframework.cloud.deployer.resource.docker.DockerResourceLoader;
 import org.springframework.cloud.deployer.resource.maven.MavenProperties;
 import org.springframework.cloud.deployer.resource.maven.MavenResourceLoader;
 import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoader;
+import org.springframework.cloud.deployer.spi.app.ActuatorOperations;
 import org.springframework.cloud.skipper.domain.SpringCloudDeployerApplicationManifestReader;
 import org.springframework.cloud.skipper.io.DefaultPackageReader;
 import org.springframework.cloud.skipper.io.DefaultPackageWriter;
@@ -80,6 +81,7 @@ import org.springframework.cloud.skipper.server.repository.jpa.PackageMetadataRe
 import org.springframework.cloud.skipper.server.repository.jpa.ReleaseRepository;
 import org.springframework.cloud.skipper.server.repository.jpa.RepositoryRepository;
 import org.springframework.cloud.skipper.server.repository.map.DeployerRepository;
+import org.springframework.cloud.skipper.server.service.ActuatorService;
 import org.springframework.cloud.skipper.server.service.PackageMetadataService;
 import org.springframework.cloud.skipper.server.service.PackageService;
 import org.springframework.cloud.skipper.server.service.ReleaseReportService;
@@ -91,6 +93,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.lang.Nullable;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -146,14 +149,19 @@ public class ServerDependencies implements AsyncConfigurer {
 
 	@Bean
 	public ReleaseController releaseController(ReleaseService releaseService,
-			SkipperStateMachineService skipperStateMachineService) {
-		return new ReleaseController(releaseService, skipperStateMachineService);
+			SkipperStateMachineService skipperStateMachineService, ActuatorService actuatorService) {
+		return new ReleaseController(releaseService, skipperStateMachineService, actuatorService);
 	}
 
 	@Bean
 	public PackageController packageController(PackageService packageService,
 			PackageMetadataService packageMetadataService, SkipperStateMachineService skipperStateMachineService) {
 		return new PackageController(packageService, packageMetadataService, skipperStateMachineService);
+	}
+
+	@Bean
+	ActuatorService actuatorService(ReleaseService releaseService, @Nullable ActuatorOperations actuatorOperations) {
+		return new ActuatorService(releaseService, actuatorOperations);
 	}
 
 	@Bean

--- a/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ActuatorPostRequest.java
+++ b/spring-cloud-skipper/src/main/java/org/springframework/cloud/skipper/domain/ActuatorPostRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.skipper.domain;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.util.Assert;
+
+public class ActuatorPostRequest {
+
+	private String endpoint;
+
+	private Map<String, Object> body;
+
+	/**
+	 * @author David Turanski
+	 */
+	public ActuatorPostRequest() {
+	}
+
+	/**
+	 * @param endpoint the relative actuator path, e.g., {@code /info}, base actuator url if empty.
+	 * @param body the request body as JSON text
+	 * @return
+	 */
+	public static ActuatorPostRequest of(String endpoint, Map<String, Object> body) {
+		Assert.notEmpty(body, "'body' must not be empty");
+		ActuatorPostRequest actuatorPostRequest = new ActuatorPostRequest();
+		actuatorPostRequest.setEndpoint(endpoint == null ? "/" : endpoint);
+		actuatorPostRequest.setBody(body);
+		return actuatorPostRequest;
+	}
+
+	public String getEndpoint() {
+		return endpoint;
+	}
+
+	public void setEndpoint(String endpoint) {
+		this.endpoint = endpoint;
+	}
+
+	public Map<String, Object> getBody() {
+		return body;
+	}
+
+	public void setBody(Map<String, Object> body) {
+		this.body = body;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ActuatorPostRequest that = (ActuatorPostRequest) o;
+		return Objects.equals(endpoint, that.endpoint) && Objects.equals(body, that.body);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(endpoint, body);
+	}
+}


### PR DESCRIPTION
resolves #1024 

The `/actuator`endpoint goes under the `/release` resource.  Following the precedent for `api/release/logs`, the functionality is similarly out of the release domain, but gets info provided by deployed app instances whose metadata are exposed via a release.  Exposed via `ReleaseController`, this adds an `ActuatorService` which also depends on `ReleaseService`, and config for the ActuatorService.  I have manually verified end-to-end functionality against the local deployer, with `time | log` deployed with 2 log instances.   

Depends on https://github.com/spring-cloud/spring-cloud-deployer-cloudfoundry/pull/385, https://github.com/spring-cloud/spring-cloud-deployer-kubernetes/pull/478, and https://github.com/spring-cloud/spring-cloud-deployer-local/pull/212