### PR TITLE
Adjust `maven.remoteRepositories` for Artifactory cutover

### DIFF
--- a/spring-cloud-skipper-server-core/src/main/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/main/resources/application.yml
@@ -201,8 +201,10 @@ spring:
 
 maven:
   remoteRepositories:
+    mavenCentral:
+      url: https://repo.maven.apache.org/maven2
     springRepo:
-      url: https://repo.spring.io/libs-snapshot
+      url: https://repo.spring.io/snapshot
 
 logging:
   level:

--- a/spring-cloud-skipper-server-core/src/test/resources/application.yml
+++ b/spring-cloud-skipper-server-core/src/test/resources/application.yml
@@ -28,10 +28,12 @@ spring:
               name: Spring Cloud Skipper Shell
               version: fake-shell-version
 
-
 maven:
   remoteRepositories:
-    springRepo: https://repo.spring.io/libs-snapshot
+    mavenCentral:
+      url: https://repo.maven.apache.org/maven2
+    springRepo:
+      url: https://repo.spring.io/snapshot
 
 logging:
   level:


### PR DESCRIPTION
- Add `mavenCentral` remote rep
- Edit `springRepo` (`libs-snapshot` -> `/snapshot`)

See https://github.com/spring-cloud/spring-cloud-dataflow/issues/5321

### Verification
**Prove its broken**
- Switch to `/snapshot`
- Clear my local m2 cache for `org/springframework/cloud/stream/app`
- Run SCDF + Skipper locally
- Register bulk kafka/maven apps from SCDF UI
- Create `time | log` stream def
- Deploy `time | log` stream def
- 💥 

**Fix**
- Add mavenCentral remote repo
- Redo the above steps and see that the 💥 goes away 