### PR TITLE
spring-cloud-skipper-1034 Tests fail under Windows

### DIFF
--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ArgumentSanitizerTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ArgumentSanitizerTests.java
@@ -36,7 +36,7 @@ public class ArgumentSanitizerTests {
 				TestResourceUtils.qualifiedResource(getClass(), "nopassword.yaml").getInputStream(),
 				Charset.defaultCharset());
 		String result = ArgumentSanitizer.sanitizeYml(initialYaml);
-		assertThat(result).isEqualTo(initialYaml);
+		assertThat(result.replace("\r", "")).isEqualTo(initialYaml.replace("\r", ""));
 	}
 
 	@Test
@@ -48,7 +48,7 @@ public class ArgumentSanitizerTests {
 				TestResourceUtils.qualifiedResource(getClass(), "passwordredacted.yaml").getInputStream(),
 				Charset.defaultCharset());
 		String result = ArgumentSanitizer.sanitizeYml(initialYaml);
-		assertThat(result).isEqualTo(redactedYaml);
+		assertThat(result.replace("\r", "")).isEqualTo(redactedYaml.replace("\r", ""));
 	}
 
 	@Test
@@ -60,6 +60,6 @@ public class ArgumentSanitizerTests {
 				TestResourceUtils.qualifiedResource(getClass(), "configpasswordredacted.yaml").getInputStream(),
 				Charset.defaultCharset());
 		String result = ArgumentSanitizer.sanitizeYml(initialYaml);
-		assertThat(result).isEqualTo(redactedYaml);
+		assertThat(result.replace("\r", "")).isEqualTo(redactedYaml.replace("\r",""));
 	}
 }

--- a/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ConfigValueUtilsTests.java
+++ b/spring-cloud-skipper-server-core/src/test/java/org/springframework/cloud/skipper/server/service/ConfigValueUtilsTests.java
@@ -85,7 +85,7 @@ public class ConfigValueUtilsTests {
 		String expectedYaml = StreamUtils.copyToString(
 				TestResourceUtils.qualifiedResource(getClass(), "merged.yaml").getInputStream(),
 				Charset.defaultCharset());
-		assertThat(mergedYaml).isEqualTo(expectedYaml);
+		assertThat(mergedYaml.replace("\r", "")).isEqualTo(expectedYaml.replace("\r",""));
 	}
 
 	@Configuration

--- a/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/io/PackageWriterTests.java
+++ b/spring-cloud-skipper/src/test/java/org/springframework/cloud/skipper/io/PackageWriterTests.java
@@ -88,7 +88,8 @@ public class PackageWriterTests {
 				TestResourceUtils.qualifiedResource(getClass(), resourceSuffix)
 						.getInputStream(),
 				Charset.defaultCharset());
-		assertThat(zipEntryAsString).isEqualTo(expectedYaml);
+		assertThat(zipEntryAsString.replace("\r", "")).isEqualTo(expectedYaml.replace("\r",""));
+
 	}
 
 	private Package createSimplePackage() throws IOException {


### PR DESCRIPTION
Remove `CR (\r)`  for comparison to files.