### PR TITLE
Update database section of ref guide

### DIFF
--- a/spring-cloud-skipper-docs/src/main/asciidoc/configuration-database.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/configuration-database.adoc
@@ -1,0 +1,65 @@
+
+[[configuration-database-overview]]
+A relational database is used to store stream and task definitions as well as the state of executed tasks.
+Spring Cloud Skipper provides schemas for *MariaDB*, *MySQL*, *Oracle*, *PostgreSQL*, *Db2*, *SQL Server*, and *H2*. The schema is automatically created when the server starts.
+
+NOTE: The JDBC drivers for *MariaDB*, *MySQL* (via the _MariaDB_ driver), *PostgreSQL*, *SQL Server* are available without additional configuration. To use any other database you need to put the corresponding JDBC driver jar on the classpath of the server as described <<#add-custom-driver,here>>.
+
+To configure a database the following properties must be set:
+
+* `spring.datasource.url`
+* `spring.datasource.username`
+* `spring.datasource.password`
+* `spring.datasource.driver-class-name`
+
+The `username` and `password` are the same regardless of the database. However, the `url` and `driver-class-name` vary per database as follows.
+
+[frame="none"]
+[cols="a,a,a,a"]
+[cols="10%,30%,20%,10%"]
+|===
+|[.small]#Database#|[.small]#spring.datasource.url#|[.small]#spring.datasource.driver-class-name#|[.small]#Driver included#
+
+|[.small]#MariaDB 10.4+#
+|[.small]#jdbc:mariadb://${db-hostname}:${db-port}/${db-name}#
+|[.small]#org.mariadb.jdbc.Driver#
+|[.small]#Yes#
+
+|[.small]#MySQL 5.7#
+|[.small]#jdbc:mysql://${db-hostname}:${db-port}/${db-name}?permitMysqlScheme#
+|[.small]#org.mariadb.jdbc.Driver#
+|[.small]#Yes#
+
+|[.small]#MySQL 8.0+#
+|[.small]#jdbc:mariadb://${db-hostname}:${db-port}/${db-name}?allowPublicKeyRetrieval=true&useSSL=false&autoReconnect=true&permitMysqlScheme#{empty}footnote:[SSL is disabled in this example, adjust accordingly for your environment and requirements]
+|[.small]#org.mariadb.jdbc.Driver#
+|[.small]#Yes#
+
+|[.small]#PostgresSQL#
+|[.small]#jdbc:postgres://${db-hostname}:${db-port}/${db-name}#
+|[.small]#org.postgresql.Driver#
+|[.small]#Yes#
+
+|[.small]#SQL Server#
+|[.small]#jdbc:sqlserver://${db-hostname}:${db-port};databasename=${db-name}&encrypt=false#
+|[.small]#com.microsoft.sqlserver.jdbc.SQLServerDriver#
+|[.small]#Yes#
+
+|[.small]#DB2#
+|[.small]#jdbc:db2://${db-hostname}:${db-port}/{db-name}#
+|[.small]#com.ibm.db2.jcc.DB2Driver#
+|[.small]#No#
+
+|[.small]#Oracle#
+|[.small]#jdbc:oracle:thin:@${db-hostname}:${db-port}/{db-name}#
+|[.small]#oracle.jdbc.OracleDriver#
+|[.small]#No#
+|===
+
+==== H2
+When no other database is configured and the *H2* driver has been added to the server classpath then
+Spring Cloud Skipper uses an embedded instance of the *H2* database as the default.
+
+NOTE: *H2* is good for development purposes but is not recommended for production use nor is it supported as an external mode.
+
+To use *H2* add the `com.h2database:h2:2.1.214` JDBC driver to the classpath and do not configure any other database.

--- a/spring-cloud-skipper-docs/src/main/asciidoc/installation.adoc
+++ b/spring-cloud-skipper-docs/src/main/asciidoc/installation.adoc
@@ -220,131 +220,31 @@ You can find more information on the deployment properties that you can configur
 [[skipper-database-configuration]]
 == Database configuration
 
-A relational database is used to store stream and task definitions as well as the state of tasks that have been run.
-Spring Cloud Skipper provides schemas for *H2*, *MySQL*, *Oracle*, *PostgreSQL*, *Db2*, and *SQL Server*. The schema is automatically created when the server starts.
+include::configuration-database.adoc[]
 
-By default, Spring Cloud Skipper offers an embedded instance of the *H2* database.
-The *H2* database is good for development purposes but is not recommended for production use.
+[#add-custom-driver]
+==== Adding a Custom JDBC Driver
+To add a custom driver for the database (for example, Oracle), you should rebuild the Skipper Server and add the dependency to the Maven `pom.xml` file.
+You need to modify the maven `pom.xml` of `spring-cloud-skipper` module.
+There are GA release tags in GitHub repository, so you can switch to desired GA tags to add the drivers on the production-ready codebase.
 
-NOTE: *H2* database in Server Mode is not supported, only Embedded Mode.
+To add a custom JDBC driver dependency for the Spring Cloud Skipper server:
 
-The JDBC drivers for *MySQL* (through the MariaDB driver), *PostgreSQL*, *SQL Server*, and embedded *H2* are available without additional configuration.
-If you are using any other database, then you need to put the corresponding JDBC driver jar on the classpath of the server.
+. Select the tag that corresponds to the version of the server you want to rebuild and clone the github repository.
+. Edit the spring-cloud-skipper-server/pom.xml and, in the `dependencies` section, add the dependency for the database driver required.  In the following example , an Oracle driver has been chosen:
 
-The database properties can be passed as environment variables or command-line arguments to the Skipper Server.
-
-==== MySQL
-
-The following example shows how to define a MySQL database connection using MariaDB driver.
-
-[source,bash,subs=attributes]
+[source,xml]
 ----
-java -jar spring-cloud-skipper-server-{project-version}.jar \
-    --spring.datasource.url=jdbc:mysql://localhost:3306/mydb \
-    --spring.datasource.username=<user> \
-    --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-----
-
-MySQL versions up to _5.7_ can be used with a MariaDB driver. Starting from version _8.0_ MySQL's own driver has to be used.
-
-[source,bash,subs=attributes]
-----
-java -jar spring-cloud-skipper-server-{project-version}.jar \
-    --spring.datasource.url=jdbc:mysql://localhost:3306/mydb \
-    --spring.datasource.username=<user> \
-    --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+<dependencies>
+  ...
+  <dependency>
+    <groupId>com.oracle.jdbc</groupId>
+    <artifactId>ojdbc8</artifactId>
+    <version>12.2.0.1</version>
+  </dependency>
+  ...
+</dependencies>
 ----
 
-NOTE: Due to licensing restrictions we're unable to bundle the MySQL driver. You need to add it to
-      server's classpath yourself.
-
-==== MariaDB
-
-The following example shows how to define a MariaDB database connection with command Line arguments
-
-[source,bash,subs=attributes]
-----
-java -jar spring-cloud-skipper-server-server-{project-version}.jar \
-    --spring.datasource.url=jdbc:mariadb://localhost:3306/mydb?useMysqlMetadata=true \
-    --spring.datasource.username=<user> \
-    --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-----
-
-Starting with MariaDB v2.4.1 connector release, it is required to also add `useMysqlMetadata=true`
-to the JDBC URL. This is a required workaround until the time when MySQL and MariaDB are considered to be two
-different databases.
-
-MariaDB version _10.3_ introduced a support for real database sequences which is yet another breaking
-change while toolings around these databases fully support MySQL and MariaDB as a separate database
-types. A workaround is to use an older hibernate dialect which doesn't try to use sequences.
-
-[source,bash,subs=attributes]
-----
-java -jar spring-cloud-spring-cloud-skipper-server-server-{project-version}.jar \
-    --spring.datasource.url=jdbc:mariadb://localhost:3306/mydb?useMysqlMetadata=true \
-    --spring.datasource.username=<user> \
-    --spring.datasource.password=<password> \
-    --spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDB102Dialect \
-    --spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-----
-
-==== PostgreSQL
-
-The following example shows how to define a PostgreSQL database connection with command line arguments:
-
-[source,bash,subs=attributes]
-----
-java -jar spring-cloud-skipper-server-{project-version}.jar \
-    --spring.datasource.url=jdbc:postgresql://localhost:5432/mydb \
-    --spring.datasource.username=<user> \
-    --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=org.postgresql.Driver
-----
-
-==== SQL Server
-
-The following example shows how to define a SQL Server database connection with command line arguments:
-
-[source,bash,subs=attributes]
-----
-java -jar spring-cloud-skipper-server-{project-version}.jar \
-    --spring.datasource.url='jdbc:sqlserver://localhost:1433;databaseName=mydb' \
-    --spring.datasource.username=<user> \
-    --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
-----
-
-==== Db2
-
-The following example shows how to define a Db2 database connection with command line arguments:
-
-[source,bash,subs=attributes]
-----
-java -jar spring-cloud-skipper-server-{project-version}.jar \
-    --spring.datasource.url=jdbc:db2://localhost:50000/mydb \
-    --spring.datasource.username=<user> \
-    --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=com.ibm.db2.jcc.DB2Driver
-----
-
-NOTE: Due to licensing restrictions we're unable to bundle Db2 driver. You need to add it to
-      server's classpath yourself.
-
-==== Oracle
-
-The following example shows how to define a Oracle database connection with command line arguments:
-
-[source,bash,subs=attributes]
-----
-java -jar spring-cloud-skipper-server-{project-version}.jar \
-    --spring.datasource.url=jdbc:oracle:thin:@localhost:1521/MYDB \
-    --spring.datasource.username=<user> \
-    --spring.datasource.password=<password> \
-    --spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
-----
-
-NOTE: Due to licensing restrictions we're unable to bundle Oracle driver. You need to add it to
-      server's classpath yourself.
+[start=3]
+. Build the application as described in <<appendix-building.adoc#building, Building Spring Cloud Skipper>>


### PR DESCRIPTION
This handles the Dataflow ref guide updates - Skipper to follow.

### Point1
I have added a "Add custom JDBC driver" section only to remain consistent w/ the SCDF docs. I believe this will not be the final suggested mechanism for users to extend the classpath as @corneil has another way that is less intrusive. We should update the ref guides accordingly (both Dataflow and Skipper - creating an issue so as to not drop the ball on this detail).

### Point2
I have attached generated PDF for your viewing pleasure while reviewing in case you do not have the IDEA asciidoc plugin etc.. (the PDF will NOT be checked in).
- [installation.pdf](https://github.com/spring-cloud/spring-cloud-skipper/files/9529618/installation.pdf)


Closes #5079