### PR TITLE
Backport "Add hibernate-micrometer to enable Hibernate metrics"

### DIFF
--- a/spring-cloud-skipper-server-core/pom.xml
+++ b/spring-cloud-skipper-server-core/pom.xml
@@ -38,6 +38,10 @@
 			<artifactId>prometheus-rsocket-spring</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-micrometer</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-dataflow-common-flyway</artifactId>
 		</dependency>


### PR DESCRIPTION
- Source: spring-cloud-dataflow/main (1354167b644c651fbe6b6c9f96d0de8c1833c9f4)

See https://github.com/spring-cloud/spring-cloud-dataflow/issues/4791\